### PR TITLE
Prepare online

### DIFF
--- a/macros/setup_onlmon.csh
+++ b/macros/setup_onlmon.csh
@@ -59,8 +59,20 @@ if (! $?ONLMON_RUNDIR) then
   setenv ONLMON_RUNDIR $ONLMON_MAIN/share
 endif
 
-source /opt/sphenix/core/bin/setup_local.csh $ONLMON_MAIN
+#set up root
+unsetenv ROOT_INCLUDE_PATH
+setenv EVT_LIB $ROOTSYS/lib
+# start with your local directory
+setenv ROOT_INCLUDE_PATH ./
+foreach local_incdir (`find $ONLINE_MAIN/include -maxdepth 1 -type d -print`)
+  if (-d $local_incdir) then
+    setenv ROOT_INCLUDE_PATH ${ROOT_INCLUDE_PATH}:$local_incdir
+  endif
+end
+setenv LD_LIBRARY_PATH ${ONLMON_MAIN}/lib:$LD_LIBRARY_PATH
+set path = (${ONLMON_MAIN}/bin $path)
 # all subsystems scripts end in Setup.csh
 foreach script ($ONLMON_BIN/*Setup.csh)
   source $script
 end
+unset local_incdir

--- a/macros/setup_onlmon.sh
+++ b/macros/setup_onlmon.sh
@@ -77,7 +77,16 @@ then
   export ONLMON_RUNDIR=$ONLMON_MAIN/share
 fi
 
-source /opt/sphenix/core/bin/setup_local.sh $ONLMON_MAIN
+for local_incdir in `find $ONLMON_MAIN/include -maxdepth 1 -type d -print`
+do
+  if [ -d $local_incdir ]
+  then
+    ROOT_INCLUDE_PATH=$ROOT_INCLUDE_PATH:$local_incdir:./
+  fi
+done
+export ROOT_INCLUDE_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${ONLMON_MAIN}/lib
+export PATH=${PATH}:${ONLMON_MAIN}/bin
 # all subsystems scripts end in Setup.csh
 for script in $ONLMON_BIN/*Setup.sh
 do

--- a/subsystems/bbc/BbcMon.cc
+++ b/subsystems/bbc/BbcMon.cc
@@ -56,7 +56,13 @@ int BbcMon::Init()
   trand3 = new TRandom3(0);
 
   // read our calibrations from BbcMonData.dat
-  std::string fullfile = std::string(getenv("BBCCALIB")) + "/" + "BbcMonData.dat";
+  const char *bbccalib = getenv("BBCCALIB");
+  if (!bbccalib)
+  {
+    std::cout << "BBCCALIB environment variable not set" << std::endl;
+    exit(1);
+  }
+  std::string fullfile = std::string(bbccalib) + "/" + "BbcMonData.dat";
   std::ifstream calib(fullfile);
   calib.close();
 

--- a/subsystems/bbcll1/Bbcll1Mon.cc
+++ b/subsystems/bbcll1/Bbcll1Mon.cc
@@ -47,7 +47,13 @@ int Bbcll1Mon::Init()
 {
   gRandom->SetSeed(rand());
   // read our calibrations from Bbcll1MonData.dat
-  std::string fullfile = std::string(getenv("BBCLL1CALIB")) + "/" + "Bbcll1MonData.dat";
+  const char *bbcll1calib = getenv("BBCLL1CALIB");
+  if (!bbcll1calib)
+  {
+    std::cout << "BBCLL1CALIB environment variable not set" << std::endl;
+    exit(1);
+  }
+  std::string fullfile = std::string(bbcll1calib) + "/" + "Bbcll1MonData.dat";
   std::ifstream calib(fullfile);
   calib.close();
   // use printf for stuff which should go the screen but not into the message

--- a/subsystems/cemc/CemcMon.cc
+++ b/subsystems/cemc/CemcMon.cc
@@ -65,7 +65,13 @@ int CemcMon::Init()
 {
 
   // read our calibrations from CemcMonData.dat
-  std::string fullfile = std::string(getenv("CEMCCALIB")) + "/" + "CemcMonData.dat";
+  const char *cemccalib = getenv("CEMCCALIB");
+  if (!cemccalib)
+  {
+    std::cout << "CEMCCALIB environment variable not set" << std::endl;
+    exit(1);
+  }
+  std::string fullfile = std::string(cemccalib) + "/" + "CemcMonData.dat";
   std::ifstream calib(fullfile);
   calib.close();
   // use printf for stuff which should go the screen but not into the message

--- a/subsystems/daq/DaqMon.cc
+++ b/subsystems/daq/DaqMon.cc
@@ -47,7 +47,13 @@ int DaqMon::Init()
 {
   gRandom->SetSeed(rand());
   // read our calibrations from DaqMonData.dat
-  std::string fullfile = std::string(getenv("DAQCALIB")) + "/" + "DaqMonData.dat";
+  const char *daqcalib = getenv("DAQCALIB");
+  if (!daqcalib)
+  {
+    std::cout << "DAQCALIB environment variable not set" << std::endl;
+    exit(1);
+  }
+  std::string fullfile = std::string(daqcalib) + "/" + "DaqMonData.dat";
   std::ifstream calib(fullfile);
   calib.close();
   // use printf for stuff which should go the screen but not into the message

--- a/subsystems/epd/EpdMon.cc
+++ b/subsystems/epd/EpdMon.cc
@@ -47,7 +47,13 @@ int EpdMon::Init()
 {
   gRandom->SetSeed(rand());
   // read our calibrations from EpdMonData.dat
-  std::string fullfile = std::string(getenv("EPDCALIB")) + "/" + "EpdMonData.dat";
+  const char *epdcalib = getenv("EPDCALIB");
+  if (!epdcalib)
+  {
+    std::cout << "EPDCALIB environment variable not set" << std::endl;
+    exit(1);
+  }
+  std::string fullfile = std::string(epdcalib) + "/" + "EpdMonData.dat";
   std::ifstream calib(fullfile);
   calib.close();
   // use printf for stuff which should go the screen but not into the message

--- a/subsystems/hcal/HcalMon.cc
+++ b/subsystems/hcal/HcalMon.cc
@@ -56,7 +56,14 @@ int HcalMon::Init()
 {
   // read our calibrations from HcalMonData.dat
   /*
-  std::string fullfile = std::string(getenv("HCALCALIB")) + "/" + "HcalMonData.dat";
+
+  const char *hcalcalib = getenv("HCALCALIB");
+  if (!hcalcalib)
+  {
+    std::cout << "HCALCALIB environment variable not set" << std::endl;
+    exit(1);
+  }
+  std::string fullfile = std::string(hcalcalib) + "/" + "HcalMonData.dat";
   std::ifstream calib(fullfile);
   calib.close();
   */

--- a/subsystems/intt/InttMon.cc
+++ b/subsystems/intt/InttMon.cc
@@ -37,7 +37,13 @@ int InttMon::Init()
 	//...
 
 	//Read in calibrartion data from InttMonData.dat
-	std::string fullfile = std::string(getenv("INTTCALIB")) + "/" + "InttMonData.dat";
+	const char *inttcalib = getenv("INTTCALIB");
+	if (!inttcalib)
+	{
+	  std::cout << "INTTCALIB environment variable not set" << std::endl;
+	  exit(1);
+	}
+	std::string fullfile = std::string(inttcalib) + "/" + "InttMonData.dat";
 	std::ifstream calib(fullfile);
 	//probably need to do stuff here (maybe write to expectation maps)
 	//or reimplment in BeginRun()

--- a/subsystems/mvtx/MvtxMon.cc
+++ b/subsystems/mvtx/MvtxMon.cc
@@ -55,7 +55,13 @@ MvtxMon::~MvtxMon()
 int MvtxMon::Init()
 {
   // read our calibrations from MvtxMonData.dat
-  std::string fullfile = std::string(getenv("MVTXCALIB")) + "/" + "MvtxMonData.dat";
+  const char *mvtxcalib = getenv("MVTXCALIB");
+  if (!mvtxcalib)
+  {
+    std::cout << "MVTXCALIB environment variable not set" << std::endl;
+    exit(1);
+  }
+  std::string fullfile = std::string(mvtxcalib) + "/" + "MvtxMonData.dat";
   std::ifstream calib(fullfile);
   calib.close();
   // use printf for stuff which should go the screen but not into the message

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -46,7 +46,12 @@ TpcMon::~TpcMon()
 int TpcMon::Init()
 {
   // read our calibrations from TpcMonData.dat
-  std::string fullfile = std::string(getenv("TPCCALIB")) + "/" + "TpcMonData.dat";
+  const char *tpccalib = getenv("TPCCALIB");
+  if (!tpccalib)
+  {
+    std::cout << "TPCCALIB environment variable not set" << std::endl;
+  }
+  std::string fullfile = std::string(tpccalib) + "/" + "TpcMonData.dat";
   std::ifstream calib(fullfile);
   calib.close();
   // use printf for stuff which should go the screen but not into the message

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -50,6 +50,7 @@ int TpcMon::Init()
   if (!tpccalib)
   {
     std::cout << "TPCCALIB environment variable not set" << std::endl;
+    exit(1);
   }
   std::string fullfile = std::string(tpccalib) + "/" + "TpcMonData.dat";
   std::ifstream calib(fullfile);

--- a/subsystems/tpot/TpotMon.cc
+++ b/subsystems/tpot/TpotMon.cc
@@ -36,7 +36,13 @@ int TpotMon::Init()
 {
   // read our calibrations from TpotMonData.dat
   {
-    std::string fullfile = std::string(getenv("TPOTCALIB")) + "/" + "TpotMonData.dat";
+  const char *tpotcalib = getenv("TPOTCALIB");
+  if (!tpotcalib)
+  {
+    std::cout << "TPOTCALIB environment variable not set" << std::endl;
+    exit(1);
+  }
+    std::string fullfile = std::string(tpotcalib) + "/" + "TpotMonData.dat";
     std::ifstream calib(fullfile);
     calib.close();
   }


### PR DESCRIPTION
The setup scripts now take care of the root_include_path, ld_library_path and path (without calling setup_local which does not exist online). If the subsystem specific CALIB variable wasn't set the code threw an stl string exception without any info where it came from. Now there is a warning and the code exits 