### PR TITLE
Multiple servers

### DIFF
--- a/macros/ServerFuncs.C
+++ b/macros/ServerFuncs.C
@@ -6,17 +6,17 @@ R__LOAD_LIBRARY(libonlmonserver.so)
 R__LOAD_LIBRARY(libonlmonserver_funcs.so)
 void CleanUpServer();
 
-void start_server(const char *prdffile = 0)
+void start_server(const std::string &prdffile = "")
 {
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework
   // set the ONLMONBBCLL1 Trigger definition (multiple triggers are possible)
   //  se->OnlTrig()->AddBbcLL1TrigName("BBCLL1(>0 tubes) narrowvtx");
-  if (!prdffile)
+  if (prdffile.empty())
   {
     cout << "No Input file given" << endl;
     return;
   }
-  if (!strcmp(prdffile, "etpool"))
+  if (prdffile == "etpool")
   {
     // gSystem->Load("libcorbamsgbuffer.so");
     // corba_msg_buffer *enablecorbabuf = new corba_msg_buffer("monitor_event_channel");
@@ -29,7 +29,7 @@ void start_server(const char *prdffile = 0)
     //      delete enablecorbabuf;
     CleanUpServer();
   }
-  else if (!strcmp(prdffile, "et_test"))
+  else if (prdffile == "et_test")
   {
     //      petopen("/tmp/Monitor@etpool");
   }
@@ -37,7 +37,7 @@ void start_server(const char *prdffile = 0)
   {
     //         gSystem->Load("libcorbamsgbuffer.so");
     //         corba_msg_buffer *enablecorbabuf = new corba_msg_buffer("monitor_event_channel");
-    pfileopen(prdffile);
+    pfileopen(prdffile.c_str());
   }
   return;
 }

--- a/macros/run_bbc_client.C
+++ b/macros/run_bbc_client.C
@@ -11,32 +11,32 @@ void bbcDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   // register histos we want with monitor name
-  cl->registerHisto("bbc_adc", "BBCMON");
-  cl->registerHisto("bbc_tdc", "BBCMON");
-  cl->registerHisto("bbc_tdc_overflow", "BBCMON");
-  cl->registerHisto("bbc_tdc_armhittime", "BBCMON");
-  cl->registerHisto("bbc_zvertex", "BBCMON");
-  cl->registerHisto("bbc_zvertex_bbll1", "BBCMON");
-  // cl->registerHisto("bbc_zvertex_zdc", "BBCMON");
-  // cl->registerHisto("bbc_zvertex_zdc_scale3", "BBCMON");
-  cl->registerHisto("bbc_zvertex_bbll1_novtx", "BBCMON");
-  cl->registerHisto("bbc_zvertex_bbll1_narrowvtx", "BBCMON");
-  cl->registerHisto("bbc_nevent_counter", "BBCMON");
-  cl->registerHisto("bbc_tzero_zvtx", "BBCMON");
-  cl->registerHisto("bbc_prescale_hist", "BBCMON");
-  cl->registerHisto("bbc_avr_hittime", "BBCMON");
-  cl->registerHisto("bbc_north_hittime", "BBCMON");
-  cl->registerHisto("bbc_south_hittime", "BBCMON");
-  cl->registerHisto("bbc_north_chargesum", "BBCMON");
-  cl->registerHisto("bbc_south_chargesum", "BBCMON");
-  // cl->registerHisto("bbc_zvertex_bbll1_zdc", "BBCMON");
+  cl->registerHisto("bbc_adc", "BBCMON_0");
+  cl->registerHisto("bbc_tdc", "BBCMON_0");
+  cl->registerHisto("bbc_tdc_overflow", "BBCMON_0");
+  cl->registerHisto("bbc_tdc_armhittime", "BBCMON_0");
+  cl->registerHisto("bbc_zvertex", "BBCMON_0");
+  cl->registerHisto("bbc_zvertex_bbll1", "BBCMON_0");
+  // cl->registerHisto("bbc_zvertex_zdc", "BBCMON_0");
+  // cl->registerHisto("bbc_zvertex_zdc_scale3", "BBCMON_0");
+  cl->registerHisto("bbc_zvertex_bbll1_novtx", "BBCMON_0");
+  cl->registerHisto("bbc_zvertex_bbll1_narrowvtx", "BBCMON_0");
+  cl->registerHisto("bbc_nevent_counter", "BBCMON_0");
+  cl->registerHisto("bbc_tzero_zvtx", "BBCMON_0");
+  cl->registerHisto("bbc_prescale_hist", "BBCMON_0");
+  cl->registerHisto("bbc_avr_hittime", "BBCMON_0");
+  cl->registerHisto("bbc_north_hittime", "BBCMON_0");
+  cl->registerHisto("bbc_south_hittime", "BBCMON_0");
+  cl->registerHisto("bbc_north_chargesum", "BBCMON_0");
+  cl->registerHisto("bbc_south_chargesum", "BBCMON_0");
+  // cl->registerHisto("bbc_zvertex_bbll1_zdc", "BBCMON_0");
 
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
 
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
-  cl->requestHistoBySubSystem("BBCMON", 1);
+  cl->requestHistoBySubSystem("BBCMON_0", 1);
   OnlMonDraw *bbcmon = new BbcMonDraw();  // create Drawing Object
   cl->registerDrawer(bbcmon);             // register with client framework
 }
@@ -44,7 +44,7 @@ void bbcDrawInit(const int online = 0)
 void bbcDraw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("BBCMON");        // update histos
+  cl->requestHistoBySubSystem("BBCMON_0");        // update histos
   cl->Draw("BBCMON", what);                     // Draw Histos of registered Drawers
 }
 

--- a/macros/run_bbc_client.C
+++ b/macros/run_bbc_client.C
@@ -37,7 +37,7 @@ void bbcDrawInit(const int online = 0)
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
   cl->requestHistoBySubSystem("BBCMON_0", 1);
-  OnlMonDraw *bbcmon = new BbcMonDraw();  // create Drawing Object
+  OnlMonDraw *bbcmon = new BbcMonDraw("BBCMONDRAW");  // create Drawing Object
   cl->registerDrawer(bbcmon);             // register with client framework
 }
 
@@ -45,19 +45,19 @@ void bbcDraw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
   cl->requestHistoBySubSystem("BBCMON_0");        // update histos
-  cl->Draw("BBCMON", what);                     // Draw Histos of registered Drawers
+  cl->Draw("BBCMONDRAW", what);                     // Draw Histos of registered Drawers
 }
 
 void bbcPS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("BBCMON");                         // Create PS files
+  cl->MakePS("BBCMONDRAW");                         // Create PS files
   return;
 }
 
 void bbcHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("BBCMON");                       // Create html output
+  cl->MakeHtml("BBCMONDRAW");                       // Create html output
   return;
 }

--- a/macros/run_bbc_server.C
+++ b/macros/run_bbc_server.C
@@ -6,9 +6,10 @@
 
 R__LOAD_LIBRARY(libonlbbcmon_server.so)
 
-void run_bbc_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
+void run_bbc_server(const std::string &name = "BBCMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
 {
   OnlMon *m = new BbcMon();                     // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                 //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework

--- a/macros/run_bbc_server.C
+++ b/macros/run_bbc_server.C
@@ -8,7 +8,7 @@ R__LOAD_LIBRARY(libonlbbcmon_server.so)
 
 void run_bbc_server(const std::string &name = "BBCMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
 {
-  OnlMon *m = new BbcMon();                     // create subsystem Monitor object
+  OnlMon *m = new BbcMon(name);                     // create subsystem Monitor object
   m->SetMonitorServerId(serverid);
                                                 //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)

--- a/macros/run_bbcll1_client.C
+++ b/macros/run_bbcll1_client.C
@@ -11,13 +11,13 @@ void bbcll1DrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   // register histos we want with monitor name
-  cl->registerHisto("bbcll1mon_hist1", "BBCLL1MON");
-  cl->registerHisto("bbcll1mon_hist2", "BBCLL1MON");
+  cl->registerHisto("bbcll1mon_hist1", "BBCLL1MON_0");
+  cl->registerHisto("bbcll1mon_hist2", "BBCLL1MON_0");
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
-  cl->requestHistoBySubSystem("BBCLL1MON", 1);
+  cl->requestHistoBySubSystem("BBCLL1MON_0", 1);
   OnlMonDraw *bbcll1mon = new Bbcll1MonDraw();  // create Drawing Object
   cl->registerDrawer(bbcll1mon);                // register with client framework
 }
@@ -25,20 +25,20 @@ void bbcll1DrawInit(const int online = 0)
 void bbcll1Draw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("BBCLL1MON");     // update histos
+  cl->requestHistoBySubSystem("BBCLL1MON_0");     // update histos
   cl->Draw("BBCLL1MON", what);                  // Draw Histos of registered Drawers
 }
 
 void bbcll1PS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("BBCLL1MON");                      // Create PS files
+  cl->MakePS("BBCLL1MON_0");                      // Create PS files
   return;
 }
 
 void bbcll1Html()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("BBCLL1MON");                    // Create html output
+  cl->MakeHtml("BBCLL1MON_0");                    // Create html output
   return;
 }

--- a/macros/run_bbcll1_client.C
+++ b/macros/run_bbcll1_client.C
@@ -18,7 +18,7 @@ void bbcll1DrawInit(const int online = 0)
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
   cl->requestHistoBySubSystem("BBCLL1MON_0", 1);
-  OnlMonDraw *bbcll1mon = new Bbcll1MonDraw();  // create Drawing Object
+  OnlMonDraw *bbcll1mon = new Bbcll1MonDraw("BBCLL1MONDRAW");  // create Drawing Object
   cl->registerDrawer(bbcll1mon);                // register with client framework
 }
 
@@ -26,19 +26,19 @@ void bbcll1Draw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
   cl->requestHistoBySubSystem("BBCLL1MON_0");     // update histos
-  cl->Draw("BBCLL1MON", what);                  // Draw Histos of registered Drawers
+  cl->Draw("BBCLL1MONDRAW", what);                  // Draw Histos of registered Drawers
 }
 
 void bbcll1PS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("BBCLL1MON_0");                      // Create PS files
+  cl->MakePS("BBCLL1MONDRAW");                      // Create PS files
   return;
 }
 
 void bbcll1Html()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("BBCLL1MON_0");                    // Create html output
+  cl->MakeHtml("BBCLL1MONDRAW");                    // Create html output
   return;
 }

--- a/macros/run_bbcll1_server.C
+++ b/macros/run_bbcll1_server.C
@@ -6,9 +6,10 @@
 
 R__LOAD_LIBRARY(libonlbbcll1mon_server.so)
 
-void run_bbcll1_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
+void run_bbcll1_server(const std::string &name = "BBCLL1MON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
 {
-  OnlMon *m = new Bbcll1Mon();                  // create subsystem Monitor object
+  OnlMon *m = new Bbcll1Mon(name);                  // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                 //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework

--- a/macros/run_cemc_client.C
+++ b/macros/run_cemc_client.C
@@ -11,25 +11,25 @@ void cemcDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   // register histos we want with monitor name
-  cl->registerHisto("cemc_occupancy", "CEMCMON");
-  cl->registerHisto("cemc_runningmean", "CEMCMON");
-  cl->registerHisto("h2_hcal_hits", "CEMCMON");
-  cl->registerHisto("h2_hcal_rm", "CEMCMON");
-  cl->registerHisto("h2_hcal_mean", "CEMCMON");
-  cl->registerHisto("h_event", "CEMCMON");
-  cl->registerHisto("h_sectorAvg_total", "CEMCMON");
-  cl->registerHisto("h_waveform_twrAvg", "CEMCMON");
-  cl->registerHisto("h_waveform_time", "CEMCMON");
-  cl->registerHisto("h_waveform_pedestal", "CEMCMON");
+  cl->registerHisto("cemc_occupancy", "CEMCMON_0");
+  cl->registerHisto("cemc_runningmean", "CEMCMON_0");
+  cl->registerHisto("h2_hcal_hits", "CEMCMON_0");
+  cl->registerHisto("h2_hcal_rm", "CEMCMON_0");
+  cl->registerHisto("h2_hcal_mean", "CEMCMON_0");
+  cl->registerHisto("h_event", "CEMCMON_0");
+  cl->registerHisto("h_sectorAvg_total", "CEMCMON_0");
+  cl->registerHisto("h_waveform_twrAvg", "CEMCMON_0");
+  cl->registerHisto("h_waveform_time", "CEMCMON_0");
+  cl->registerHisto("h_waveform_pedestal", "CEMCMON_0");
   for (int ih=0; ih<32; ih++){
-    cl->registerHisto(Form("h_rm_sectorAvg_s%d",ih), "CEMCMON");
+    cl->registerHisto(Form("h_rm_sectorAvg_s%d",ih), "CEMCMON_0");
   }
   cl->AddServerHost("localhost");  // check local host first
   // CreateHostList(online);
   //  get my histos from server, the second parameter = 1
   //  says I know they are all on the same node
-  cl->requestHistoBySubSystem("CEMCMON", 1);
-  OnlMonDraw *cemcmon = new CemcMonDraw();  // create Drawing Object
+  cl->requestHistoBySubSystem("CEMCMON_0", 1);
+  OnlMonDraw *cemcmon = new CemcMonDraw("CEMCMONDRAW");  // create Drawing Object
   cl->registerDrawer(cemcmon);              // register with client framework
 }
 
@@ -37,22 +37,22 @@ void cemcDraw(const char *what = "Standard")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
   std::cout << 1 << std::endl;
-  cl->requestHistoBySubSystem("CEMCMON");  // update histos
+  cl->requestHistoBySubSystem("CEMCMON_0");  // update histos
   std::cout << 2 << std::endl;
-  cl->Draw("CEMCMON", what);  // Draw Histos of registered Drawers
+  cl->Draw("CEMCMONDRAW", what);  // Draw Histos of registered Drawers
   std::cout << 3 << std::endl;
 }
 
 void cemcPS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("CEMCMON");                        // Create PS files
+  cl->MakePS("CEMCMONDRAW");                        // Create PS files
   return;
 }
 
 void cemcHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("CEMCMON");                      // Create html output
+  cl->MakeHtml("CEMCMONDRAW");                      // Create html output
   return;
 }

--- a/macros/run_cemc_client_2subevents.C
+++ b/macros/run_cemc_client_2subevents.C
@@ -7,41 +7,49 @@
 // cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlcemcmon_client.so)
 
+std::string monitorname("CEMCMON");
+
 void cemcDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  // register histos we want with monitor name
-  cl->registerHisto("cemc_occupancy_SEB00", "CEMCMON");
-  cl->registerHisto("cemc_occupancy_SEB01", "CEMCMON");
-  cl->registerHisto("cemc_runningmean_SEB00", "CEMCMON");
-  cl->registerHisto("cemc_runningmean_SEB01", "CEMCMON");
   cl->AddServerHost("localhost");  // stand-in for SEB00
   cl->AddServerHost("rcas2068");   //  stand-in for SEB01
   // CreateHostList(online);
+  // register histos we want with monitor name
+  for (unsigned int i = 0; i < 2; i++)
+  {
+  std::string monitor = monitorname + string("_") + to_string(i);
+  cl->registerHisto("cemc_occupancy", monitor);
+  cl->registerHisto("cemc_runningmean", monitor);
+  cl->requestHistoBySubSystem(monitor, 1);
+  }
   //  get my histos from server, the second parameter = 1
   //  says I know they are all on the same node
-  cl->requestHistoBySubSystem("CEMCMON", 1);
-  OnlMonDraw *cemcmon = new CemcMonDraw();  // create Drawing Object
+  OnlMonDraw *cemcmon = new CemcMonDraw("CEMCMONDRAW");  // create Drawing Object
   cl->registerDrawer(cemcmon);              // register with client framework
 }
 
 void cemcDraw(const char *what = "Standard")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("CEMCMON");       // update histos
-  cl->Draw("CEMCMON", what);                    // Draw Histos of registered Drawers
+  for (unsigned int i = 0; i < 2; i++)
+  {
+  std::string monitor = monitorname + string("_") + to_string(i);
+  cl->requestHistoBySubSystem(monitor);       // update histos
+  }
+  cl->Draw("CEMCMONDRAW", what);                    // Draw Histos of registered Drawers
 }
 
 void cemcPS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("CEMCMON");                        // Create PS files
+  cl->MakePS("CEMCMONDRAW");                        // Create PS files
   return;
 }
 
 void cemcHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("CEMCMON");                      // Create html output
+  cl->MakeHtml("CEMCMONDRAW");                      // Create html output
   return;
 }

--- a/macros/run_cemc_server.C
+++ b/macros/run_cemc_server.C
@@ -7,9 +7,10 @@
 R__LOAD_LIBRARY(libonlcemcmon_server.so)
 
 // void run_cemc_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
-void run_cemc_server(const char *prdffile = "/sphenix/data/data02/sphenix/cemc/combinedEvents/EmCalSEB00-000000222-0000.prdf")
+void run_cemc_server(const std::string &name = "CEMCMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/cemc/combinedEvents/EmCalSEB00-000000222-0000.prdf")
 {
-  OnlMon *m = new CemcMon();                    // create subsystem Monitor object
+  OnlMon *m = new CemcMon(name);                    // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                 //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework

--- a/macros/run_cemc_server_SEB00.C
+++ b/macros/run_cemc_server_SEB00.C
@@ -9,9 +9,10 @@ R__LOAD_LIBRARY(libonlcemcmon_server.so)
 // this pretends to run a subevent from seb00  (packets 6001...6016)
 
 // void run_cemc_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
-void run_cemc_server_SEB00(const char *prdffile = "/sphenix/data/data02/sphenix/cemc/combinedEvents/EmCalSEB00-000000222-0000.prdf")
+void run_cemc_server_SEB00(const std::string &name = "CEMCMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/cemc/combinedEvents/EmCalSEB00-000000222-0000.prdf")
 {
-  OnlMon *m = new CemcMon("CemcMon", "_SEB00");  // create subsystem Monitor object
+  OnlMon *m = new CemcMon(name);  // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                  //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                  //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();   // get pointer to Server Framework

--- a/macros/run_cemc_server_SEB01.C
+++ b/macros/run_cemc_server_SEB01.C
@@ -9,9 +9,10 @@ R__LOAD_LIBRARY(libonlcemcmon_server.so)
 // this pretends to run a subevent from seb01 (packets 6017...6032)
 
 // void run_cemc_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
-void run_cemc_server_SEB01(const char *prdffile = "/sphenix/data/data02/sphenix/cemc/combinedEvents/EmCalSEB01-000000222-0000.prdf")
+void run_cemc_server_SEB01(const std::string &name = "CEMCMON", unsigned int serverid = 1, const std::string &prdffile = "/sphenix/data/data02/sphenix/cemc/combinedEvents/EmCalSEB01-000000222-0000.prdf")
 {
-  OnlMon *m = new CemcMon("CemcMon", "_SEB01");  // create subsystem Monitor object
+  OnlMon *m = new CemcMon(name);  // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                  //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                  //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();   // get pointer to Server Framework

--- a/macros/run_daq_client.C
+++ b/macros/run_daq_client.C
@@ -11,34 +11,34 @@ void daqDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   // register histos we want with monitor name
-  cl->registerHisto("daqmon_hist1", "DAQMON");
-  cl->registerHisto("daqmon_hist2", "DAQMON");
+  cl->registerHisto("daqmon_hist1", "DAQMON_0");
+  cl->registerHisto("daqmon_hist2", "DAQMON_0");
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
-  cl->requestHistoBySubSystem("DAQMON", 1);
-  OnlMonDraw *daqmon = new DaqMonDraw();  // create Drawing Object
+  cl->requestHistoBySubSystem("DAQMON_0", 1);
+  OnlMonDraw *daqmon = new DaqMonDraw("DAQMONDRAW");  // create Drawing Object
   cl->registerDrawer(daqmon);             // register with client framework
 }
 
 void daqDraw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("DAQMON");        // update histos
-  cl->Draw("DAQMON", what);                     // Draw Histos of registered Drawers
+  cl->requestHistoBySubSystem("DAQMON_0");        // update histos
+  cl->Draw("DAQMONDRAW", what);                     // Draw Histos of registered Drawers
 }
 
 void daqPS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("DAQMON");                         // Create PS files
+  cl->MakePS("DAQMONDRAW");                         // Create PS files
   return;
 }
 
 void daqHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("DAQMON");                       // Create html output
+  cl->MakeHtml("DAQMONDRAW");                       // Create html output
   return;
 }

--- a/macros/run_daq_server.C
+++ b/macros/run_daq_server.C
@@ -6,9 +6,10 @@
 
 R__LOAD_LIBRARY(libonldaqmon_server.so)
 
-void run_daq_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
+void run_daq_server(const std::string &name = "DAQMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
 {
-  OnlMon *m = new DaqMon();                     // create subsystem Monitor object
+  OnlMon *m = new DaqMon(name);                     // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                 //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework

--- a/macros/run_epd_client.C
+++ b/macros/run_epd_client.C
@@ -11,34 +11,34 @@ void epdDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   // register histos we want with monitor name
-  cl->registerHisto("epdmon_hist1", "EPDMON");
-  cl->registerHisto("epdmon_hist2", "EPDMON");
+  cl->registerHisto("epdmon_hist1", "EPDMON_0");
+  cl->registerHisto("epdmon_hist2", "EPDMON_0");
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
-  cl->requestHistoBySubSystem("EPDMON", 1);
-  OnlMonDraw *epdmon = new EpdMonDraw();  // create Drawing Object
+  cl->requestHistoBySubSystem("EPDMON_0", 1);
+  OnlMonDraw *epdmon = new EpdMonDraw("EPDMONDRAW");  // create Drawing Object
   cl->registerDrawer(epdmon);             // register with client framework
 }
 
 void epdDraw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("EPDMON");        // update histos
-  cl->Draw("EPDMON", what);                     // Draw Histos of registered Drawers
+  cl->requestHistoBySubSystem("EPDMON_0");        // update histos
+  cl->Draw("EPDMONDRAW", what);                     // Draw Histos of registered Drawers
 }
 
 void epdPS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("EPDMON");                         // Create PS files
+  cl->MakePS("EPDMONDRAW");                         // Create PS files
   return;
 }
 
 void epdHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("EPDMON");                       // Create html output
+  cl->MakeHtml("EPDMONDRAW");                       // Create html output
   return;
 }

--- a/macros/run_epd_server.C
+++ b/macros/run_epd_server.C
@@ -6,9 +6,10 @@
 
 R__LOAD_LIBRARY(libonlepdmon_server.so)
 
-void run_epd_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
+void run_epd_server(const std::string &name = "EPDMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
 {
-  OnlMon *m = new EpdMon();                     // create subsystem Monitor object
+  OnlMon *m = new EpdMon(name);                     // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                 //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework

--- a/macros/run_example_client.C
+++ b/macros/run_example_client.C
@@ -21,7 +21,7 @@ void exampleDrawInit(const int online = 0)
   // says I know they are all on the same node
   cl->requestHistoBySubSystem("MYMON_0", 1);
   cl->requestHistoBySubSystem("MYMON_1", 1);
-  OnlMonDraw *mymon = new MyMonDraw();  // create Drawing Object
+  OnlMonDraw *mymon = new MyMonDraw("MYMONDRAW");  // create Drawing Object
   cl->registerDrawer(mymon);            // register with client framework
 }
 
@@ -30,19 +30,19 @@ void exampleDraw(const char *what = "ALL")
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
   cl->requestHistoBySubSystem("MYMON_1");         // update histos
   cl->requestHistoBySubSystem("MYMON_0");         // update histos
-  cl->Draw("MYMON", what);                      // Draw Histos of registered Drawers
+  cl->Draw("MYMONDRAW", what);                      // Draw Histos of registered Drawers
 }
 
 void examplePS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("MYMON");                          // Create PS files
+  cl->MakePS("MYMONDRAW");                          // Create PS files
   return;
 }
 
 void exampleHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("MYMON");                        // Create html output
+  cl->MakeHtml("MYMONDRAW");                        // Create html output
   return;
 }

--- a/macros/run_example_client.C
+++ b/macros/run_example_client.C
@@ -13,6 +13,8 @@ void exampleDrawInit(const int online = 0)
   // register histos we want with monitor name
   cl->registerHisto("mymon_hist1", "MYMON");
   cl->registerHisto("mymon_hist2", "MYMON");
+  cl->registerHisto("mymon_hist1", "MYMON2");
+  cl->registerHisto("mymon_hist2", "MYMON2");
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
   // get my histos from server, the second parameter = 1

--- a/macros/run_example_client.C
+++ b/macros/run_example_client.C
@@ -11,15 +11,16 @@ void exampleDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   // register histos we want with monitor name
-  cl->registerHisto("mymon_hist1", "MYMON");
-  cl->registerHisto("mymon_hist2", "MYMON");
-  cl->registerHisto("mymon_hist1", "MYMON2");
-  cl->registerHisto("mymon_hist2", "MYMON2");
+  cl->registerHisto("mymon_hist1", "MYMON_0");
+  cl->registerHisto("mymon_hist2", "MYMON_0");
+  cl->registerHisto("mymon_hist1", "MYMON_1");
+  cl->registerHisto("mymon_hist2", "MYMON_1");
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
-  cl->requestHistoBySubSystem("MYMON", 1);
+  cl->requestHistoBySubSystem("MYMON_0", 1);
+  cl->requestHistoBySubSystem("MYMON_1", 1);
   OnlMonDraw *mymon = new MyMonDraw();  // create Drawing Object
   cl->registerDrawer(mymon);            // register with client framework
 }
@@ -27,7 +28,8 @@ void exampleDrawInit(const int online = 0)
 void exampleDraw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("MYMON");         // update histos
+  cl->requestHistoBySubSystem("MYMON_1");         // update histos
+  cl->requestHistoBySubSystem("MYMON_0");         // update histos
   cl->Draw("MYMON", what);                      // Draw Histos of registered Drawers
 }
 

--- a/macros/run_example_server.C
+++ b/macros/run_example_server.C
@@ -8,11 +8,15 @@ R__LOAD_LIBRARY(libonlmymon_server.so)
 
 void run_example_server(const std::string &name = "MYMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
 {
-  OnlMon *m = new MyMon(name);                      // create subsystem Monitor object
-  m->SetServerId(serverid);                                                //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
-                                                //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
-  OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework
-  se->registerMonitor(m);                       // register subsystem Monitor with Framework
+// create subsystem Monitor object
+  OnlMon *m = new MyMon(name);
+// set server id needed for running multiple servers
+  m->SetMonitorServerId(serverid);
+// get pointer to Server Framework
+  OnlMonServer *se = OnlMonServer::instance();
+//  se->Verbosity(3);
+  se->registerMonitor(m);
   start_server(prdffile);
+  prun(100);
   return;
 }

--- a/macros/run_example_server.C
+++ b/macros/run_example_server.C
@@ -6,10 +6,10 @@
 
 R__LOAD_LIBRARY(libonlmymon_server.so)
 
-void run_example_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
+void run_example_server(const std::string &name = "MYMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
 {
-  OnlMon *m = new MyMon();                      // create subsystem Monitor object
-                                                //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
+  OnlMon *m = new MyMon(name);                      // create subsystem Monitor object
+  m->SetServerId(serverid);                                                //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework
   se->registerMonitor(m);                       // register subsystem Monitor with Framework

--- a/macros/run_hcal_client.C
+++ b/macros/run_hcal_client.C
@@ -11,48 +11,48 @@ void hcalDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   // register histos we want with monitor name
-  cl->registerHisto("h2_hcal_hits", "HCALMON");
-  cl->registerHisto("h2_hcal_rm", "HCALMON");
-  cl->registerHisto("h2_hcal_mean", "HCALMON");
-  cl->registerHisto("h_event", "HCALMON");
-  cl->registerHisto("h_sectorAvg_total", "HCALMON");
-  cl->registerHisto("h_waveform_twrAvg", "HCALMON");
-  cl->registerHisto("h_waveform_time", "HCALMON");
-  cl->registerHisto("h_waveform_pedestal", "HCALMON");
+  cl->registerHisto("h2_hcal_hits", "HCALMON_0");
+  cl->registerHisto("h2_hcal_rm", "HCALMON_0");
+  cl->registerHisto("h2_hcal_mean", "HCALMON_0");
+  cl->registerHisto("h_event", "HCALMON_0");
+  cl->registerHisto("h_sectorAvg_total", "HCALMON_0");
+  cl->registerHisto("h_waveform_twrAvg", "HCALMON_0");
+  cl->registerHisto("h_waveform_time", "HCALMON_0");
+  cl->registerHisto("h_waveform_pedestal", "HCALMON_0");
   for (int ih=0; ih<32; ih++){
-    cl->registerHisto(Form("h_rm_sectorAvg_s%d",ih), "HCALMON");
+    cl->registerHisto(Form("h_rm_sectorAvg_s%d",ih), "HCALMON_0");
   }
   for (int ieta = 0; ieta < 24; ieta++) {
     for (int iphi = 0; iphi < 64; iphi++) {
-      cl->registerHisto(Form("h_rm_tower_%d_%d", ieta, iphi), "HCALMON");
+      cl->registerHisto(Form("h_rm_tower_%d_%d", ieta, iphi), "HCALMON_0");
     }
   }
   cl->AddServerHost("localhost");   // check local host first
   CreateHostList(online);
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
-  cl->requestHistoBySubSystem("HCALMON", 1);
-  OnlMonDraw *hcalmon = new HcalMonDraw();    // create Drawing Object
+  cl->requestHistoBySubSystem("HCALMON_0", 1);
+  OnlMonDraw *hcalmon = new HcalMonDraw("HCALMONDRAW");    // create Drawing Object
   cl->registerDrawer(hcalmon);              // register with client framework
 }
 
 void hcalDraw(const char *what="ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("HCALMON");         // update histos
-  cl->Draw("HCALMON",what);                       // Draw Histos of registered Drawers
+  cl->requestHistoBySubSystem("HCALMON_0");         // update histos
+  cl->Draw("HCALMONDRAW",what);                       // Draw Histos of registered Drawers
 }
 
 void hcalPS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("HCALMON");                          // Create PS files
+  cl->MakePS("HCALMONDRAW");                          // Create PS files
   return;
 }
 
 void hcalHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("HCALMON");                        // Create html output
+  cl->MakeHtml("HCALMONDRAW");                        // Create html output
   return;
 }

--- a/macros/run_hcal_server.C
+++ b/macros/run_hcal_server.C
@@ -6,9 +6,10 @@
 
 R__LOAD_LIBRARY(libonlhcalmon_server.so)
 
-void run_hcal_server(const char *prdffile = "/sphenix/data/data02/sphenix/hcal/1008/LED/led-West-East-00001713-0000.prdf")
+void run_hcal_server(const std::string &name = "HCALMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/hcal/1008/LED/led-West-East-00001713-0000.prdf")
 {
-  OnlMon *m = new HcalMon();                    // create subsystem Monitor object
+  OnlMon *m = new HcalMon(name);                    // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                 //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework

--- a/macros/run_intt_client.C
+++ b/macros/run_intt_client.C
@@ -7,25 +7,6 @@
 // cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlinttmon_client.so)
 
-void run_intt_client()
-{
-
-  OnlMonClient *cl = OnlMonClient::instance();
-  // register histos we want with monitor name
-
-  cl->registerHisto("InttNumEvents", "INTTMON");
-  cl->registerHisto("InttHitMap", "INTTMON");
-  cl->registerHisto("InttHitMapRef", "INTTMON");
-
-  cl->AddServerHost("localhost");   // check local host first
-  CreateHostList(0);
-  // get my histos from server, the second parameter = 1
-  // says I know they are all on the same node
-  cl->requestHistoBySubSystem("INTTMON");
-  OnlMonDraw* inttmondraw = new InttMonDraw();
-  cl->registerDrawer(inttmondraw);              // register with client framework
-}
-
 void inttDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
@@ -34,10 +15,13 @@ void inttDrawInit(const int online = 0)
 
   cl->AddServerHost("localhost");   // check local host first
   CreateHostList(online);
+   cl->registerHisto("InttNumEvents", "INTTMON_0");
+   cl->registerHisto("InttHitMap", "INTTMON_0");
+   cl->registerHisto("InttHitMapRef", "INTTMON_0");
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
-  cl->requestHistoBySubSystem("INTTMON", 1);
-  OnlMonDraw *inttmon = new InttMonDraw();    // create Drawing Object
+  cl->requestHistoBySubSystem("INTTMON_0", 1);
+  OnlMonDraw *inttmon = new InttMonDraw("INTTMONDRAW");    // create Drawing Object
 	inttmon->Init(); //registers the hists it will need to the OnlMonClient
   cl->registerDrawer(inttmon);              // register with client framework
 }
@@ -45,20 +29,20 @@ void inttDrawInit(const int online = 0)
 void inttDraw(const char *what="ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("INTTMON");         // update histos
-  cl->Draw("INTTMON",what);                       // Draw Histos of registered Drawers
+  cl->requestHistoBySubSystem("INTTMON_0");         // update histos
+  cl->Draw("INTTMONDRAW",what);                       // Draw Histos of registered Drawers
 }
 
 void inttPS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("INTTMON");                          // Create PS files
+  cl->MakePS("INTTMONDRAW");                          // Create PS files
   return;
 }
 
 void inttHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("INTTMON");                        // Create html output
+  cl->MakeHtml("INTTMONDRAW");                        // Create html output
   return;
 }

--- a/macros/run_intt_server.C
+++ b/macros/run_intt_server.C
@@ -7,19 +7,24 @@
 // cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlinttmon_server.so)
 
-void run_intt_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
+void run_intt_server(const std::string &name = "INTTMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
 {
 //  //for debugging
 //  InttMon *m = new InttMon();
 //  m->MiscDebug();
 
-  OnlMon *m = new InttMon();      // create subsystem Monitor object
-//  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
+  OnlMon *m = new InttMon(name);      // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance(); // get pointer to Server Framework
   se->registerMonitor(m);       // register subsystem Monitor with Framework
   start_server(prdffile);
 
+//**********************************************************
+//
+// just a comment: This is not how this will be run
+//
+//**********************************************************
   //m->Init(); this must already be called somewhere above
   m->BeginRun(1);
 

--- a/macros/run_mvtx_client.C
+++ b/macros/run_mvtx_client.C
@@ -11,17 +11,17 @@ void mvtxDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   // register histos we want with monitor name
-  //cl->registerHisto("mvtxmon_hist1", "MVTXMON");
-  //cl->registerHisto("mvtxmon_hist2", "MVTXMON");
-  cl->registerHisto("mvtxmon_ChipStaveOcc", "MVTXMON");
-  cl->registerHisto("mvtxmon_ChipStave1D", "MVTXMON");
-  cl->registerHisto("mvtxmon_ChipFiredHis", "MVTXMON");
-  cl->registerHisto("mvtxmon_EvtHitChip", "MVTXMON");
-  cl->registerHisto("mvtxmon_EvtHitDis", "MVTXMON");
+  //cl->registerHisto("mvtxmon_hist1", "MVTXMON_0");
+  //cl->registerHisto("mvtxmon_hist2", "MVTXMON_0");
+  cl->registerHisto("mvtxmon_ChipStaveOcc", "MVTXMON_0");
+  cl->registerHisto("mvtxmon_ChipStave1D", "MVTXMON_0");
+  cl->registerHisto("mvtxmon_ChipFiredHis", "MVTXMON_0");
+  cl->registerHisto("mvtxmon_EvtHitChip", "MVTXMON_0");
+  cl->registerHisto("mvtxmon_EvtHitDis", "MVTXMON_0");
 
    for(int i = 0; i < MvtxMonDraw::NSTAVE; i++){
 		for(int j = 0; j < MvtxMonDraw::NCHIP; j++){
-			cl->registerHisto(Form("mvtxmon_HitMap_%d_%d",i,j), "MVTXMON");
+			cl->registerHisto(Form("mvtxmon_HitMap_%d_%d",i,j), "MVTXMON_0");
     }
   }
 
@@ -29,28 +29,28 @@ void mvtxDrawInit(const int online = 0)
   CreateHostList(online);
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
-  cl->requestHistoBySubSystem("MVTXMON", 1);
-  OnlMonDraw *mvtxmon = new MvtxMonDraw();  // create Drawing Object
+  cl->requestHistoBySubSystem("MVTXMON_0", 1);
+  OnlMonDraw *mvtxmon = new MvtxMonDraw("MVTXMONDRAW");  // create Drawing Object
   cl->registerDrawer(mvtxmon);              // register with client framework
 }
 
 void mvtxDraw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("MVTXMON");       // update histos
-  cl->Draw("MVTXMON", what);                    // Draw Histos of registered Drawers
+  cl->requestHistoBySubSystem("MVTXMON_0");       // update histos
+  cl->Draw("MVTXMONDRAW", what);                    // Draw Histos of registered Drawers
 }
 
 void mvtxPS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("MVTXMON");                        // Create PS files
+  cl->MakePS("MVTXMONDRAW");                        // Create PS files
   return;
 }
 
 void mvtxHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("MVTXMON");                      // Create html output
+  cl->MakeHtml("MVTXMONDRAW");                      // Create html output
   return;
 }

--- a/macros/run_mvtx_server.C
+++ b/macros/run_mvtx_server.C
@@ -6,9 +6,10 @@
 
 R__LOAD_LIBRARY(libonlmvtxmon_server.so)
 
-void run_mvtx_server(const char *prdffile = "/sphenix/data/data01/mvtx/tb-1441-052019/longrun/longrun_00000872-0000.prdf")
+void run_mvtx_server(const std::string &name = "MVTXMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data01/mvtx/tb-1441-052019/longrun/longrun_00000872-0000.prdf")
 {
-  OnlMon *m = new MvtxMon();                    // create subsystem Monitor object
+  OnlMon *m = new MvtxMon(name);                    // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                 //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework

--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -11,36 +11,36 @@ void tpcDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   // register histos we want with monitor name
-  cl->registerHisto("tpcmon_hist1", "TPCMON");
-  cl->registerHisto("tpcmon_hist2", "TPCMON");
-  cl->registerHisto("NorthSideADC", "TPCMON");
-  cl->registerHisto("SouthSideADC", "TPCMON");
+  cl->registerHisto("tpcmon_hist1", "TPCMON_0");
+  cl->registerHisto("tpcmon_hist2", "TPCMON_0");
+  cl->registerHisto("NorthSideADC", "TPCMON_0");
+  cl->registerHisto("SouthSideADC", "TPCMON_0");
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
-  cl->requestHistoBySubSystem("TPCMON", 1);
-  OnlMonDraw *tpcmon = new TpcMonDraw();  // create Drawing Object
+  cl->requestHistoBySubSystem("TPCMON_0", 1);
+  OnlMonDraw *tpcmon = new TpcMonDraw("TPCMONDRAW");  // create Drawing Object
   cl->registerDrawer(tpcmon);             // register with client framework
 }
 
 void tpcDraw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("TPCMON");        // update histos
-  cl->Draw("TPCMON", what);                     // Draw Histos of registered Drawers
+  cl->requestHistoBySubSystem("TPCMON_0");        // update histos
+  cl->Draw("TPCMONDRAW", what);                     // Draw Histos of registered Drawers
 }
 
 void tpcPS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("TPCMON");                         // Create PS files
+  cl->MakePS("TPCMONDRAW");                         // Create PS files
   return;
 }
 
 void tpcHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("TPCMON");                       // Create html output
+  cl->MakeHtml("TPCMONDRAW");                       // Create html output
   return;
 }

--- a/macros/run_tpc_server.C
+++ b/macros/run_tpc_server.C
@@ -6,9 +6,10 @@
 
 R__LOAD_LIBRARY(libonltpcmon_server.so)
 
-void run_tpc_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
+void run_tpc_server(const std::string &name = "TPCMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
 {
-  OnlMon *m = new TpcMon();                     // create subsystem Monitor object
+  OnlMon *m = new TpcMon(name);                     // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                 //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework

--- a/macros/run_tpot_client.C
+++ b/macros/run_tpot_client.C
@@ -13,43 +13,43 @@ void tpotDrawInit(const int online = 0)
   OnlMonClient *cl = OnlMonClient::instance();
   
   // register all histograms
-  cl->registerHisto("m_hv_onoff_phi", "TPOTMON");
-  cl->registerHisto("m_hv_onoff_z", "TPOTMON");
+  cl->registerHisto("m_hv_onoff_phi", "TPOTMON_0");
+  cl->registerHisto("m_hv_onoff_z", "TPOTMON_0");
 
-  cl->registerHisto("m_fee_onoff_phi", "TPOTMON");
-  cl->registerHisto("m_fee_onoff_z", "TPOTMON");
+  cl->registerHisto("m_fee_onoff_phi", "TPOTMON_0");
+  cl->registerHisto("m_fee_onoff_z", "TPOTMON_0");
 
   for( const std::string& hname: { "m_adc_sample", "m_hit_charge", "m_hit_multiplicity", "m_hit_vs_channel" } )
   {
     for( const auto& detname : TpotDefs::detector_names )
-    { cl->registerHisto( hname+"_"+detname, "TPOTMON" ); }
+    { cl->registerHisto( hname+"_"+detname, "TPOTMON_0" ); }
   }
   
   CreateHostList(online);
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
-  cl->requestHistoBySubSystem("TPOTMON", 1);
-  OnlMonDraw *tpotmon = new TpotMonDraw();  // create Drawing Object
+  cl->requestHistoBySubSystem("TPOTMON_0", 1);
+  OnlMonDraw *tpotmon = new TpotMonDraw("TPOTMONDRAW");  // create Drawing Object
   cl->registerDrawer(tpotmon);              // register with client framework
 }
 
 void tpotDraw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->requestHistoBySubSystem("TPOTMON");       // update histos
-  cl->Draw("TPOTMON", what);                    // Draw Histos of registered Drawers
+  cl->requestHistoBySubSystem("TPOTMON_0");       // update histos
+  cl->Draw("TPOTMONDRAW", what);                    // Draw Histos of registered Drawers
 }
 
 void tpotPS()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakePS("TPOTMON");                        // Create PS files
+  cl->MakePS("TPOTMONDRAW");                        // Create PS files
   return;
 }
 
 void tpotHtml()
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
-  cl->MakeHtml("TPOTMON");                      // Create html output
+  cl->MakeHtml("TPOTMONDRAW");                      // Create html output
   return;
 }

--- a/macros/run_tpot_server.C
+++ b/macros/run_tpot_server.C
@@ -6,9 +6,10 @@
 
 R__LOAD_LIBRARY(libonltpotmon_server.so)
 
-void run_tpot_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
+void run_tpot_server(const std::string &name = "TPOTMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
 {
-  OnlMon *m = new TpotMon();                    // create subsystem Monitor object
+  OnlMon *m = new TpotMon(name);                    // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
                                                 //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
                                                 //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
   OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework

--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -254,7 +254,10 @@ int OnlMonClient::requestHistoBySubSystem(const std::string &subsys, int getall)
       {
         if (requestHistoByName(subsys, hiter.first))
         {
+	  if (Verbosity() > 2)
+	  {
           std::cout << "Request for " << hiter.first << " on " << subsys << " failed " << std::endl;
+	  }
           if (hiter.second->Histo())
           {
             hiter.second->Histo()->Delete();
@@ -266,21 +269,21 @@ int OnlMonClient::requestHistoBySubSystem(const std::string &subsys, int getall)
         }
       
     }
-//    requestHistoByName("FrameWorkVars");
   }
   else if (getall == 1)
   {
-//    std::map<std::pair<std::string, int>, std::list<std::string> > transferlist;
     std::map<std::string, std::list<std::string> > transferlist;
     std::ostringstream host_port;
     
     int failed_to_locate = 0;
     auto subs = SubsysHisto.find(subsys);
-//    for (auto &subs = SubsysHisto.find)
     {
       for (auto &histos : subs->second)
       {
+	if (Verbosity() > 2)
+	{
       std::cout << "checking for subsystem " << subs->first << ", histo " << histos.first << std::endl;
+	}
       if (histos.second->SubSystem() == subsys)
       {
         int unknown_histo = 0;
@@ -291,7 +294,10 @@ int OnlMonClient::requestHistoBySubSystem(const std::string &subsys, int getall)
           {
             if (LocateHistogram(hname, subsys) < 1)
             {
+	if (Verbosity() > 2)
+	{
               std::cout << "Subsystem " << subsys << " Histogram " << hname << " cannot be located" << std::endl;
+	}
               failed_to_locate = 1;
               unknown_histo = 1;
               iret = -1;
@@ -309,10 +315,6 @@ int OnlMonClient::requestHistoBySubSystem(const std::string &subsys, int getall)
         }
         if (!unknown_histo)
         {
-          // host_port.str("");
-          // host_port << histos.second->ServerHost() << " "
-          //           << histos.second->ServerPort();
-          // std::pair<std::string, int> hostport(histos.second->ServerHost(), histos.second->ServerPort());
 	  std::string fullhname = subsys + std::string(" ") + hname; 
           (transferlist[subsys]).push_back(fullhname);
         }
@@ -560,7 +562,10 @@ int OnlMonClient::requestHistoByName(const std::string &subsys, const std::strin
   int moniport = OnlMonDefs::MONIPORT;
   std::map<std::string, std::map<const std::string, ClientHistoList *>>::const_iterator histos = SubsysHisto.find(subsys);
   auto histoiter = histos->second.find(what);
+	if (Verbosity() > 2)
+	{
   std::cout << PHWHERE << "checking for " << what << " on monitor " << subsys << std::endl;
+	}
   if (histoiter != histos->second.end())
   {
     hostname = histoiter->second->ServerHost();
@@ -610,7 +615,10 @@ int OnlMonClient::requestHistoByName(const std::string &subsys, const std::strin
   TSocket sock(hostname.c_str(), moniport);
   TMessage *mess;
   std::string fullhistoname = subsys + std::string(" ") + what;
+	if (Verbosity() > 2)
+	{
   std::cout <<  PHWHERE << " sending " << fullhistoname << " to " << hostname << " port " << moniport << std::endl;
+	}
   sock.Send(fullhistoname.c_str());
   while (true)
   {
@@ -762,8 +770,11 @@ int OnlMonClient::requestMonitorList(const std::string &hostname, const int moni
       {
 	break;
       }
+	if (Verbosity() > 2)
+	{
       std::cout << "inserting " << str << " on host " << hostname
 		<< " listening to " << moniport << std::endl;
+	}
       MonitorHostPorts.insert(std::make_pair(str,std::make_pair(hostname,moniport)));
     }
     else
@@ -797,7 +808,10 @@ int OnlMonClient::requestHistoList(const std::string &subsys, const std::string 
   delete mess;
   for (listiter = histolist.begin(); listiter != histolist.end(); ++listiter)
   {
+	if (Verbosity() > 2)
+	{
     std::cout << PHWHERE << "asking for " << *listiter << std::endl;
+	}
     sock.Send((*listiter).c_str());
     sock.Recv(mess);
     if (!mess)
@@ -860,10 +874,10 @@ void OnlMonClient::updateHistoMap(const std::string &subsys, const std::string &
 //  std::map<const std::string, ClientHistoList *>::const_iterator histoiter = Histo.find(hname);
   if (histoiter != subsysiter->second.end())
   {
-#ifdef DEBUG
+	if (Verbosity() > 2)
+	{
     std::cout << "deleting histogram " << hname << " at " << Histo[hname] << std::endl;
-#endif
-
+	}
     delete histoiter->second->Histo();  // delete old histogram
     histoiter->second->Histo(h1d);
   }
@@ -871,11 +885,10 @@ void OnlMonClient::updateHistoMap(const std::string &subsys, const std::string &
   {
     ClientHistoList *newhisto = new ClientHistoList();
     newhisto->Histo(h1d);
-//    Histo[hname] = newhisto;
-#ifdef DEBUG
-
+	if (Verbosity() > 2)
+	{
     std::cout << "new histogram " << hname << " at " << Histo[hname] << std::endl;
-#endif
+	}
   }
   return;
 }
@@ -1608,7 +1621,10 @@ void OnlMonClient::FindAllMonitors()
 {
   for (auto &hostiter:  MonitorHosts)
   {
+	if (Verbosity() > 2)
+	{
     std::cout << "checking " << hostiter << std::endl;
+	}
     for (unsigned int moniport = OnlMonDefs::MONIPORT; moniport < OnlMonDefs::MONIPORT+OnlMonDefs::NUMMONIPORT; ++moniport)
     {
       requestMonitorList(hostiter,moniport);
@@ -1623,16 +1639,25 @@ int OnlMonClient::FindMonitor(const std::string &name)
   int iret = 0;
   for (auto &hostiter:  MonitorHosts)
   {
+	if (Verbosity() > 2)
+	{
     std::cout << "checking " << hostiter << std::endl;
+	}
     for (unsigned int moniport = OnlMonDefs::MONIPORT; moniport < OnlMonDefs::MONIPORT+OnlMonDefs::NUMMONIPORT; ++moniport)
     {
       requestMonitorList(hostiter,moniport);
+	if (Verbosity() > 2)
+	{
       std::cout << "looking for " << name << std::endl;
+	}
       auto moniter = MonitorHostPorts.find(name);
       if (moniter != MonitorHostPorts.end())
       {
+	if (Verbosity() > 2)
+	{
 	std::cout << "found " << name << " running on " << moniter->second.first
 		  << " listening to port " <<  moniter->second.second << std::endl;
+	}
 	return 1;
       }
     }

--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -1529,3 +1529,16 @@ OnlMonClient::RunType()
   CacheRunDB(RunNumber());
   return runtype;
 }
+
+void OnlMonClient::FindAllMonitors()
+{
+  for (auto &hostiter:  MonitorHosts)
+  {
+    std::cout << "checking " << hostiter << std::endl;
+    for (unsigned int moniport = OnlMonDefs::MONIPORT; moniport < OnlMonDefs::MONIPORT+OnlMonDefs::NUMMONIPORT; ++moniport)
+    {
+      requestMonitorList(hostiter,moniport);
+    }
+  }
+  return;
+}

--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -899,6 +899,21 @@ TH1 *OnlMonClient::getHisto(const std::string &hname)
   return nullptr;
 }
 
+TH1 *OnlMonClient::getHisto(const std::string &monitor, const std::string &hname)
+{
+    auto subsysiter = SubsysHisto.find(monitor);
+    if (subsysiter == SubsysHisto.end())
+    {
+      return nullptr;
+    }
+  auto hiter = subsysiter->second.find(hname);
+  if (hiter == subsysiter->second.end())
+  {
+    return nullptr;
+  }
+  return hiter->second->Histo();
+}
+
 void OnlMonClient::Print(const char *what)
 {
   if (!strcmp(what, "ALL") || !strcmp(what, "DRAWER"))

--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -902,16 +902,6 @@ OnlMonClient::getDrawer(const std::string &name)
   return nullptr;
 }
 
-TH1 *OnlMonClient::getHisto(const std::string &hname)
-{
-  std::map<const std::string, ClientHistoList *>::const_iterator histoiter = Histo.find(hname);
-  if (histoiter != Histo.end())
-  {
-    return histoiter->second->Histo();
-  }
-  return nullptr;
-}
-
 TH1 *OnlMonClient::getHisto(const std::string &monitor, const std::string &hname)
 {
   auto subsysiter = SubsysHisto.find(monitor);

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -1,5 +1,5 @@
-#ifndef ONLMONCLIENT_H__
-#define ONLMONCLIENT_H__
+#ifndef ONLMONCLIENT_ONLMONCLIENT_H
+#define ONLMONCLIENT_ONLMONCLIENT_H
 
 #include <onlmon/OnlMonBase.h>
 #include <onlmon/OnlMonDefs.h>
@@ -23,16 +23,15 @@ class OnlMonClient : public OnlMonBase
  public:
   static OnlMonClient *instance();
   ~OnlMonClient() override;
-  int UpdateServerHistoMap(const std::string &hname, const std::string &hostname);
-  void PutHistoInMap(const std::string &hname, const std::string &hostname, const int port);
+  int UpdateServerHistoMap(const std::string &hname, const std::string &subsys, const std::string &hostname);
+  void PutHistoInMap(const std::string &hname, const std::string &subsys, const std::string &hostname, const int port);
   void updateHistoMap(const char *hname, TH1 *h1d);
   TH1 *getHisto(const std::string &hname);
   OnlMonDraw *getDrawer(const std::string &name);
   int requestHisto(const char *what = "ALL", const std::string &hostname = "localhost", const int moniport = OnlMonDefs::MONIPORT);
   int requestHistoList(const std::string &hostname, const int moniport, std::list<std::string> &histolist);
   int requestHistoByName(const std::string &what = "ALL");
-  int requestHistoBySubSystem(const char *subsystem, int getall = 0);
-  int requestHistoBySubSystem_new(const std::string &subsystem, int getall = 0);
+  int requestHistoBySubSystem(const std::string &subsystem, int getall = 0);
   void registerHisto(const std::string &hname, const std::string &subsys);
   void Print(const char *what = "ALL");
 
@@ -55,7 +54,7 @@ class OnlMonClient : public OnlMonBase
                  const std::string &ext, std::string &fullfilename,
                  std::string &filename);
 
-  int LocateHistogram(const std::string &hname);
+  int LocateHistogram(const std::string &hname, const std::string &subsys);
   int RunNumber();
   time_t EventTime(const char *which = "CURRENT");
   int SendCommand(const char *hostname, const int port, const char *cmd);
@@ -96,10 +95,10 @@ class OnlMonClient : public OnlMonBase
   int cachedrun = 0;
 
   std::string runtype = "UNKNOWN";
-  std::map<std::pair<const std::string, const std::string>, ClientHistoList *> SubsysHisto;
+  std::map<std::string, std::map<const std::string, ClientHistoList *>> SubsysHisto;
   std::map<const std::string, ClientHistoList *> Histo;
   std::map<const std::string, OnlMonDraw *> DrawerList;
   std::vector<std::string> MonitorHosts;
 };
 
-#endif /* __ONLMONCLIENT_H__ */
+#endif /* ONLMONCLIENT_ONLMONCLIENT_H */

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -97,7 +97,7 @@ class OnlMonClient : public OnlMonBase
 
   std::string runtype = "UNKNOWN";
   std::map<std::string, std::map<const std::string, ClientHistoList *>> SubsysHisto;
-  std::map<std::string, std::pair<std::string, unsigned int>> SubsysHostPorts;
+  std::map<std::string, std::pair<std::string, unsigned int>> MonitorHostPorts;
   std::map<const std::string, ClientHistoList *> Histo;
   std::map<const std::string, OnlMonDraw *> DrawerList;
   std::vector<std::string> MonitorHosts;

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -28,6 +28,7 @@ class OnlMonClient : public OnlMonBase
   void updateHistoMap(const std::string &subsys, const std::string &hname, TH1 *h1d);
   int requestMonitorList(const std::string &hostname, const int moniport);
   TH1 *getHisto(const std::string &hname);
+  TH1 *getHisto(const std::string &monitor, const std::string &hname);
   OnlMonDraw *getDrawer(const std::string &name);
   int requestHisto(const char *what = "ALL", const std::string &hostname = "localhost", const int moniport = OnlMonDefs::MONIPORT);
   int requestHistoList(const std::string &subsys, const std::string &hostname, const int moniport, std::list<std::string> &histolist);

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -27,7 +27,6 @@ class OnlMonClient : public OnlMonBase
   void PutHistoInMap(const std::string &hname, const std::string &subsys, const std::string &hostname, const int port);
   void updateHistoMap(const std::string &subsys, const std::string &hname, TH1 *h1d);
   int requestMonitorList(const std::string &hostname, const int moniport);
-  TH1 *getHisto(const std::string &hname);
   TH1 *getHisto(const std::string &monitor, const std::string &hname);
   OnlMonDraw *getDrawer(const std::string &name);
   int requestHisto(const char *what = "ALL", const std::string &hostname = "localhost", const int moniport = OnlMonDefs::MONIPORT);

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -26,6 +26,7 @@ class OnlMonClient : public OnlMonBase
   int UpdateServerHistoMap(const std::string &hname, const std::string &subsys, const std::string &hostname);
   void PutHistoInMap(const std::string &hname, const std::string &subsys, const std::string &hostname, const int port);
   void updateHistoMap(const std::string &subsys, const std::string &hname, TH1 *h1d);
+  int requestMonitorList(const std::string &hostname, const int moniport);
   TH1 *getHisto(const std::string &hname);
   OnlMonDraw *getDrawer(const std::string &name);
   int requestHisto(const char *what = "ALL", const std::string &hostname = "localhost", const int moniport = OnlMonDefs::MONIPORT);

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -32,7 +32,7 @@ class OnlMonClient : public OnlMonBase
   OnlMonDraw *getDrawer(const std::string &name);
   int requestHisto(const char *what = "ALL", const std::string &hostname = "localhost", const int moniport = OnlMonDefs::MONIPORT);
   int requestHistoList(const std::string &subsys, const std::string &hostname, const int moniport, std::list<std::string> &histolist);
-  int requestHistoByName(const std::string &what = "ALL");
+  int requestHistoByName(const std::string &subsystem, const std::string &what = "ALL");
   int requestHistoBySubSystem(const std::string &subsystem, int getall = 0);
   void registerHisto(const std::string &hname, const std::string &subsys);
   void Print(const char *what = "ALL");

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -25,11 +25,11 @@ class OnlMonClient : public OnlMonBase
   ~OnlMonClient() override;
   int UpdateServerHistoMap(const std::string &hname, const std::string &subsys, const std::string &hostname);
   void PutHistoInMap(const std::string &hname, const std::string &subsys, const std::string &hostname, const int port);
-  void updateHistoMap(const char *hname, TH1 *h1d);
+  void updateHistoMap(const std::string &subsys, const std::string &hname, TH1 *h1d);
   TH1 *getHisto(const std::string &hname);
   OnlMonDraw *getDrawer(const std::string &name);
   int requestHisto(const char *what = "ALL", const std::string &hostname = "localhost", const int moniport = OnlMonDefs::MONIPORT);
-  int requestHistoList(const std::string &hostname, const int moniport, std::list<std::string> &histolist);
+  int requestHistoList(const std::string &subsys, const std::string &hostname, const int moniport, std::list<std::string> &histolist);
   int requestHistoByName(const std::string &what = "ALL");
   int requestHistoBySubSystem(const std::string &subsystem, int getall = 0);
   void registerHisto(const std::string &hname, const std::string &subsys);
@@ -96,6 +96,7 @@ class OnlMonClient : public OnlMonBase
 
   std::string runtype = "UNKNOWN";
   std::map<std::string, std::map<const std::string, ClientHistoList *>> SubsysHisto;
+  std::map<std::string, std::pair<std::string, unsigned int>> SubsysHostPorts;
   std::map<const std::string, ClientHistoList *> Histo;
   std::map<const std::string, OnlMonDraw *> DrawerList;
   std::vector<std::string> MonitorHosts;

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -2,7 +2,7 @@
 #define ONLMONCLIENT_H__
 
 #include <onlmon/OnlMonBase.h>
-#include <onlmon/PortNumber.h>
+#include <onlmon/OnlMonDefs.h>
 
 #include <ctime>
 #include <list>
@@ -28,10 +28,11 @@ class OnlMonClient : public OnlMonBase
   void updateHistoMap(const char *hname, TH1 *h1d);
   TH1 *getHisto(const std::string &hname);
   OnlMonDraw *getDrawer(const std::string &name);
-  int requestHisto(const char *what = "ALL", const std::string &hostname = "localhost", const int moniport = MONIPORT);
+  int requestHisto(const char *what = "ALL", const std::string &hostname = "localhost", const int moniport = OnlMonDefs::MONIPORT);
   int requestHistoList(const std::string &hostname, const int moniport, std::list<std::string> &histolist);
   int requestHistoByName(const std::string &what = "ALL");
   int requestHistoBySubSystem(const char *subsystem, int getall = 0);
+  int requestHistoBySubSystem_new(const std::string &subsystem, int getall = 0);
   void registerHisto(const std::string &hname, const std::string &subsys);
   void Print(const char *what = "ALL");
 
@@ -95,6 +96,7 @@ class OnlMonClient : public OnlMonBase
   int cachedrun = 0;
 
   std::string runtype = "UNKNOWN";
+  std::map<std::pair<const std::string, const std::string>, ClientHistoList *> SubsysHisto;
   std::map<const std::string, ClientHistoList *> Histo;
   std::map<const std::string, OnlMonDraw *> DrawerList;
   std::vector<std::string> MonitorHosts;

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -78,6 +78,8 @@ class OnlMonClient : public OnlMonBase
   std::string RunType();
   void CacheRunDB(const int runno);
   void FindAllMonitors();
+  int FindMonitor(const std::string &name);
+  int IsMonitorRunning(const std::string &name);
 
  private:
   OnlMonClient(const std::string &name = "ONLMONCLIENT");

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -77,6 +77,7 @@ class OnlMonClient : public OnlMonBase
   int isStandalone();
   std::string RunType();
   void CacheRunDB(const int runno);
+  void FindAllMonitors();
 
  private:
   OnlMonClient(const std::string &name = "ONLMONCLIENT");

--- a/onlmonserver/Makefile.am
+++ b/onlmonserver/Makefile.am
@@ -44,10 +44,10 @@ pkginclude_HEADERS = \
   HistoBinDefs.h \
   OnlMon.h \
   OnlMonBase.h \
+  OnlMonDefs.h \
   OnlMonServer.h \
   OnlMonStatus.h \
-  OnlMonTrigger.h \
-  PortNumber.h
+  OnlMonTrigger.h
 
 libonlmonserver_funcs_la_SOURCES = \
   pmonitorInterface.cc

--- a/onlmonserver/OnlMon.cc
+++ b/onlmonserver/OnlMon.cc
@@ -12,6 +12,11 @@ class Event;
 OnlMon::OnlMon(const std::string &name)
   : OnlMonBase(name)
 {
+  if (name.find('_') != std::string::npos)
+  {
+    std::cout << "No underscore (_) in online monitoring server name " << name << " allowed" << std::endl;
+    exit(1);
+  }
   livetrigmask = 0;
   status = OnlMon::ACTIVE;
   return;
@@ -139,3 +144,16 @@ void OnlMon::SetStatus(const int newstatus)
   }
   return;
 }
+
+void OnlMon::SetServerId(unsigned int i)
+{
+  if (Name().find('_') != std::string::npos)
+  {
+    std::cout << "Server Id was already set " << Name() << std::endl;
+    return;
+  }
+  m_ServerId = i;
+  Name(Name() + '_' + std::to_string(i));
+  return;
+}
+

--- a/onlmonserver/OnlMon.cc
+++ b/onlmonserver/OnlMon.cc
@@ -149,14 +149,14 @@ void OnlMon::SetStatus(const int newstatus)
   return;
 }
 
-void OnlMon::SetServerId(unsigned int i)
+void OnlMon::SetMonitorServerId(unsigned int i)
 {
   if (Name().find('_') != std::string::npos)
   {
-    std::cout << "Server Id was already set " << Name() << std::endl;
+    std::cout << "Monitor Server Id was already set " << Name() << std::endl;
     return;
   }
-  m_ServerId = i;
+  m_MonitorServerId = i;
   Name(Name() + '_' + std::to_string(i));
   return;
 }

--- a/onlmonserver/OnlMon.cc
+++ b/onlmonserver/OnlMon.cc
@@ -3,6 +3,8 @@
 
 #include <Event/msg_profile.h>
 
+#include <TH1.h>
+
 #include <cstdio>  // for printf
 #include <iostream>
 #include <sstream>
@@ -89,8 +91,10 @@ void OnlMon::AddLiveTrigger(const std::string &name)
   return;
 }
 
-int OnlMon::InitCommon(OnlMonServer * /* se */)
+int OnlMon::InitCommon(OnlMonServer *  se)
 {
+//  m_LocalFrameWorkVars = static_cast<TH1 *>(se->getCommonHisto("FrameWorkVars")->Clone());
+  se->registerHisto(this,se->getCommonHisto("FrameWorkVars"));
   return 0;
 }
 

--- a/onlmonserver/OnlMon.h
+++ b/onlmonserver/OnlMon.h
@@ -1,5 +1,5 @@
-#ifndef __ONLMON_H__
-#define __ONLMON_H__
+#ifndef ONLMONSERVER_ONLMON_H
+#define ONLMONSERVER_ONLMON_H
 
 #include "OnlMonBase.h"
 
@@ -9,6 +9,7 @@
 
 class Event;
 class OnlMonServer;
+class TH1;
 
 class OnlMon : public OnlMonBase
 {
@@ -44,6 +45,7 @@ class OnlMon : public OnlMonBase
   unsigned int livetrigmask;
   int status;
   unsigned int m_ServerId = 0;
+  TH1 *m_LocalFrameWorkVars = nullptr;
 };
 
-#endif /* __ONLMON_H__ */
+#endif /* ONLMONSERVER_ONLMON_H */

--- a/onlmonserver/OnlMon.h
+++ b/onlmonserver/OnlMon.h
@@ -37,14 +37,14 @@ class OnlMon : public OnlMonBase
   virtual void AddLiveTrigger(const std::string &name);
   virtual void SetStatus(const int newstatus);
   virtual int ResetEvent() { return 0; }
-  virtual void SetServerId(unsigned int i);
+  virtual void SetMonitorServerId(unsigned int i);
 
  protected:
   std::set<std::string> TriggerList;      // trigger selection send to the et pool
   std::set<std::string> LiveTriggerList;  // triggers filtered in process_event according to live bit
   unsigned int livetrigmask;
   int status;
-  unsigned int m_ServerId = 0;
+  unsigned int m_MonitorServerId = 0;
   TH1 *m_LocalFrameWorkVars = nullptr;
 };
 

--- a/onlmonserver/OnlMon.h
+++ b/onlmonserver/OnlMon.h
@@ -36,12 +36,14 @@ class OnlMon : public OnlMonBase
   virtual void AddLiveTrigger(const std::string &name);
   virtual void SetStatus(const int newstatus);
   virtual int ResetEvent() { return 0; }
+  virtual void SetServerId(unsigned int i);
 
  protected:
   std::set<std::string> TriggerList;      // trigger selection send to the et pool
   std::set<std::string> LiveTriggerList;  // triggers filtered in process_event according to live bit
   unsigned int livetrigmask;
   int status;
+  unsigned int m_ServerId = 0;
 };
 
 #endif /* __ONLMON_H__ */

--- a/onlmonserver/OnlMonBase.h
+++ b/onlmonserver/OnlMonBase.h
@@ -10,6 +10,7 @@ class OnlMonBase
   virtual ~OnlMonBase() {}
 
   const std::string Name() const { return ThisName; }
+  void Name(const std::string &name) {ThisName = name;}
   virtual void Verbosity(const int i) { verbosity = i; }
   virtual int Verbosity() const { return verbosity; }
 

--- a/onlmonserver/OnlMonDefs.h
+++ b/onlmonserver/OnlMonDefs.h
@@ -1,0 +1,12 @@
+#ifndef ONLMONSERVER_ONLMONDEFS_H
+#define ONLMONSERVER_ONLMONDEFS_H
+
+namespace OnlMonDefs
+{
+// Port to use by framework
+  const unsigned int MONIPORT = 9081;
+  const unsigned int NUMMONIPORT = 5;
+  const unsigned int MSGLEN = 256;
+}
+
+#endif

--- a/onlmonserver/OnlMonDefs.h
+++ b/onlmonserver/OnlMonDefs.h
@@ -5,7 +5,7 @@ namespace OnlMonDefs
 {
 // Port to use by framework
   const unsigned int MONIPORT = 9081;
-  const unsigned int NUMMONIPORT = 5;
+  const unsigned int NUMMONIPORT = 2;
   const unsigned int MSGLEN = 256;
 }
 

--- a/onlmonserver/OnlMonServer.cc
+++ b/onlmonserver/OnlMonServer.cc
@@ -489,7 +489,6 @@ void OnlMonServer::Print(const std::string &what) const
     // loop over the map and print out the content (name and location in memory)
     printf("\n--------------------------------------\n\n");
     printf("List of Common Histograms in OnlMonServer:\n");
-    std::map<const std::string, TH1 *>::const_iterator hiter;
     for (auto &hiter : Histo)
     {
       std::cout << hiter.first << std::endl;
@@ -502,8 +501,6 @@ void OnlMonServer::Print(const std::string &what) const
     printf("--------------------------------------\n\n");
     printf("List of Monitors with registered histos in OnlMonServer:\n");
 
-    std::vector<OnlMon *>::const_iterator miter;
-    std::map<std::string, std::set<std::string>>::const_iterator mhisiter;
     for (auto &miter : MonitorList)
     {
       std::cout << miter->Name() << std::endl;

--- a/onlmonserver/OnlMonServer.cc
+++ b/onlmonserver/OnlMonServer.cc
@@ -135,7 +135,7 @@ void OnlMonServer::dumpHistos(const std::string &filename)
 void OnlMonServer::registerCommonHisto(TH1 *h1d)
 {
   Histo.insert(std::make_pair(h1d->GetName(), h1d));
-//  registerCommonHisto(h1d->GetName(), h1d, 0);
+  //  registerCommonHisto(h1d->GetName(), h1d, 0);
   CommonHistoSet.insert(h1d->GetName());
   return;
 }
@@ -165,7 +165,7 @@ void OnlMonServer::registerHisto(const std::string &monitorname, const std::stri
   auto histoiter = moniiter->second.find(hname);
   if (histoiter == moniiter->second.end())
   {
-    moniiter->second.insert(std::make_pair(hname,h1d));
+    moniiter->second.insert(std::make_pair(hname, h1d));
   }
   else
   {
@@ -176,8 +176,8 @@ void OnlMonServer::registerHisto(const std::string &monitorname, const std::stri
     }
     else
     {
-      std::cout << "Histogram " << hname << " already registered with " <<  monitorname 
-		<< ", it will not be overwritten" << std::endl;
+      std::cout << "Histogram " << hname << " already registered with " << monitorname
+                << ", it will not be overwritten" << std::endl;
     }
   }
   return;
@@ -190,7 +190,7 @@ void OnlMonServer::registerHisto(const std::string &hname, TH1 *h1d, const int r
     std::cout << "No empty spaces in registered histogram names : " << hname << std::endl;
     exit(1);
   }
-  const std::string& tmpstr = hname;
+  const std::string &tmpstr = hname;
   std::map<const std::string, TH1 *>::const_iterator histoiter = Histo.find(tmpstr);
   std::ostringstream msg;
   int histoexist;
@@ -333,7 +333,7 @@ TH1 *OnlMonServer::getHisto(const std::string &subsys, const std::string &hname)
 {
   if (Verbosity() > 2)
   {
-  std::cout << PHWHERE << " checking for subsys " << subsys << ", hname " << hname << std::endl;
+    std::cout << PHWHERE << " checking for subsys " << subsys << ", hname " << hname << std::endl;
   }
   auto moniiter = MonitorHistoSet.find(subsys);
   if (moniiter != MonitorHistoSet.end())
@@ -355,7 +355,6 @@ TH1 *OnlMonServer::getHisto(const std::string &subsys, const std::string &hname)
 
 TH1 *OnlMonServer::getCommonHisto(const std::string &hname) const
 {
-  
   std::map<const std::string, TH1 *>::const_iterator histoiter = Histo.find(hname);
   if (histoiter != Histo.end())
   {
@@ -373,17 +372,16 @@ TH1 *OnlMonServer::getCommonHisto(const std::string &hname) const
 int OnlMonServer::run_empty(const int nevents)
 {
   int iret = 0;
-  for (int i = 0; i<nevents; i++)
+  for (int i = 0; i < nevents; i++)
   {
     iret = process_event(nullptr);
-    if (iret )
+    if (iret)
     {
       break;
     }
   }
   return iret;
 }
-
 
 int OnlMonServer::process_event(Event *evt)
 {
@@ -467,12 +465,13 @@ void OnlMonServer::Print(const std::string &what) const
 {
   if (what == "ALL" || what == "PORT")
   {
-      utsname ThisNode;
-      uname(&ThisNode);
+    utsname ThisNode;
+    uname(&ThisNode);
     printf("--------------------------------------\n\n");
-    std::cout << "Server running on " << ThisNode.nodename 
-	      << " and is listening on port " << PortNumber() << std::endl << std::endl;
-  } 
+    std::cout << "Server running on " << ThisNode.nodename
+              << " and is listening on port " << PortNumber() << std::endl
+              << std::endl;
+  }
   if (what == "ALL" || what == "HISTOS")
   {
     std::set<std::string> cached_hists;
@@ -483,7 +482,7 @@ void OnlMonServer::Print(const std::string &what) const
       std::cout << "Monitor " << moniiter.first << std::endl;
       for (auto &histiter : moniiter.second)
       {
-	std::cout << histiter.first << std::endl;
+        std::cout << histiter.first << std::endl;
         cached_hists.insert(histiter.first);
       }
     }
@@ -504,7 +503,7 @@ void OnlMonServer::Print(const std::string &what) const
     printf("List of Monitors with registered histos in OnlMonServer:\n");
 
     std::vector<OnlMon *>::const_iterator miter;
-    std::map<std::string, std::set<std::string> >::const_iterator mhisiter;
+    std::map<std::string, std::set<std::string>>::const_iterator mhisiter;
     for (auto &miter : MonitorList)
     {
       std::cout << miter->Name() << std::endl;
@@ -552,82 +551,82 @@ void OnlMonServer::RunNumber(const int irun)
 
 int OnlMonServer::WriteHistoFile()
 {
-/*
-  utsname ThisNode;
-  uname(&ThisNode);
-  std::string nn = ThisNode.nodename;
-  std::string mm = nn.substr(0, nn.find('.'));  // strip the domain (all chars after first .)
-  std::ostringstream dirname, filename;
-  // filename is Run_<runno>_<monitor>_<nodename>.root
-  if (getenv("ONLMON_SAVEDIR"))
-  {
-    dirname << getenv("ONLMON_SAVEDIR") << "/";
-  }
-  int irun = RunNumber();
-  std::map<std::string, std::set<std::string> >::const_iterator mhistiter;
-  // assignedhists set stores all encountered histograms so histos which are not accounted
-  // for can be saved
-  std::set<std::string> assignedhists = CommonHistoSet;
-  std::set<std::string>::const_iterator siter;
-  std::map<const std::string, TH1 *>::const_iterator hiter;
-  for (auto &mhistiter :  MonitorHistoSet.begin())
-  {
-    if (mhistiter->first == "COMMON")
+  /*
+    utsname ThisNode;
+    uname(&ThisNode);
+    std::string nn = ThisNode.nodename;
+    std::string mm = nn.substr(0, nn.find('.'));  // strip the domain (all chars after first .)
+    std::ostringstream dirname, filename;
+    // filename is Run_<runno>_<monitor>_<nodename>.root
+    if (getenv("ONLMON_SAVEDIR"))
     {
-      continue;
+      dirname << getenv("ONLMON_SAVEDIR") << "/";
     }
+    int irun = RunNumber();
+    std::map<std::string, std::set<std::string> >::const_iterator mhistiter;
+    // assignedhists set stores all encountered histograms so histos which are not accounted
+    // for can be saved
+    std::set<std::string> assignedhists = CommonHistoSet;
+    std::set<std::string>::const_iterator siter;
+    std::map<const std::string, TH1 *>::const_iterator hiter;
+    for (auto &mhistiter :  MonitorHistoSet.begin())
+    {
+      if (mhistiter->first == "COMMON")
+      {
+        continue;
+      }
+      filename.str("");
+      filename << dirname.str() << "Run_" << irun << "_" << mhistiter->first << "_" << mm << "_" << PortNumber() << ".root";
+      TFile *hfile = new TFile(filename.str().c_str(), "RECREATE", "Created by Online Monitor", compression_level);
+      for (siter = CommonHistoSet.begin(); siter != CommonHistoSet.end(); ++siter)
+      {
+        hiter = Histo.find(*siter);
+        if (hiter != Histo.end())
+        {
+          hiter->second->Write();
+        }
+        else
+        {
+          std::cout << "could not locate histogram " << *siter << std::endl;
+        }
+      }
+      for (siter = (mhistiter->second).begin(); siter != (mhistiter->second).end(); ++siter)
+      {
+        hiter = Histo.find(*siter);
+        assignedhists.insert(*siter);
+        if (hiter != Histo.end())
+        {
+          hiter->second->Write();
+        }
+        else
+        {
+          std::cout << "could not locate histogram " << *siter << std::endl;
+        }
+      }
+      hfile->Close();
+      delete hfile;
+    }
+    TFile *hfile = nullptr;
     filename.str("");
-    filename << dirname.str() << "Run_" << irun << "_" << mhistiter->first << "_" << mm << "_" << PortNumber() << ".root";
-    TFile *hfile = new TFile(filename.str().c_str(), "RECREATE", "Created by Online Monitor", compression_level);
-    for (siter = CommonHistoSet.begin(); siter != CommonHistoSet.end(); ++siter)
+    filename << dirname.str() << "Run_" << irun << "_" << mm << "_"
+             << PortNumber() << ".root";
+    for (hiter = Histo.begin(); hiter != Histo.end(); ++hiter)
     {
-      hiter = Histo.find(*siter);
-      if (hiter != Histo.end())
+      if (assignedhists.find(hiter->first) == assignedhists.end())
       {
+        if (!hfile)
+        {
+          hfile = new TFile(filename.str().c_str(), "RECREATE", "Created by Online Monitor", compression_level);
+        }
         hiter->second->Write();
       }
-      else
-      {
-        std::cout << "could not locate histogram " << *siter << std::endl;
-      }
     }
-    for (siter = (mhistiter->second).begin(); siter != (mhistiter->second).end(); ++siter)
+    if (hfile)
     {
-      hiter = Histo.find(*siter);
-      assignedhists.insert(*siter);
-      if (hiter != Histo.end())
-      {
-        hiter->second->Write();
-      }
-      else
-      {
-        std::cout << "could not locate histogram " << *siter << std::endl;
-      }
+      hfile->Close();
+      delete hfile;
     }
-    hfile->Close();
-    delete hfile;
-  }
-  TFile *hfile = nullptr;
-  filename.str("");
-  filename << dirname.str() << "Run_" << irun << "_" << mm << "_"
-           << PortNumber() << ".root";
-  for (hiter = Histo.begin(); hiter != Histo.end(); ++hiter)
-  {
-    if (assignedhists.find(hiter->first) == assignedhists.end())
-    {
-      if (!hfile)
-      {
-        hfile = new TFile(filename.str().c_str(), "RECREATE", "Created by Online Monitor", compression_level);
-      }
-      hiter->second->Write();
-    }
-  }
-  if (hfile)
-  {
-    hfile->Close();
-    delete hfile;
-  }
-*/
+  */
   return 0;
 }
 

--- a/onlmonserver/OnlMonServer.cc
+++ b/onlmonserver/OnlMonServer.cc
@@ -154,6 +154,11 @@ void OnlMonServer::registerHisto(const std::string &monitorname, const std::stri
 
 void OnlMonServer::registerHisto(const std::string &hname, TH1 *h1d, const int replace)
 {
+  if (hname.find(' ') != std::string::npos)
+  {
+    std::cout << "No empty spaces in registered histogram names : " << hname << std::endl;
+    exit(1);
+  }
   const std::string& tmpstr = hname;
   std::map<const std::string, TH1 *>::const_iterator histoiter = Histo.find(tmpstr);
   std::ostringstream msg;

--- a/onlmonserver/OnlMonServer.cc
+++ b/onlmonserver/OnlMonServer.cc
@@ -158,6 +158,7 @@ void OnlMonServer::registerHisto(const std::string &monitorname, const std::stri
   {
     std::map<std::string, TH1 *> histo;
     histo[hname] = h1d;
+    std::cout << PHWHERE << " inserting " << monitorname << " hname " << hname << std::endl;
     MonitorHistoSet.insert(std::make_pair(monitorname, histo));
     return;
   }
@@ -330,11 +331,15 @@ OnlMonServer::getHistoName(const unsigned int ihisto) const
 
 TH1 *OnlMonServer::getHisto(const std::string &subsys, const std::string &hname) const
 {
-  
-  std::map<const std::string, TH1 *>::const_iterator histoiter = Histo.find(hname);
-  if (histoiter != Histo.end())
+  std::cout << PHWHERE << " checking for subsys " << subsys << ", hname " << hname << std::endl;
+  auto moniiter = MonitorHistoSet.find(subsys);
+  if (moniiter != MonitorHistoSet.end())
   {
-    return histoiter->second;
+    auto histoiter = moniiter->second.find(hname);
+    if (histoiter != moniiter->second.end())
+    {
+      return histoiter->second;
+    }
   }
   std::ostringstream msg;
 

--- a/onlmonserver/OnlMonServer.cc
+++ b/onlmonserver/OnlMonServer.cc
@@ -331,7 +331,10 @@ OnlMonServer::getHistoName(const unsigned int ihisto) const
 
 TH1 *OnlMonServer::getHisto(const std::string &subsys, const std::string &hname) const
 {
+  if (Verbosity() > 2)
+  {
   std::cout << PHWHERE << " checking for subsys " << subsys << ", hname " << hname << std::endl;
+  }
   auto moniiter = MonitorHistoSet.find(subsys);
   if (moniiter != MonitorHistoSet.end())
   {

--- a/onlmonserver/OnlMonServer.h
+++ b/onlmonserver/OnlMonServer.h
@@ -25,9 +25,9 @@ class OnlMonServer : public OnlMonBase
   static OnlMonServer *instance();
   ~OnlMonServer() override;
 
- // delete copy ctor and assignment operator (cppcheck)
-  explicit OnlMonServer(const OnlMonServer&) = delete;
-  OnlMonServer& operator=(const OnlMonServer&) = delete;
+  // delete copy ctor and assignment operator (cppcheck)
+  explicit OnlMonServer(const OnlMonServer &) = delete;
+  OnlMonServer &operator=(const OnlMonServer &) = delete;
 
   void registerHisto(const std::string &monitorname, const std::string &hname, TH1 *h1d, const int replace = 0);
   void registerHisto(const OnlMon *monitor, TH1 *h1d);
@@ -102,10 +102,10 @@ class OnlMonServer : public OnlMonBase
   PHCompositeNode *TopNode() { return topNode; }
 
   int run_empty(const int nevents);
-  std::map<std::string, std::map<std::string, TH1 *>>::const_iterator monibegin() {return MonitorHistoSet.begin();}
-  std::map<std::string, std::map<std::string, TH1 *>>::const_iterator moniend() {return MonitorHistoSet.end();}
-  std::vector<OnlMon *>::const_iterator monitor_vec_begin() {return MonitorList.begin();}
-  std::vector<OnlMon *>::const_iterator monitor_vec_end() {return MonitorList.end();}
+  std::map<std::string, std::map<std::string, TH1 *>>::const_iterator monibegin() { return MonitorHistoSet.begin(); }
+  std::map<std::string, std::map<std::string, TH1 *>>::const_iterator moniend() { return MonitorHistoSet.end(); }
+  std::vector<OnlMon *>::const_iterator monitor_vec_begin() { return MonitorList.begin(); }
+  std::vector<OnlMon *>::const_iterator monitor_vec_end() { return MonitorList.end(); }
 
  private:
   OnlMonServer(const std::string &name = "OnlMonServer");
@@ -137,7 +137,7 @@ class OnlMonServer : public OnlMonBase
   std::vector<OnlMon *> MonitorList;
   std::set<unsigned int> activepackets;
   std::map<std::string, MessageSystem *> MsgSystem;
-  std::map<std::string, std::map<std::string, TH1 *> > MonitorHistoSet;
+  std::map<std::string, std::map<std::string, TH1 *>> MonitorHistoSet;
   std::set<std::string> CommonHistoSet;
   pthread_mutex_t mutex;
   pthread_t serverthreadid = 0;

--- a/onlmonserver/OnlMonServer.h
+++ b/onlmonserver/OnlMonServer.h
@@ -33,7 +33,8 @@ class OnlMonServer : public OnlMonBase
   void registerHisto(const OnlMon *monitor, TH1 *h1d);
 
   void registerCommonHisto(TH1 *h1d);
-  TH1 *getHisto(const std::string &hname) const;
+  TH1 *getHisto(const std::string &subsys, const std::string &hname) const;
+  TH1 *getCommonHisto(const std::string &hname) const;
   TH1 *getHisto(const unsigned int ihisto) const;
   const std::string getHistoName(const unsigned int ihisto) const;
   unsigned int nHistos() const { return Histo.size(); }
@@ -101,8 +102,8 @@ class OnlMonServer : public OnlMonBase
   PHCompositeNode *TopNode() { return topNode; }
 
   int run_empty(const int nevents);
-  std::map<std::string, std::set<std::string> >::const_iterator monibegin() {return MonitorHistoSet.begin();}
-  std::map<std::string, std::set<std::string> >::const_iterator moniend() {return MonitorHistoSet.end();}
+  std::map<std::string, std::map<std::string, TH1 *>>::const_iterator monibegin() {return MonitorHistoSet.begin();}
+  std::map<std::string, std::map<std::string, TH1 *>>::const_iterator moniend() {return MonitorHistoSet.end();}
 
  private:
   OnlMonServer(const std::string &name = "OnlMonServer");
@@ -134,7 +135,7 @@ class OnlMonServer : public OnlMonBase
   std::vector<OnlMon *> MonitorList;
   std::set<unsigned int> activepackets;
   std::map<std::string, MessageSystem *> MsgSystem;
-  std::map<std::string, std::set<std::string> > MonitorHistoSet;
+  std::map<std::string, std::map<std::string, TH1 *> > MonitorHistoSet;
   std::set<std::string> CommonHistoSet;
   pthread_mutex_t mutex;
   pthread_t serverthreadid = 0;

--- a/onlmonserver/OnlMonServer.h
+++ b/onlmonserver/OnlMonServer.h
@@ -104,6 +104,8 @@ class OnlMonServer : public OnlMonBase
   int run_empty(const int nevents);
   std::map<std::string, std::map<std::string, TH1 *>>::const_iterator monibegin() {return MonitorHistoSet.begin();}
   std::map<std::string, std::map<std::string, TH1 *>>::const_iterator moniend() {return MonitorHistoSet.end();}
+  std::vector<OnlMon *>::const_iterator monitor_vec_begin() {return MonitorList.begin();}
+  std::vector<OnlMon *>::const_iterator monitor_vec_end() {return MonitorList.end();}
 
  private:
   OnlMonServer(const std::string &name = "OnlMonServer");

--- a/onlmonserver/OnlMonServer.h
+++ b/onlmonserver/OnlMonServer.h
@@ -1,8 +1,8 @@
-#ifndef __ONLMONSERVER_H
-#define __ONLMONSERVER_H
+#ifndef ONLMONSERVER_ONLMONSERVER_H
+#define ONLMONSERVER_ONLMONSERVER_H
 
 #include "OnlMonBase.h"
-#include "PortNumber.h"
+#include "OnlMonDefs.h"
 
 #include <pthread.h>
 #include <ctime>
@@ -101,6 +101,8 @@ class OnlMonServer : public OnlMonBase
   PHCompositeNode *TopNode() { return topNode; }
 
   int run_empty(const int nevents);
+  std::map<std::string, std::set<std::string> >::const_iterator monibegin() {return MonitorHistoSet.begin();}
+  std::map<std::string, std::set<std::string> >::const_iterator moniend() {return MonitorHistoSet.end();}
 
  private:
   OnlMonServer(const std::string &name = "OnlMonServer");
@@ -112,7 +114,7 @@ class OnlMonServer : public OnlMonBase
   unsigned int trigger[3];
   int runnumber = -1;
   int eventnumber = 0;
-  int portnumber = MONIPORT;
+  int portnumber = OnlMonDefs::MONIPORT;
   int badevents = 0;
   time_t currentticks = 0;
   time_t borticks = 0;

--- a/onlmonserver/PortNumber.h
+++ b/onlmonserver/PortNumber.h
@@ -1,7 +1,0 @@
-#ifndef __PORTNUMBER_H__
-#define __PORTNUMBER_H__
-
-// Port to use by framework
-#define MONIPORT 9081
-#define NUMMONIPORT 5
-#endif

--- a/onlmonserver/pmonitorInterface.cc
+++ b/onlmonserver/pmonitorInterface.cc
@@ -504,7 +504,6 @@ void handleconnection(void *arg)
       }
       else if (str.find("ISRUNNING") != std::string::npos)
       {
-        bool foundit = false;
         std::string answer = "No";
         unsigned int pos_space = str.find(' ');
         std::string moniname = str.substr(pos_space + 1, str.size());

--- a/onlmonserver/pmonitorInterface.cc
+++ b/onlmonserver/pmonitorInterface.cc
@@ -5,6 +5,7 @@
 #include "pmonitorInterface.h"
 #include "OnlMonServer.h"
 #include "OnlMonDefs.h"
+#include "OnlMon.h"
 #include "HistoBinDefs.h"
 
 #include <phool/phool.h>
@@ -498,6 +499,34 @@ void handleconnection(void *arg)
           }
         }
         s0->Send("Finished");
+      }
+      else if (str == "LISTMONITORS")
+      {
+        for (auto moniter = Onlmonserver->monitor_vec_begin(); moniter != Onlmonserver->monitor_vec_end(); ++moniter)
+	{
+	  s0->Send((*moniter)->Name().c_str());
+	  while (true)
+	  {
+	    char strmess[OnlMonDefs::MSGLEN];
+	    s0->Recv(mess);
+	    if (!mess)
+	    {
+	      break;
+	    }
+	    mess->ReadString(strmess, OnlMonDefs::MSGLEN);
+	    delete mess;
+	    std::string str(strmess);
+	    std::cout << "got " << str << std::endl;
+	    if (str == "Finished")
+	    {
+	      break;
+	    }
+        s0->Send("Ack");
+
+	  }
+	}
+        s0->Send("Finished");
+	break;
       }
       else if (str == "LIST")
       {

--- a/onlmonserver/pmonitorInterface.cc
+++ b/onlmonserver/pmonitorInterface.cc
@@ -460,9 +460,12 @@ void handleconnection(void *arg)
 	  for (auto &histos: monitors->second)
 	  {
 
-	    std::cout << "subsystem: " << monitors->first << ", histo: " << histos.first << std::endl;
 	    std::string subsyshisto =   monitors->first + ' ' + histos.first;
+  if (Onlmonserver->Verbosity() > 2)
+  {
+	    std::cout << "subsystem: " << monitors->first << ", histo: " << histos.first << std::endl;
             std::cout << " sending: \"" << subsyshisto << "\"" << std::endl;
+  }
           s0->Send(subsyshisto.c_str());
           int nbytes = s0->Recv(mess);
           delete mess;
@@ -514,7 +517,10 @@ void handleconnection(void *arg)
 	    break;
 	  }
 	}
+  if (Onlmonserver->Verbosity() > 2)
+  {
 	std::cout << "got " << str << ", replied " << answer << std::endl;
+  }
 	s0->Send(answer.c_str());
       }
       else if (str == "LISTMONITORS")
@@ -522,7 +528,10 @@ void handleconnection(void *arg)
         s0->Send("go");
         for (auto moniter = Onlmonserver->monitor_vec_begin(); moniter != Onlmonserver->monitor_vec_end(); ++moniter)
 	{
+  if (Onlmonserver->Verbosity() > 2)
+  {
 	  std::cout << "sending " << (*moniter)->Name().c_str() << std::endl;
+  }
 	  s0->Send((*moniter)->Name().c_str());
 	}
         s0->Send("Finished");
@@ -551,7 +560,10 @@ void handleconnection(void *arg)
           }
 	  std::string str1(strmess);
           unsigned int pos_space = str1.find(' ');
+  if (Onlmonserver->Verbosity() > 2)
+  {
 	  std::cout << PHWHERE << " getting subsystem " << str1.substr(0,pos_space) << ", histo " <<  str1.substr(pos_space+1,str1.size()) << std::endl;
+  }
           TH1 *histo = Onlmonserver->getHisto(str1.substr(0,pos_space),str1.substr(pos_space+1,str1.size()));
           if (histo)
           {

--- a/onlmonserver/pmonitorInterface.cc
+++ b/onlmonserver/pmonitorInterface.cc
@@ -551,6 +551,7 @@ void handleconnection(void *arg)
           }
 	  std::string str1(strmess);
           unsigned int pos_space = str1.find(' ');
+	  std::cout << PHWHERE << " getting subsystem " << str1.substr(0,pos_space) << ", histo " <<  str1.substr(pos_space+1,str1.size()) << std::endl;
           TH1 *histo = Onlmonserver->getHisto(str1.substr(0,pos_space),str1.substr(pos_space+1,str1.size()));
           if (histo)
           {
@@ -561,7 +562,7 @@ void handleconnection(void *arg)
           }
           else
           {
-            s0->Send("unknown");
+            s0->Send("UnknownHisto");
           }
           //		  delete mess;
         }

--- a/onlmonserver/pmonitorInterface.cc
+++ b/onlmonserver/pmonitorInterface.cc
@@ -3,10 +3,10 @@
 */
 
 #include "pmonitorInterface.h"
-#include "OnlMonServer.h"
-#include "OnlMonDefs.h"
-#include "OnlMon.h"
 #include "HistoBinDefs.h"
+#include "OnlMon.h"
+#include "OnlMonDefs.h"
+#include "OnlMonServer.h"
 
 #include <phool/phool.h>
 
@@ -77,7 +77,7 @@ int pinit()
   pthread_t ThreadId = 0;
   if (!ServerThread)
   {
-    //std::cout << "creating server thread" << std::endl;
+    // std::cout << "creating server thread" << std::endl;
 #ifdef SERVER
 
     ServerThread = pthread_create(&ThreadId, nullptr, server, (void *) nullptr);
@@ -168,8 +168,8 @@ int process_event(Event *evt)
     {
       std::ostringstream msg;
       msg << PHWHERE << " huge or tiny event run number "
-	  << evt->getRunNumber()
-	  << " discarding event" ;
+          << evt->getRunNumber()
+          << " discarding event" ;
       send_message(MSG_SEV_WARNING, msg.str());
       se->AddBadEvent();
       return 0;
@@ -373,11 +373,11 @@ again:
   }
   //  std::cout << "try locking mutex" << std::endl;
   pthread_mutex_lock(&mutex);
-  //std::cout << "got mutex" << std::endl;
+  // std::cout << "got mutex" << std::endl;
   handleconnection(s0);
-  //std::cout << "try releasing mutex" << std::endl;
+  // std::cout << "try releasing mutex" << std::endl;
   pthread_mutex_unlock(&mutex);
-  //std::cout << "mutex released" << std::endl;
+  // std::cout << "mutex released" << std::endl;
   delete s0;
   /*
     if (!aargh)
@@ -387,8 +387,8 @@ again:
     aargh->Run();
     }
   */
-  //std::cout << "closing socket" << std::endl;
-  //s0->Close();
+  // std::cout << "closing socket" << std::endl;
+  // s0->Close();
   goto again;
 }
 
@@ -427,7 +427,7 @@ void handleconnection(void *arg)
     if (mess->What() == kMESS_STRING)
     {
       char strchr[OnlMonDefs::MSGLEN];
-      mess->ReadString(strchr,OnlMonDefs::MSGLEN);
+      mess->ReadString(strchr, OnlMonDefs::MSGLEN);
       delete mess;
       mess = nullptr;
       std::string str = strchr;
@@ -455,30 +455,29 @@ void handleconnection(void *arg)
         {
           std::cout << "number of histos: " << Onlmonserver->nHistos() << std::endl;
         }
-	for (auto monitors = Onlmonserver->monibegin(); monitors != Onlmonserver->moniend(); ++monitors)
-	{
-	  for (auto &histos: monitors->second)
-	  {
-
-	    std::string subsyshisto =   monitors->first + ' ' + histos.first;
-  if (Onlmonserver->Verbosity() > 2)
-  {
-	    std::cout << "subsystem: " << monitors->first << ", histo: " << histos.first << std::endl;
-            std::cout << " sending: \"" << subsyshisto << "\"" << std::endl;
-  }
-          s0->Send(subsyshisto.c_str());
-          int nbytes = s0->Recv(mess);
-          delete mess;
-          mess = nullptr;
-          if (nbytes <= 0)
+        for (auto monitors = Onlmonserver->monibegin(); monitors != Onlmonserver->moniend(); ++monitors)
+        {
+          for (auto &histos : monitors->second)
           {
-            std::ostringstream msg;
+            std::string subsyshisto = monitors->first + ' ' + histos.first;
+            if (Onlmonserver->Verbosity() > 2)
+            {
+              std::cout << "subsystem: " << monitors->first << ", histo: " << histos.first << std::endl;
+              std::cout << " sending: \"" << subsyshisto << "\"" << std::endl;
+            }
+            s0->Send(subsyshisto.c_str());
+            int nbytes = s0->Recv(mess);
+            delete mess;
+            mess = nullptr;
+            if (nbytes <= 0)
+            {
+              std::ostringstream msg;
 
-            msg << "Problem receiving message: return code: " << nbytes;
-            send_message(MSG_SEV_ERROR, msg.str());
+              msg << "Problem receiving message: return code: " << nbytes;
+              send_message(MSG_SEV_ERROR, msg.str());
+            }
           }
         }
-	}
         s0->Send("Finished");
       }
       else if (str == "ALL")
@@ -506,43 +505,43 @@ void handleconnection(void *arg)
       else if (str.find("ISRUNNING") != std::string::npos)
       {
         bool foundit = false;
-	std::string answer = "No";
+        std::string answer = "No";
         unsigned int pos_space = str.find(' ');
-	std::string moniname = str.substr(pos_space+1,str.size());
-	for (auto moniter = Onlmonserver->monitor_vec_begin(); moniter != Onlmonserver->monitor_vec_end(); ++moniter)
-	{
-	  if ((*moniter)->Name() == moniname)
-	  {
-	    answer = "Yes";
-	    break;
-	  }
-	}
-  if (Onlmonserver->Verbosity() > 2)
-  {
-	std::cout << "got " << str << ", replied " << answer << std::endl;
-  }
-	s0->Send(answer.c_str());
+        std::string moniname = str.substr(pos_space + 1, str.size());
+        for (auto moniter = Onlmonserver->monitor_vec_begin(); moniter != Onlmonserver->monitor_vec_end(); ++moniter)
+        {
+          if ((*moniter)->Name() == moniname)
+          {
+            answer = "Yes";
+            break;
+          }
+        }
+        if (Onlmonserver->Verbosity() > 2)
+        {
+          std::cout << "got " << str << ", replied " << answer << std::endl;
+        }
+        s0->Send(answer.c_str());
       }
       else if (str == "LISTMONITORS")
       {
         s0->Send("go");
         for (auto moniter = Onlmonserver->monitor_vec_begin(); moniter != Onlmonserver->monitor_vec_end(); ++moniter)
-	{
-  if (Onlmonserver->Verbosity() > 2)
-  {
-	  std::cout << "sending " << (*moniter)->Name().c_str() << std::endl;
-  }
-	  s0->Send((*moniter)->Name().c_str());
-	}
+        {
+          if (Onlmonserver->Verbosity() > 2)
+          {
+            std::cout << "sending " << (*moniter)->Name().c_str() << std::endl;
+          }
+          s0->Send((*moniter)->Name().c_str());
+        }
         s0->Send("Finished");
-	break;
+        break;
       }
       else if (str == "LIST")
       {
         s0->Send("go");
         while (true)
         {
-	  char strmess[OnlMonDefs::MSGLEN];
+          char strmess[OnlMonDefs::MSGLEN];
           s0->Recv(mess);
           if (!mess)
           {
@@ -550,7 +549,7 @@ void handleconnection(void *arg)
           }
           if (mess->What() == kMESS_STRING)
           {
-            mess->ReadString(strmess,OnlMonDefs::MSGLEN);
+            mess->ReadString(strmess, OnlMonDefs::MSGLEN);
             delete mess;
             mess = nullptr;
             if (std::string(strmess) == "alldone")
@@ -558,13 +557,13 @@ void handleconnection(void *arg)
               break;
             }
           }
-	  std::string str1(strmess);
+          std::string str1(strmess);
           unsigned int pos_space = str1.find(' ');
-  if (Onlmonserver->Verbosity() > 2)
-  {
-	  std::cout << PHWHERE << " getting subsystem " << str1.substr(0,pos_space) << ", histo " <<  str1.substr(pos_space+1,str1.size()) << std::endl;
-  }
-          TH1 *histo = Onlmonserver->getHisto(str1.substr(0,pos_space),str1.substr(pos_space+1,str1.size()));
+          if (Onlmonserver->Verbosity() > 2)
+          {
+            std::cout << PHWHERE << " getting subsystem " << str1.substr(0, pos_space) << ", histo " << str1.substr(pos_space + 1, str1.size()) << std::endl;
+          }
+          TH1 *histo = Onlmonserver->getHisto(str1.substr(0, pos_space), str1.substr(pos_space + 1, str1.size()));
           if (histo)
           {
             outgoing.Reset();
@@ -582,9 +581,9 @@ void handleconnection(void *arg)
       }
       else
       {
-	std::string strstr(str);
+        std::string strstr(str);
         unsigned int pos_space = str.find(' ');
-        TH1 *histo = Onlmonserver->getHisto(strstr.substr(0,pos_space),strstr.substr(pos_space+1,str.size()));
+        TH1 *histo = Onlmonserver->getHisto(strstr.substr(0, pos_space), strstr.substr(pos_space + 1, str.size()));
         if (histo)
         {
           //		  const char *hisname = histo->GetName();

--- a/onlmonserver/pmonitorInterface.cc
+++ b/onlmonserver/pmonitorInterface.cc
@@ -500,6 +500,23 @@ void handleconnection(void *arg)
         }
         s0->Send("Finished");
       }
+      else if (str.find("ISRUNNING") != std::string::npos)
+      {
+        bool foundit = false;
+	std::string answer = "No";
+        unsigned int pos_space = str.find(' ');
+	std::string moniname = str.substr(pos_space+1,str.size());
+	for (auto moniter = Onlmonserver->monitor_vec_begin(); moniter != Onlmonserver->monitor_vec_end(); ++moniter)
+	{
+	  if ((*moniter)->Name() == moniname)
+	  {
+	    answer = "Yes";
+	    break;
+	  }
+	}
+	std::cout << "got " << str << ", replied " << answer << std::endl;
+	s0->Send(answer.c_str());
+      }
       else if (str == "LISTMONITORS")
       {
         s0->Send("go");
@@ -532,9 +549,9 @@ void handleconnection(void *arg)
               break;
             }
           }
-	  std::string str(strmess);
-          unsigned int pos_space = str.find(' ');
-          TH1 *histo = Onlmonserver->getHisto(str.substr(0,pos_space),str.substr(pos_space+1,str.size()));
+	  std::string str1(strmess);
+          unsigned int pos_space = str1.find(' ');
+          TH1 *histo = Onlmonserver->getHisto(str1.substr(0,pos_space),str1.substr(pos_space+1,str1.size()));
           if (histo)
           {
             outgoing.Reset();

--- a/onlmonserver/pmonitorInterface.cc
+++ b/onlmonserver/pmonitorInterface.cc
@@ -502,28 +502,11 @@ void handleconnection(void *arg)
       }
       else if (str == "LISTMONITORS")
       {
+        s0->Send("go");
         for (auto moniter = Onlmonserver->monitor_vec_begin(); moniter != Onlmonserver->monitor_vec_end(); ++moniter)
 	{
+	  std::cout << "sending " << (*moniter)->Name().c_str() << std::endl;
 	  s0->Send((*moniter)->Name().c_str());
-	  while (true)
-	  {
-	    char strmess[OnlMonDefs::MSGLEN];
-	    s0->Recv(mess);
-	    if (!mess)
-	    {
-	      break;
-	    }
-	    mess->ReadString(strmess, OnlMonDefs::MSGLEN);
-	    delete mess;
-	    std::string str(strmess);
-	    std::cout << "got " << str << std::endl;
-	    if (str == "Finished")
-	    {
-	      break;
-	    }
-        s0->Send("Ack");
-
-	  }
 	}
         s0->Send("Finished");
 	break;

--- a/subsystems/bbc/BbcMonDraw.cc
+++ b/subsystems/bbc/BbcMonDraw.cc
@@ -843,23 +843,23 @@ int BbcMonDraw::Draw(const std::string &what)
   PRINT_DEBUG("Start Getting Histogram");
 
   name << "bbc_tdc";
-  bbc_tdc = static_cast<TH2 *>(cl->getHisto(name.str().c_str()));
+  bbc_tdc = static_cast<TH2 *>(cl->getHisto("BBCMON_0",name.str().c_str()));
   name.str("");
 
   /*
   name << "bbc_tdc_overflow" ;
-  bbc_tdc_overflow =  static_cast<TH2 *> (cl->getHisto(name.str().c_str()));
+  bbc_tdc_overflow =  static_cast<TH2 *> (cl->getHisto("BBCMON_0",name.str().c_str()));
   name.str("");
 
   for ( int i = 0 ; i < nPMT_BBC ; i++ )
   {
     name << "bbc_tdc_overflow_" << setw(3) << setfill('0') << i ;
-    bbc_tdc_overflow_each[i] = cl->getHisto(name.str().c_str());
+    bbc_tdc_overflow_each[i] = cl->getHisto("BBCMON_0",name.str().c_str());
     name.str("");
   }
   */
 
-  bbc_adc = static_cast<TH2 *>(cl->getHisto("bbc_adc"));
+  bbc_adc = static_cast<TH2 *>(cl->getHisto("BBCMON_0","bbc_adc"));
   ifdelete(Adc);
   for (int i = 0; i < nCANVAS; i++)
   {
@@ -892,73 +892,73 @@ int BbcMonDraw::Draw(const std::string &what)
   for (int trig = 0; trig < nTRIGGER; trig++)
   {
     name << "bbc_nhit_" << bbc_onlmon::TRIGGER_str[trig];
-    bbc_nhit[trig] = static_cast<TH2 *>(cl->getHisto(name.str().c_str()));
+    bbc_nhit[trig] = static_cast<TH2 *>(cl->getHisto("BBCMON_0",name.str().c_str()));
     name.str("");
   }
 
-  bbc_tdc_armhittime = static_cast<TH2 *>(cl->getHisto("bbc_tdc_armhittime"));
+  bbc_tdc_armhittime = static_cast<TH2 *>(cl->getHisto("BBCMON_0","bbc_tdc_armhittime"));
   ifdelete(ArmHit);
   ArmHit = static_cast<TH2 *>(bbc_tdc_armhittime->Clone());
 
-  bbc_zvertex = cl->getHisto("bbc_zvertex");
+  bbc_zvertex = cl->getHisto("BBCMON_0","bbc_zvertex");
   ifdelete(Zvtx);
   Zvtx = static_cast<TH1 *>(bbc_zvertex->Clone());
 
-  bbc_zvertex_bbll1 = cl->getHisto("bbc_zvertex_bbll1");
+  bbc_zvertex_bbll1 = cl->getHisto("BBCMON_0","bbc_zvertex_bbll1");
   ifdelete(Zvtx_bbll1);
   Zvtx_bbll1 = static_cast<TH1 *>(bbc_zvertex_bbll1->Clone());
 
   /*
-  bbc_zvertex_zdc = cl->getHisto("bbc_zvertex_zdc");
+  bbc_zvertex_zdc = cl->getHisto("BBCMON_0","bbc_zvertex_zdc");
   ifdelete( Zvtx_zdc );
   Zvtx_zdc =  static_cast<TH1 *> (bbc_zvertex_zdc->Clone());
 
-  bbc_zvertex_zdc_scale3 = cl->getHisto("bbc_zvertex_zdc_scale3");
+  bbc_zvertex_zdc_scale3 = cl->getHisto("BBCMON_0","bbc_zvertex_zdc_scale3");
   ifdelete( Zvtx_zdc_scale3 );
   Zvtx_zdc_scale3 =  static_cast<TH1 *> (bbc_zvertex_zdc_scale3->Clone());
   */
 
-  bbc_zvertex_bbll1_novtx = cl->getHisto("bbc_zvertex_bbll1_novtx");
+  bbc_zvertex_bbll1_novtx = cl->getHisto("BBCMON_0","bbc_zvertex_bbll1_novtx");
   ifdelete(Zvtx_bbll1_novtx);
   Zvtx_bbll1_novtx = static_cast<TH1 *>(bbc_zvertex_bbll1_novtx->Clone());
 
-  bbc_zvertex_bbll1_narrowvtx = cl->getHisto("bbc_zvertex_bbll1_narrowvtx");
+  bbc_zvertex_bbll1_narrowvtx = cl->getHisto("BBCMON_0","bbc_zvertex_bbll1_narrowvtx");
   ifdelete(Zvtx_bbll1_narrowvtx);
   Zvtx_bbll1_narrowvtx = static_cast<TH1 *>(bbc_zvertex_bbll1_narrowvtx->Clone());
 
   /*
-  bbc_zvertex_bbll1_zdc = cl->getHisto("bbc_zvertex_bbll1_zdc");
+  bbc_zvertex_bbll1_zdc = cl->getHisto("BBCMON_0","bbc_zvertex_bbll1_zdc");
   ifdelete( Zvtx_bbll1_zdc );
   Zvtx_bbll1_zdc =  static_cast<TH1 *> (bbc_zvertex_bbll1_zdc->Clone());
   */
 
-  bbc_nevent_counter = cl->getHisto("bbc_nevent_counter");
+  bbc_nevent_counter = cl->getHisto("BBCMON_0","bbc_nevent_counter");
 
-  bbc_tzero_zvtx = static_cast<TH2 *>(cl->getHisto("bbc_tzero_zvtx"));
+  bbc_tzero_zvtx = static_cast<TH2 *>(cl->getHisto("BBCMON_0","bbc_tzero_zvtx"));
   ifdelete(TzeroZvtx);
   TzeroZvtx = static_cast<TH2 *>(bbc_tzero_zvtx->Clone());
 
-  bbc_avr_hittime = cl->getHisto("bbc_avr_hittime");
+  bbc_avr_hittime = cl->getHisto("BBCMON_0","bbc_avr_hittime");
   ifdelete(AvrHitTime);
   AvrHitTime = static_cast<TH1 *>(bbc_avr_hittime->Clone());
 
-  bbc_north_hittime = cl->getHisto("bbc_north_hittime");
+  bbc_north_hittime = cl->getHisto("BBCMON_0","bbc_north_hittime");
   ifdelete(NorthHitTime);
   NorthHitTime = static_cast<TH1 *>(bbc_north_hittime->Clone());
 
-  bbc_south_hittime = cl->getHisto("bbc_south_hittime");
+  bbc_south_hittime = cl->getHisto("BBCMON_0","bbc_south_hittime");
   ifdelete(SouthHitTime);
   SouthHitTime = static_cast<TH1 *>(bbc_south_hittime->Clone());
 
-  bbc_south_chargesum = cl->getHisto("bbc_south_chargesum");
+  bbc_south_chargesum = cl->getHisto("BBCMON_0","bbc_south_chargesum");
   ifdelete(SouthChargeSum);
   SouthChargeSum = static_cast<TH1 *>(bbc_south_chargesum->Clone());
 
-  bbc_north_chargesum = cl->getHisto("bbc_north_chargesum");
+  bbc_north_chargesum = cl->getHisto("BBCMON_0","bbc_north_chargesum");
   ifdelete(NorthChargeSum);
   NorthChargeSum = static_cast<TH1 *>(bbc_north_chargesum->Clone());
 
-  bbc_prescale_hist = cl->getHisto("bbc_prescale_hist");
+  bbc_prescale_hist = cl->getHisto("BBCMON_0","bbc_prescale_hist");
   ifdelete(Prescale_hist);
   Prescale_hist = static_cast<TH1 *>(bbc_prescale_hist->Clone());
 
@@ -1994,8 +1994,8 @@ int BbcMonDraw::Draw(const std::string &what)
    int BbcMonDraw::DrawFirst(const std::string & )
    {
    OnlMonClient *cl = OnlMonClient::instance();
-   TH1 *bbcmon_hist1 = cl->getHisto("bbc_zvertex");
-   TH2 *bbcmon_hist2 = (TH2*)cl->getHisto("bbc_tzero_zvtx");
+   TH1 *bbcmon_hist1 = cl->getHisto("BBCMON_0","bbc_zvertex");
+   TH2 *bbcmon_hist2 = (TH2*)cl->getHisto("BBCMON_0","bbc_tzero_zvtx");
    if (!gROOT->FindObject("BbcMon1"))
    {
    MakeCanvas("BbcMon1");
@@ -2041,8 +2041,8 @@ return 0;
 int BbcMonDraw::DrawSecond(const std::string & )
 {
 OnlMonClient *cl = OnlMonClient::instance();
-TH1 *bbcmon_hist1 = cl->getHisto("bbc_zvertex");
-TH2 *bbcmon_hist2 = (TH2*)cl->getHisto("bbc_tzero_zvtx");
+TH1 *bbcmon_hist1 = cl->getHisto("BBCMON_0","bbc_zvertex");
+TH2 *bbcmon_hist2 = (TH2*)cl->getHisto("BBCMON_0","bbc_tzero_zvtx");
 if (!gROOT->FindObject("BbcMon2"))
 {
 MakeCanvas("BbcMon2");

--- a/subsystems/bbc/BbcMonDraw.h
+++ b/subsystems/bbc/BbcMonDraw.h
@@ -30,7 +30,7 @@ class TSpectrum;
 class BbcMonDraw : public OnlMonDraw
 {
  public:
-  explicit BbcMonDraw(const std::string &name = "BBCMON");  // same name as server!
+  explicit BbcMonDraw(const std::string &name);
 
   ~BbcMonDraw() override;
 

--- a/subsystems/bbcll1/Bbcll1Mon.cc
+++ b/subsystems/bbcll1/Bbcll1Mon.cc
@@ -45,6 +45,7 @@ Bbcll1Mon::~Bbcll1Mon()
 
 int Bbcll1Mon::Init()
 {
+  gRandom->SetSeed(rand());
   // read our calibrations from Bbcll1MonData.dat
   std::string fullfile = std::string(getenv("BBCLL1CALIB")) + "/" + "Bbcll1MonData.dat";
   std::ifstream calib(fullfile);

--- a/subsystems/bbcll1/Bbcll1Mon.cc
+++ b/subsystems/bbcll1/Bbcll1Mon.cc
@@ -13,6 +13,7 @@
 
 #include <TH1.h>
 #include <TH2.h>
+#include <TRandom.h>
 
 #include <cmath>
 #include <cstdio>  // for printf
@@ -93,8 +94,8 @@ int Bbcll1Mon::process_event(Event * /* evt */)
   // one can do in principle directly se->getHisto("bbcll1hist1")->Fill()
   // but the search in the histogram Map is somewhat expensive and slows
   // things down if you make more than one operation on a histogram
-  bbcll1hist1->Fill((float) idummy);
-  bbcll1hist2->Fill((float) idummy, (float) idummy, 1.);
+  bbcll1hist1->Fill(gRandom->Gaus(50,10));
+  bbcll1hist2->Fill(gRandom->Gaus(50,10), gRandom->Gaus(50,10), 1.);
 
   if (idummy++ > 10)
   {

--- a/subsystems/bbcll1/Bbcll1MonDraw.cc
+++ b/subsystems/bbcll1/Bbcll1MonDraw.cc
@@ -123,8 +123,8 @@ int Bbcll1MonDraw::Draw(const std::string &what)
 int Bbcll1MonDraw::DrawFirst(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *bbcll1mon_hist1 = cl->getHisto("bbcll1mon_hist1");
-  TH1 *bbcll1mon_hist2 = cl->getHisto("bbcll1mon_hist1");
+  TH1 *bbcll1mon_hist1 = cl->getHisto("BBCLL1MON_0","bbcll1mon_hist1");
+  TH1 *bbcll1mon_hist2 = cl->getHisto("BBCLL1MON_0","bbcll1mon_hist1");
   if (!gROOT->FindObject("Bbcll1Mon1"))
   {
     MakeCanvas("Bbcll1Mon1");
@@ -170,8 +170,8 @@ int Bbcll1MonDraw::DrawFirst(const std::string & /* what */)
 int Bbcll1MonDraw::DrawSecond(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *bbcll1mon_hist1 = cl->getHisto("bbcll1mon_hist2");
-  TH1 *bbcll1mon_hist2 = cl->getHisto("bbcll1mon_hist2");
+  TH1 *bbcll1mon_hist1 = cl->getHisto("BBCLL1MON_0","bbcll1mon_hist2");
+  TH1 *bbcll1mon_hist2 = cl->getHisto("BBCLL1MON_0","bbcll1mon_hist2");
   if (!gROOT->FindObject("Bbcll1Mon2"))
   {
     MakeCanvas("Bbcll1Mon2");

--- a/subsystems/bbcll1/Bbcll1MonDraw.h
+++ b/subsystems/bbcll1/Bbcll1MonDraw.h
@@ -13,7 +13,7 @@ class TPad;
 class Bbcll1MonDraw : public OnlMonDraw
 {
  public:
-  Bbcll1MonDraw(const std::string &name = "BBCLL1MON"); // same name as server!
+  Bbcll1MonDraw(const std::string &name);
 
   ~Bbcll1MonDraw() override {}
 

--- a/subsystems/cemc/CemcMon.cc
+++ b/subsystems/cemc/CemcMon.cc
@@ -59,14 +59,11 @@ emcxy adcxy[64];
 
 
 
-CemcMon::CemcMon(const std::string &name, const std::string &id)
+CemcMon::CemcMon(const std::string &name)
   : OnlMon(name)
 {
   // leave ctor fairly empty, its hard to debug if code crashes already
   // during a new CemcMon()
-
-  // tag our histogram names
-  id_string = id;
 
   for (int ix = 0; ix < 8; ix++ )
     {
@@ -142,7 +139,7 @@ int CemcMon::Init()
   }
 
 
-  std::string h_id = "cemc_occupancy" + id_string; 
+  std::string h_id = "cemc_occupancy";
   cemc_occupancy = new TH2F(h_id.c_str(), "cemc_occupancy plot", 48*2 , -48 , 48, 32*8, -0.5, 255.5 );
   cemc_occupancy->GetXaxis()->SetTitle("eta");
   cemc_occupancy->GetYaxis()->SetTitle("phi");
@@ -150,7 +147,7 @@ int CemcMon::Init()
   //cemc_occupancy->SetMinimum(0);
   //  cemc_occupancy->SetMaximum(1200);
 
-  h_id = "cemc_runningmean" + id_string; 
+  h_id = "cemc_runningmean";
   cemc_runningmean = new TH2F(h_id.c_str(), "Cemc Running Mean Run 0 Event 0", 48*2 , -48 , 48, 32*8, -0.5, 255.5 );
   cemc_runningmean->GetXaxis()->SetTitle("eta");
   cemc_runningmean->GetYaxis()->SetTitle("phi");

--- a/subsystems/cemc/CemcMon.h
+++ b/subsystems/cemc/CemcMon.h
@@ -18,7 +18,7 @@ class runningMean;
 class CemcMon : public OnlMon
 {
  public:
-  CemcMon(const std::string &name = "CEMCMON", const std::string &id ="");
+  CemcMon(const std::string &name);
   virtual ~CemcMon();
 
   int process_event(Event *evt);

--- a/subsystems/cemc/CemcMonDraw.cc
+++ b/subsystems/cemc/CemcMonDraw.cc
@@ -166,9 +166,9 @@ int CemcMonDraw::Draw(const std::string &what)
 int CemcMonDraw::DrawFirst(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH2D* hist1 = (TH2D*)cl->getHisto("h2_hcal_rm");
-  TH2D* h2_hcal_mean = (TH2D*)cl->getHisto("h2_hcal_mean");
-  TH1F* h_event = (TH1F*)cl->getHisto("h_event");
+  TH2D* hist1 = (TH2D*)cl->getHisto("CEMC_0","h2_hcal_rm");
+  TH2D* h2_hcal_mean = (TH2D*)cl->getHisto("CEMC_0","h2_hcal_mean");
+  TH1F* h_event = (TH1F*)cl->getHisto("CEMC_0","h_event");
   if (!gROOT->FindObject("CemcMon1"))
    {
      MakeCanvas("CemcMon1");
@@ -276,11 +276,11 @@ int CemcMonDraw::DrawSecond(const std::string & /* what */)
 {
   const int Nsector = 32;
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1F* h_sectorAvg_total = (TH1F*) cl->getHisto("h_sectorAvg_total");
-  TH1F* h_event = (TH1F*) cl->getHisto("h_event");
+  TH1F* h_sectorAvg_total = (TH1F*) cl->getHisto("CEMC_0","h_sectorAvg_total");
+  TH1F* h_event = (TH1F*) cl->getHisto("CEMC_0","h_event");
   TH1F* h_rm_sectorAvg[Nsector];
   for (int ih=0; ih<Nsector; ih++) {
-    h_rm_sectorAvg[ih] = (TH1F*)cl->getHisto(Form("h_rm_sectorAvg_s%d",ih));
+    h_rm_sectorAvg[ih] = (TH1F*)cl->getHisto("CEMC_0",Form("h_rm_sectorAvg_s%d",ih));
   }
   
  if (!gROOT->FindObject("CemcMon2"))
@@ -361,9 +361,9 @@ int CemcMonDraw::DrawSecond(const std::string & /* what */)
 int CemcMonDraw::DrawThird(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1F* h_waveform_twrAvg = (TH1F*) cl->getHisto("h_waveform_twrAvg");
-  TH1F* h_waveform_time = (TH1F*) cl->getHisto("h_waveform_time");
-  TH1F* h_waveform_pedestal = (TH1F*) cl->getHisto("h_waveform_pedestal");
+  TH1F* h_waveform_twrAvg = (TH1F*) cl->getHisto("CEMC_0","h_waveform_twrAvg");
+  TH1F* h_waveform_time = (TH1F*) cl->getHisto("CEMC_0","h_waveform_time");
+  TH1F* h_waveform_pedestal = (TH1F*) cl->getHisto("CEMC_0","h_waveform_pedestal");
 
  if (!gROOT->FindObject("CemcMon3"))
    {
@@ -529,7 +529,7 @@ int CemcMonDraw::FindHotTower(TPad *warningpad,TH2D* hhit){
 /*
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH2D* hist1 = (TH2D*)cl->getHisto("h2_hcal_rm");
+  TH2D* hist1 = (TH2D*)cl->getHisto("CEMC_0","h2_hcal_rm");
   
  if (!gROOT->FindObject("CemcMon2"))
    {

--- a/subsystems/daq/DaqMon.cc
+++ b/subsystems/daq/DaqMon.cc
@@ -13,6 +13,7 @@
 
 #include <TH1.h>
 #include <TH2.h>
+#include <TRandom.h>
 
 #include <cmath>
 #include <cstdio>  // for printf
@@ -44,6 +45,7 @@ DaqMon::~DaqMon()
 
 int DaqMon::Init()
 {
+  gRandom->SetSeed(rand());
   // read our calibrations from DaqMonData.dat
   std::string fullfile = std::string(getenv("DAQCALIB")) + "/" + "DaqMonData.dat";
   std::ifstream calib(fullfile);
@@ -93,8 +95,8 @@ int DaqMon::process_event(Event * /* evt */)
   // one can do in principle directly se->getHisto("daqhist1")->Fill()
   // but the search in the histogram Map is somewhat expensive and slows
   // things down if you make more than one operation on a histogram
-  daqhist1->Fill((float) idummy);
-  daqhist2->Fill((float) idummy, (float) idummy, 1.);
+  daqhist1->Fill(gRandom->Gaus(50,10));
+  daqhist2->Fill(gRandom->Gaus(50,10), gRandom->Gaus(50,10), 1.);
 
   if (idummy++ > 10)
   {

--- a/subsystems/daq/DaqMonDraw.cc
+++ b/subsystems/daq/DaqMonDraw.cc
@@ -123,8 +123,8 @@ int DaqMonDraw::Draw(const std::string &what)
 int DaqMonDraw::DrawFirst(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *daqmon_hist1 = cl->getHisto("daqmon_hist1");
-  TH1 *daqmon_hist2 = cl->getHisto("daqmon_hist1");
+  TH1 *daqmon_hist1 = cl->getHisto("DAQMON_0","daqmon_hist1");
+  TH1 *daqmon_hist2 = cl->getHisto("DAQMON_0","daqmon_hist1");
   if (!gROOT->FindObject("DaqMon1"))
   {
     MakeCanvas("DaqMon1");
@@ -170,8 +170,8 @@ int DaqMonDraw::DrawFirst(const std::string & /* what */)
 int DaqMonDraw::DrawSecond(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *daqmon_hist1 = cl->getHisto("daqmon_hist2");
-  TH1 *daqmon_hist2 = cl->getHisto("daqmon_hist2");
+  TH1 *daqmon_hist1 = cl->getHisto("DAQMON_0","daqmon_hist2");
+  TH1 *daqmon_hist2 = cl->getHisto("DAQMON_0","daqmon_hist2");
   if (!gROOT->FindObject("DaqMon2"))
   {
     MakeCanvas("DaqMon2");

--- a/subsystems/daq/DaqMonDraw.h
+++ b/subsystems/daq/DaqMonDraw.h
@@ -13,7 +13,7 @@ class TPad;
 class DaqMonDraw : public OnlMonDraw
 {
  public:
-  DaqMonDraw(const std::string &name = "DAQMON"); // same name as server!
+  DaqMonDraw(const std::string &name);
 
   ~DaqMonDraw() override {}
 

--- a/subsystems/epd/EpdMon.cc
+++ b/subsystems/epd/EpdMon.cc
@@ -13,6 +13,7 @@
 
 #include <TH1.h>
 #include <TH2.h>
+#include <TRandom.h>
 
 #include <cmath>
 #include <cstdio>  // for printf
@@ -44,6 +45,7 @@ EpdMon::~EpdMon()
 
 int EpdMon::Init()
 {
+  gRandom->SetSeed(rand());
   // read our calibrations from EpdMonData.dat
   std::string fullfile = std::string(getenv("EPDCALIB")) + "/" + "EpdMonData.dat";
   std::ifstream calib(fullfile);
@@ -93,8 +95,8 @@ int EpdMon::process_event(Event * /* evt */)
   // one can do in principle directly se->getHisto("epdhist1")->Fill()
   // but the search in the histogram Map is somewhat expensive and slows
   // things down if you make more than one operation on a histogram
-  epdhist1->Fill((float) idummy);
-  epdhist2->Fill((float) idummy, (float) idummy, 1.);
+  epdhist1->Fill(gRandom->Gaus(50,10));
+  epdhist2->Fill(gRandom->Gaus(50,10), gRandom->Gaus(50,10), 1.);
 
   if (idummy++ > 10)
   {

--- a/subsystems/epd/EpdMon.h
+++ b/subsystems/epd/EpdMon.h
@@ -11,7 +11,7 @@ class TH2;
 class EpdMon : public OnlMon
 {
  public:
-  EpdMon(const std::string &name = "EPDMON");
+  EpdMon(const std::string &name);
   virtual ~EpdMon();
 
   int process_event(Event *evt);

--- a/subsystems/epd/EpdMonDraw.cc
+++ b/subsystems/epd/EpdMonDraw.cc
@@ -123,8 +123,8 @@ int EpdMonDraw::Draw(const std::string &what)
 int EpdMonDraw::DrawFirst(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *epdmon_hist1 = cl->getHisto("epdmon_hist1");
-  TH1 *epdmon_hist2 = cl->getHisto("epdmon_hist1");
+  TH1 *epdmon_hist1 = cl->getHisto("EPDMON_0","epdmon_hist1");
+  TH1 *epdmon_hist2 = cl->getHisto("EPDMON_0","epdmon_hist1");
   if (!gROOT->FindObject("EpdMon1"))
   {
     MakeCanvas("EpdMon1");
@@ -170,8 +170,8 @@ int EpdMonDraw::DrawFirst(const std::string & /* what */)
 int EpdMonDraw::DrawSecond(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *epdmon_hist1 = cl->getHisto("epdmon_hist2");
-  TH1 *epdmon_hist2 = cl->getHisto("epdmon_hist2");
+  TH1 *epdmon_hist1 = cl->getHisto("EPDMON_0","epdmon_hist2");
+  TH1 *epdmon_hist2 = cl->getHisto("EPDMON_0","epdmon_hist2");
   if (!gROOT->FindObject("EpdMon2"))
   {
     MakeCanvas("EpdMon2");

--- a/subsystems/epd/EpdMonDraw.h
+++ b/subsystems/epd/EpdMonDraw.h
@@ -13,7 +13,7 @@ class TPad;
 class EpdMonDraw : public OnlMonDraw
 {
  public:
-  EpdMonDraw(const std::string &name = "EPDMON"); // same name as server!
+  EpdMonDraw(const std::string &name);
 
   ~EpdMonDraw() override {}
 

--- a/subsystems/example/MyMon.cc
+++ b/subsystems/example/MyMon.cc
@@ -26,7 +26,7 @@ enum
   FILLMESSAGE = 2
 };
 
-MyMon::MyMon(const char *name)
+MyMon::MyMon(const std::string &name)
   : OnlMon(name)
 {
   // leave ctor fairly empty, its hard to debug if code crashes already

--- a/subsystems/example/MyMon.cc
+++ b/subsystems/example/MyMon.cc
@@ -13,6 +13,7 @@
 
 #include <TH1.h>
 #include <TH2.h>
+#include <TRandom.h>
 
 #include <cmath>
 #include <cstdio>  // for printf
@@ -43,6 +44,7 @@ MyMon::~MyMon()
 
 int MyMon::Init()
 {
+  gRandom->SetSeed(rand());
   // use printf for stuff which should go the screen but not into the message
   // system (all couts are redirected)
   printf("doing the Init\n");
@@ -88,8 +90,8 @@ int MyMon::process_event(Event * /* evt */)
   // one can do in principle directly se->getHisto("myhist1")->Fill()
   // but the search in the histogram Map is somewhat expensive and slows
   // things down if you make more than one operation on a histogram
-  myhist1->Fill((float) idummy);
-  myhist2->Fill((float) idummy, (float) idummy, 1.);
+  myhist1->Fill(gRandom->Gaus(50,10));
+  myhist2->Fill(gRandom->Gaus(50,10), gRandom->Gaus(50,10), 1.);
 
   if (idummy++ > 10)
   {

--- a/subsystems/example/MyMon.h
+++ b/subsystems/example/MyMon.h
@@ -11,7 +11,7 @@ class TH2;
 class MyMon : public OnlMon
 {
  public:
-  MyMon(const char *name = "MYMON");
+  MyMon(const std::string &name = "MYMON");
   virtual ~MyMon();
 
   int process_event(Event *evt);

--- a/subsystems/example/MyMonDraw.cc
+++ b/subsystems/example/MyMonDraw.cc
@@ -123,8 +123,8 @@ int MyMonDraw::Draw(const std::string &what)
 int MyMonDraw::DrawFirst(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *mymon_hist1 = cl->getHisto("mymon_hist1");
-  TH1 *mymon_hist2 = cl->getHisto("mymon_hist1");
+  TH1 *mymon_hist1 = cl->getHisto("MYMON_0","mymon_hist1");
+  TH1 *mymon_hist2 = cl->getHisto("MYMON_1","mymon_hist1");
   if (!gROOT->FindObject("MyMon1"))
   {
     MakeCanvas("MyMon1");
@@ -170,8 +170,8 @@ int MyMonDraw::DrawFirst(const std::string & /* what */)
 int MyMonDraw::DrawSecond(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *mymon_hist1 = cl->getHisto("mymon_hist2");
-  TH1 *mymon_hist2 = cl->getHisto("mymon_hist2");
+  TH1 *mymon_hist1 = cl->getHisto("MYMON_0","mymon_hist2");
+  TH1 *mymon_hist2 = cl->getHisto("MYMON_1","mymon_hist2");
   if (!gROOT->FindObject("MyMon2"))
   {
     MakeCanvas("MyMon2");

--- a/subsystems/example/MyMonDraw.h
+++ b/subsystems/example/MyMonDraw.h
@@ -13,7 +13,7 @@ class TPad;
 class MyMonDraw : public OnlMonDraw
 {
  public:
-  MyMonDraw(const std::string &name = "MYMON"); // same name as server!
+  MyMonDraw(const std::string &name);
   ~MyMonDraw() override {}
 
   int Init() override;

--- a/subsystems/hcal/HcalMon.h
+++ b/subsystems/hcal/HcalMon.h
@@ -1,8 +1,9 @@
 #ifndef HCAL_HCALMON_H
 #define HCAL_HCALMON_H
 
-#include <calobase/TowerInfoContainerv1.h>
 #include <onlmon/OnlMon.h>
+
+#include <calobase/TowerInfoContainerv1.h>
 
 #include <vector>
 
@@ -17,7 +18,7 @@ class runningMean;
 class HcalMon : public OnlMon
 {
  public:
-  HcalMon(const std::string& name = "HCALMON");
+  HcalMon(const std::string& name);
   virtual ~HcalMon();
 
   int process_event(Event* evt);

--- a/subsystems/hcal/HcalMonDraw.cc
+++ b/subsystems/hcal/HcalMonDraw.cc
@@ -169,9 +169,9 @@ int HcalMonDraw::Draw(const std::string& what)
 int HcalMonDraw::DrawFirst(const std::string& /* what */)
 {
   OnlMonClient* cl = OnlMonClient::instance();
-  TH2D* hist1 = (TH2D*) cl->getHisto("h2_hcal_rm");
-  TH2D* h2_hcal_mean = (TH2D*) cl->getHisto("h2_hcal_mean");
-  TH1F* h_event = (TH1F*) cl->getHisto("h_event");
+  TH2D* hist1 = (TH2D*) cl->getHisto("HCALMON_0","h2_hcal_rm");
+  TH2D* h2_hcal_mean = (TH2D*) cl->getHisto("HCALMON_0","h2_hcal_mean");
+  TH1F* h_event = (TH1F*) cl->getHisto("HCALMON_0","h_event");
   if (!gROOT->FindObject("HcalMon1"))
   {
     MakeCanvas("HcalMon1");
@@ -311,12 +311,12 @@ int HcalMonDraw::DrawSecond(const std::string& /* what */)
 {
   const int Nsector = 32;
   OnlMonClient* cl = OnlMonClient::instance();
-  TH1F* h_sectorAvg_total = (TH1F*) cl->getHisto("h_sectorAvg_total");
-  TH1F* h_event = (TH1F*) cl->getHisto("h_event");
+  TH1F* h_sectorAvg_total = (TH1F*) cl->getHisto("HCALMON_0","h_sectorAvg_total");
+  TH1F* h_event = (TH1F*) cl->getHisto("HCALMON_0","h_event");
   TH1F* h_rm_sectorAvg[Nsector];
   for (int ih = 0; ih < Nsector; ih++)
   {
-    h_rm_sectorAvg[ih] = (TH1F*) cl->getHisto(Form("h_rm_sectorAvg_s%d", ih));
+    h_rm_sectorAvg[ih] = (TH1F*) cl->getHisto("HCALMON_0",Form("h_rm_sectorAvg_s%d", ih));
   }
 
   if (!gROOT->FindObject("HcalMon2"))
@@ -398,9 +398,9 @@ int HcalMonDraw::DrawSecond(const std::string& /* what */)
 int HcalMonDraw::DrawThird(const std::string& /* what */)
 {
   OnlMonClient* cl = OnlMonClient::instance();
-  TH1F* h_waveform_twrAvg = (TH1F*) cl->getHisto("h_waveform_twrAvg");
-  TH1F* h_waveform_time = (TH1F*) cl->getHisto("h_waveform_time");
-  TH1F* h_waveform_pedestal = (TH1F*) cl->getHisto("h_waveform_pedestal");
+  TH1F* h_waveform_twrAvg = (TH1F*) cl->getHisto("HCALMON_0","h_waveform_twrAvg");
+  TH1F* h_waveform_time = (TH1F*) cl->getHisto("HCALMON_0","h_waveform_time");
+  TH1F* h_waveform_pedestal = (TH1F*) cl->getHisto("HCALMON_0","h_waveform_pedestal");
 
   if (!gROOT->FindObject("HcalMon3"))
   {
@@ -868,7 +868,7 @@ void HcalMonDraw::HandleEvent(int event, int x, int y, TObject *selected)
 
     OnlMonClient* cl = OnlMonClient::instance();
 
-    TH1F* h_rm_tower = (TH1F*) cl->getHisto(Form("h_rm_tower_%d_%d", binx, biny));;
+    TH1F* h_rm_tower = (TH1F*) cl->getHisto("HCALMON_0",Form("h_rm_tower_%d_%d", binx, biny));;
 
     if (!gROOT->FindObject("HcalPopUp"))
     {

--- a/subsystems/hcal/HcalMonDraw.h
+++ b/subsystems/hcal/HcalMonDraw.h
@@ -5,6 +5,7 @@
 
 #include <TH2.h>
 #include <TStyle.h>
+
 #include <string>  // for allocator, string
 
 class OnlMonDB;
@@ -15,7 +16,7 @@ class TPad;
 class HcalMonDraw : public OnlMonDraw
 {
  public:
-  explicit HcalMonDraw(const std::string& name = "HCALMON");  // same name as server!
+  explicit HcalMonDraw(const std::string& name);
 
   ~HcalMonDraw() override {}
 

--- a/subsystems/intt/InttMon.h
+++ b/subsystems/intt/InttMon.h
@@ -23,7 +23,7 @@
 class InttMon : public OnlMon
 {
 public:
-	InttMon(const std::string &name = "INTTMON");
+	InttMon(const std::string &name);
 	virtual ~InttMon();
 	
 	int Init();

--- a/subsystems/intt/InttMonDraw.cc
+++ b/subsystems/intt/InttMonDraw.cc
@@ -26,13 +26,13 @@ int InttMonDraw::Init()
 
 /*
 	//===	Register OnlMon Histograms	===//
-	OnlMonClient* omc = OnlMonClient::instance();
+	OnlMonClient* cl = OnlMonClient::instance();
 
-//	omc->AddServerHost("localhost");
-	omc->requestHistoBySubSystem("INTTMON", 1);
+//	cl->AddServerHost("localhost");
+	cl->requestHistoBySubSystem("INTTMON", 1);
 
-	omc->registerHisto("InttHitMap", "INTTMON");
-	omc->registerHisto("InttHitMapRef", "INTTMON");
+	cl->registerHisto("InttHitMap", "INTTMON");
+	cl->registerHisto("InttHitMapRef", "INTTMON");
 	//...
 	//===	~Register OnlMon Histograms	===//
 */
@@ -69,7 +69,7 @@ int InttMonDraw::Draw(const std::string &what)
 
 int InttMonDraw::MakePS(const std::string &what)
 {
-	OnlMonClient* omc = OnlMonClient::instance();
+	OnlMonClient* cl = OnlMonClient::instance();
 	if(Draw(what))return 1;
 
 	TCanvas* canvas = nullptr;
@@ -79,10 +79,10 @@ int InttMonDraw::MakePS(const std::string &what)
 		filename.str("");
 		if(what == "ALL" or what == itr->first)
 		{
-			filename << ThisName << "_" <<  itr->first << "_" << omc->RunNumber() << ".ps";
+			filename << ThisName << "_" <<  itr->first << "_" << cl->RunNumber() << ".ps";
 			canvas = (TCanvas*)gROOT->FindObject(Form("INTT_%s_Canvas", itr->first.c_str()));
 			if(canvas)canvas->Print(filename.str().c_str());
-			if(canvas)omc->CanvasToPng(canvas, omc->htmlRegisterPage(*this, itr->first, itr->first, "png"));
+			if(canvas)cl->CanvasToPng(canvas, cl->htmlRegisterPage(*this, itr->first, itr->first, "png"));
 			//needs attention
 		}
 	}
@@ -92,7 +92,7 @@ int InttMonDraw::MakePS(const std::string &what)
 
 int InttMonDraw::MakeHtml(const std::string &what)
 {
-	OnlMonClient* omc = OnlMonClient::instance();
+	OnlMonClient* cl = OnlMonClient::instance();
 	if(Draw(what))return 1;
 
 	TCanvas* canvas = nullptr;
@@ -101,7 +101,7 @@ int InttMonDraw::MakeHtml(const std::string &what)
 		if(what == "ALL" or what == itr->first)
 		{
 			canvas = (TCanvas*)gROOT->FindObject(Form("INTT_%s_Canvas", itr->first.c_str()));
-			if(canvas)omc->CanvasToPng(canvas, omc->htmlRegisterPage(*this, itr->first, itr->first, "png"));
+			if(canvas)cl->CanvasToPng(canvas, cl->htmlRegisterPage(*this, itr->first, itr->first, "png"));
 		}
 	}
 
@@ -979,9 +979,9 @@ TH1* InttMonDraw::GetLayerHitMap(int layer)
 	//===	~Retrieve Hists from gROOT	===//
 
 	//===	~Retrieve Hists and Vars from OnlMon	===//
-	OnlMonClient* omc = OnlMonClient::instance();
+	OnlMonClient* cl = OnlMonClient::instance();
 
-	TH1D* hitmap = (TH1D*)(omc->getHisto("InttHitMap"));
+	TH1D* hitmap = (TH1D*)( cl->getHisto("INTTMON_0","InttHitMap"));
 	if(!hitmap)
 	{
 		std::cout << "In InttMonDraw::GetLayerHitMap()" << std::endl;
@@ -1053,9 +1053,9 @@ TH1* InttMonDraw::GetChipHitMap(int layer, int ladder, int northsouth, int chip)
 	//===	~Retrieve Hists from gROOT		===//
 
 	//===	Retrieve Hists and Vars from OnlMon	===//
-	OnlMonClient* omc = OnlMonClient::instance();
+	OnlMonClient* cl = OnlMonClient::instance();
 
-	TH1D* hitmap = (TH1D*)(omc->getHisto("InttHitMap"));
+	TH1D* hitmap = (TH1D*)( cl->getHisto("INTTMON_0","InttHitMap"));
 	if(!hitmap)
 	{
 		std::cout << "TH1* InttMonDraw::GetChipHitMap()" << std::endl;
@@ -1126,9 +1126,9 @@ TH1* InttMonDraw::GetLayerHitMapZ(int layer)
 	//===	~Retrieve Hists from gROOT	===//
 
 	//===	~Retrieve Hists and Vars from OnlMon	===//
-	OnlMonClient* omc = OnlMonClient::instance();
+	OnlMonClient* cl = OnlMonClient::instance();
 
-	TH1D* hitmap = (TH1D*)(omc->getHisto("InttHitMap"));
+	TH1D* hitmap = (TH1D*)( cl->getHisto("INTTMON_0","InttHitMap"));
 	if(!hitmap)
 	{
 		std::cout << "In InttMonDraw::GetLayerHitMapZ()" << std::endl;
@@ -1139,7 +1139,7 @@ TH1* InttMonDraw::GetLayerHitMapZ(int layer)
 		return hist;
 	}
 
-	TH1D* hitmapref = (TH1D*)(omc->getHisto("InttHitMapRef"));
+	TH1D* hitmapref = (TH1D*)( cl->getHisto("INTTMON_0","InttHitMapRef"));
 	if(!hitmap)
 	{
 		std::cout << "In InttMonDraw::GetLayerHitMapZ()" << std::endl;
@@ -1150,7 +1150,7 @@ TH1* InttMonDraw::GetLayerHitMapZ(int layer)
 		return hist;
 	}
 
-	TH1D* num_events = (TH1D*)(omc->getHisto("InttNumEvents"));
+	TH1D* num_events = (TH1D*)( cl->getHisto("INTTMON_0","InttNumEvents"));
 	if(!num_events)
 	{
 		std::cout << "In InttMonDraw::GetLayerHitMapZ()" << std::endl;
@@ -1247,9 +1247,9 @@ TH1* InttMonDraw::GetChipHitMapZ(int layer, int ladder, int northsouth, int chip
 	//===	~Retrieve Hists from gROOT		===//
 
 	//===	Retrieve Hists and Vars from OnlMon	===//
-	OnlMonClient* omc = OnlMonClient::instance();
+	OnlMonClient* cl = OnlMonClient::instance();
 
-	TH1D* hitmap = (TH1D*)(omc->getHisto("InttHitMap"));
+	TH1D* hitmap = (TH1D*)( cl->getHisto("INTTMON_0","InttHitMap"));
 	if(!hitmap)
 	{
 		std::cout << "In InttMonDraw::GetChipHitMapZ()" << std::endl;
@@ -1259,7 +1259,7 @@ TH1* InttMonDraw::GetChipHitMapZ(int layer, int ladder, int northsouth, int chip
 		return hist;
 	}
 
-	TH1D* hitmapref = (TH1D*)(omc->getHisto("InttHitMapRef"));
+	TH1D* hitmapref = (TH1D*)( cl->getHisto("INTTMON_0","InttHitMapRef"));
 	if(!hitmap)
 	{
 		std::cout << "In InttMonDraw::GetChipHitMapZ()" << std::endl;
@@ -1269,7 +1269,7 @@ TH1* InttMonDraw::GetChipHitMapZ(int layer, int ladder, int northsouth, int chip
 		return hist;
 	}
 
-	TH1D* num_events = (TH1D*)(omc->getHisto("InttNumEvents"));
+	TH1D* num_events = (TH1D*)( cl->getHisto("INTTMON_0","InttNumEvents"));
 	if(!num_events)
 	{
 		std::cout << "In InttMonDraw::GetLayerHitMapZ()" << std::endl;

--- a/subsystems/intt/InttMonDraw.h
+++ b/subsystems/intt/InttMonDraw.h
@@ -31,7 +31,7 @@
 class InttMonDraw : public OnlMonDraw
 {
 public:
-	InttMonDraw(const std::string &name = "INTTMON");
+	InttMonDraw(const std::string &name);
 	~InttMonDraw() override;
 
 	int Init() override;

--- a/subsystems/mvtx/MvtxMon.h
+++ b/subsystems/mvtx/MvtxMon.h
@@ -14,7 +14,7 @@ class pair;
 class MvtxMon : public OnlMon
 {
  public:
-  MvtxMon(const std::string &name = "MVTXMON");
+  MvtxMon(const std::string &name);
   virtual ~MvtxMon();
 
   int process_event(Event *evt);

--- a/subsystems/mvtx/MvtxMonDraw.cc
+++ b/subsystems/mvtx/MvtxMonDraw.cc
@@ -144,12 +144,12 @@ int MvtxMonDraw::Draw(const std::string &what)
 int MvtxMonDraw::DrawFirst(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  //TH1 *mvtxmon_hist1 = cl->getHisto("mvtxmon_hist1");
-  //TH1 *mvtxmon_hist2 = cl->getHisto("mvtxmon_hist1");
+  //TH1 *mvtxmon_hist1 =  cl->getHisto("MVTXMON_0","mvtxmon_hist1");
+  //TH1 *mvtxmon_hist2 =  cl->getHisto("MVTXMON_0","mvtxmon_hist1");
 
-  TH2 *mvtxmon_ChipStaveOcc = dynamic_cast<TH2*>(cl->getHisto("mvtxmon_ChipStaveOcc"));
-  TH1 *mvtxmon_ChipStave1D = cl->getHisto("mvtxmon_ChipStave1D");
-  TH1 *mvtxmon_ChipFiredHis = cl->getHisto("mvtxmon_ChipFiredHis");
+  TH2 *mvtxmon_ChipStaveOcc = dynamic_cast<TH2*>( cl->getHisto("MVTXMON_0","mvtxmon_ChipStaveOcc"));
+  TH1 *mvtxmon_ChipStave1D =  cl->getHisto("MVTXMON_0","mvtxmon_ChipStave1D");
+  TH1 *mvtxmon_ChipFiredHis =  cl->getHisto("MVTXMON_0","mvtxmon_ChipFiredHis");
 
   if (!gROOT->FindObject("MvtxMon1"))
   {
@@ -201,8 +201,8 @@ int MvtxMonDraw::DrawFirst(const std::string & /* what */)
 int MvtxMonDraw::DrawSecond(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-    TH1 *mvtxmon_EvtHitChip = cl->getHisto("mvtxmon_EvtHitChip");
-  TH1 *mvtxmon_EvtHitDis = cl->getHisto("mvtxmon_EvtHitDis");
+    TH1 *mvtxmon_EvtHitChip =  cl->getHisto("MVTXMON_0","mvtxmon_EvtHitChip");
+  TH1 *mvtxmon_EvtHitDis =  cl->getHisto("MVTXMON_0","mvtxmon_EvtHitDis");
   if (!gROOT->FindObject("MvtxMon2"))
   {
     MakeCanvas("MvtxMon2");
@@ -248,13 +248,13 @@ int MvtxMonDraw::DrawSecond(const std::string & /* what */)
 int MvtxMonDraw::DrawHitMap(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  //TH1 *mvtxmon_hist1 = cl->getHisto("mvtxmon_hist1");
-  //TH1 *mvtxmon_hist2 = cl->getHisto("mvtxmon_hist1");
+  //TH1 *mvtxmon_hist1 =  cl->getHisto("MVTXMON_0","mvtxmon_hist1");
+  //TH1 *mvtxmon_hist2 =  cl->getHisto("MVTXMON_0","mvtxmon_hist1");
   TH2 *mvtxmon_HitMap[NSTAVE][NCHIP] = {nullptr};
 
   for(int i = 0; i < NSTAVE; i++){
 		for(int j = 0; j < NCHIP; j++){
-			mvtxmon_HitMap[i][j] = dynamic_cast<TH2*>(cl->getHisto(Form("mvtxmon_HitMap_%d_%d",i,j)));
+			mvtxmon_HitMap[i][j] = dynamic_cast<TH2*>( cl->getHisto("MVTXMON_0",Form("mvtxmon_HitMap_%d_%d",i,j)));
     }
   }
 

--- a/subsystems/mvtx/MvtxMonDraw.h
+++ b/subsystems/mvtx/MvtxMonDraw.h
@@ -13,7 +13,7 @@ class TPad;
 class MvtxMonDraw : public OnlMonDraw
 {
  public:
-  MvtxMonDraw(const std::string &name = "MVTXMON"); // same name as server!
+  MvtxMonDraw(const std::string &name);
 
   ~MvtxMonDraw() override {}
 

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -11,7 +11,7 @@ class TH2;
 class TpcMon : public OnlMon
 {
  public:
-  TpcMon(const std::string &name = "TPCMON");
+  TpcMon(const std::string &name);
   virtual ~TpcMon();
 
   int process_event(Event *evt);

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -137,8 +137,8 @@ int TpcMonDraw::Draw(const std::string &what)
 int TpcMonDraw::DrawFirst(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *tpcmon_hist1 = cl->getHisto("tpcmon_hist1");
-  TH1 *tpcmon_hist2 = cl->getHisto("tpcmon_hist1");
+  TH1 *tpcmon_hist1 =  cl->getHisto("TPCMON_0","tpcmon_hist1");
+  TH1 *tpcmon_hist2 =  cl->getHisto("TPCMON_0","tpcmon_hist1");
   if (!gROOT->FindObject("TpcMon1"))
   {
     MakeCanvas("TpcMon1");
@@ -184,8 +184,8 @@ int TpcMonDraw::DrawFirst(const std::string & /* what */)
 int TpcMonDraw::DrawSecond(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *tpcmon_hist1 = cl->getHisto("tpcmon_hist2");
-  TH1 *tpcmon_hist2 = cl->getHisto("tpcmon_hist2");
+  TH1 *tpcmon_hist1 =  cl->getHisto("TPCMON_0","tpcmon_hist2");
+  TH1 *tpcmon_hist2 =  cl->getHisto("TPCMON_0","tpcmon_hist2");
   if (!gROOT->FindObject("TpcMon2"))
   {
     MakeCanvas("TpcMon2");
@@ -232,8 +232,8 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
 {
   std::cout<<"This is Charles' temporary function 02.15.23 !!!!!"<<std::endl;
   OnlMonClient *cl = OnlMonClient::instance();
-  TH2 *tpcmon_NSIDEADC = (TH2*)cl->getHisto("NorthSideADC");
-  TH2 *tpcmon_SSIDEADC = (TH2*)cl->getHisto("SouthSideADC");
+  TH2 *tpcmon_NSIDEADC = (TH2*) cl->getHisto("TPCMON_0","NorthSideADC");
+  TH2 *tpcmon_SSIDEADC = (TH2*) cl->getHisto("TPCMON_0","SouthSideADC");
 
   if (!gROOT->FindObject("TPCModules"))
   {

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -15,7 +15,7 @@ class TPaveLabel;
 class TpcMonDraw : public OnlMonDraw
 {
  public:
-  TpcMonDraw(const std::string &name = "TPCMON"); // same name as server!
+  TpcMonDraw(const std::string &name);
 
   ~TpcMonDraw() override {}
 

--- a/subsystems/tpot/TpotMon.h
+++ b/subsystems/tpot/TpotMon.h
@@ -16,7 +16,7 @@ class TH2;
 class TpotMon : public OnlMon
 {
  public:
-  TpotMon(const std::string &name = "TPOTMON");
+  TpotMon(const std::string &name);
   ~TpotMon() override = default;
 
   int process_event(Event *evt) override;

--- a/subsystems/tpot/TpotMonDraw.cc
+++ b/subsystems/tpot/TpotMonDraw.cc
@@ -328,8 +328,8 @@ int TpotMonDraw::draw_hv_onoff()
  
   // get histograms
   auto cl = OnlMonClient::instance();
-  auto m_hv_onoff_phi = cl->getHisto("m_hv_onoff_phi");
-  auto m_hv_onoff_z = cl->getHisto("m_hv_onoff_z");
+  auto m_hv_onoff_phi =  cl->getHisto("TPOTMON_0","m_hv_onoff_phi");
+  auto m_hv_onoff_z =  cl->getHisto("TPOTMON_0","m_hv_onoff_z");
 
   auto cv = get_canvas("TPOT_hv_onoff");
   auto transparent = get_transparent_pad("TPOT_hv_onoff");
@@ -361,8 +361,8 @@ int TpotMonDraw::draw_fee_onoff()
 {
   // get histograms
   auto cl = OnlMonClient::instance();
-  auto m_fee_onoff_phi = cl->getHisto("m_fee_onoff_phi");
-  auto m_fee_onoff_z = cl->getHisto("m_fee_onoff_z");
+  auto m_fee_onoff_phi =  cl->getHisto("TPOTMON_0","m_fee_onoff_phi");
+  auto m_fee_onoff_z =  cl->getHisto("TPOTMON_0","m_fee_onoff_z");
 
   auto cv = get_canvas("TPOT_fee_onoff");
   auto transparent = get_transparent_pad("TPOT_fee_onoff");
@@ -399,7 +399,7 @@ TpotMonDraw::histogram_array_t TpotMonDraw::get_histograms( const std::string& n
   for( int i = 0; i < TpotDefs::n_detectors; ++i )
   { 
     const auto hname = name + "_" + TpotDefs::detector_names[i];
-    out[i] = cl->getHisto( hname );
+    out[i] =  cl->getHisto("TPOTMON_0", hname );
     if( Verbosity() )
     { std::cout << "TpotMonDraw::get_histograms - " << hname << (out[i]?" found":" not found" ) << std::endl; }
   }

--- a/subsystems/tpot/TpotMonDraw.h
+++ b/subsystems/tpot/TpotMonDraw.h
@@ -19,7 +19,7 @@ class TpotMonDraw : public OnlMonDraw
   public:
   
   /// constructor
-  TpotMonDraw(const std::string &name = "TPOTMON");
+  TpotMonDraw(const std::string &name);
   
   /// destructor
   ~TpotMonDraw() override = default;


### PR DESCRIPTION
This PR adds the capability to run multiple monitor servers and collect and display identically named histograms from them. The only adjustment in the user code is the need to add the monitor id to the getHisto() call in the client. Everything else is behind the scenery or in the macros 