### PR TITLE
fix client crashes in calorimeters

### DIFF
--- a/subsystems/cemc/CemcMonDraw.cc
+++ b/subsystems/cemc/CemcMonDraw.cc
@@ -133,6 +133,11 @@ int CemcMonDraw::DrawStandard(const std::string & /* what */)
 
   TH1 *cemc_runningmean_SEB00 = cl->getHisto("cemc_runningmean_SEB00");
   TH1 *cemc_runningmean_SEB01 = cl->getHisto("cemc_runningmean_SEB01");
+  if (!gROOT->FindObject("Standard"))
+  {
+    MakeCanvas("Standard");
+
+  }
   if (!cemc_runningmean_SEB00)
   {
     DrawDeadServer(transparent[0]);
@@ -149,11 +154,6 @@ int CemcMonDraw::DrawStandard(const std::string & /* what */)
   cemc_runningmean->SetMinimum(0);
 
 
-  if (!gROOT->FindObject("Standard"))
-  {
-    MakeCanvas("Standard");
-
-  }
   TC[0]->SetEditable(true);
   TC[0]->Clear("D");
 

--- a/subsystems/hcal/HcalMonDraw.cc
+++ b/subsystems/hcal/HcalMonDraw.cc
@@ -167,6 +167,10 @@ int HcalMonDraw::DrawFirst(const std::string & /* what */)
   TH2D* hist1 = (TH2D*)cl->getHisto("h2_hcal_rm");
   TH2D* h2_hcal_mean = (TH2D*)cl->getHisto("h2_hcal_mean");
   TH1F* h_event = (TH1F*)cl->getHisto("h_event");
+  if (!gROOT->FindObject("HcalMon1"))
+   {
+     MakeCanvas("HcalMon1");
+   }
   if (!hist1)
   {
     DrawDeadServer(transparent[0]);
@@ -176,10 +180,6 @@ int HcalMonDraw::DrawFirst(const std::string & /* what */)
   h2_hcal_mean->Scale(1./h_event->GetEntries()); 
   hist1->Divide(h2_hcal_mean); 
 
-  if (!gROOT->FindObject("HcalMon1"))
-   {
-     MakeCanvas("HcalMon1");
-   }
   
   TC[0]->SetEditable(1);
   TC[0]->Clear("D");
@@ -290,7 +290,7 @@ int HcalMonDraw::DrawSecond(const std::string & /* what */)
   if (!h_rm_sectorAvg[0] || !h_event || !h_sectorAvg_total)
   {
     DrawDeadServer(transparent[1]);
-    TC[3]->SetEditable(0);
+    TC[1]->SetEditable(0);
     return -1;
   }
  

--- a/subsystems/mvtx/MvtxMon.h
+++ b/subsystems/mvtx/MvtxMon.h
@@ -36,8 +36,8 @@ class MvtxMon : public OnlMon
   const static int IDMVTXV1_MAXRUCHN = 28;
   const int NRowMax = 512;
   const int NColMax = 1024;
-  int HitPerChip[NSTAVE][NCHIP];
-  float OccPerChip[NSTAVE][NCHIP];
+  int HitPerChip[NSTAVE][NCHIP] = {};
+  float OccPerChip[NSTAVE][NCHIP] = {};
   const int NBins = 30;
 
 


### PR DESCRIPTION
The clients of the cemc and hcal crashed with null pointers. This PR fixes those