### PR TITLE
Registering sample_size_hist in tpc client macro

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -15,6 +15,7 @@ void tpcDrawInit(const int online = 0)
   cl->registerHisto("tpcmon_hist2", "TPCMON_0");
   cl->registerHisto("NorthSideADC", "TPCMON_0");
   cl->registerHisto("SouthSideADC", "TPCMON_0");
+  cl->registerHisto("sample_size_hist","TPCMON_0");
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
   // get my histos from server, the second parameter = 1


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C

**Changes:**

Register histogram for sample size distribution

**TODO:**

get output from .prdfs into TPC Pie Chart
Add histos for the following:

    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel
    CheckSumError Probability vs FEE*8 + SAMPA
    BCO Plots?

