### PR TITLE
Adding CheckSumError Probability Histo

### DIFF
--- a/macros/ServerFuncs.C
+++ b/macros/ServerFuncs.C
@@ -3,6 +3,7 @@
 
 // cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlmonserver.so)
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlmonserver_funcs.so)
 void CleanUpServer();
 

--- a/macros/run_bbc_server.C
+++ b/macros/run_bbc_server.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlbbcmon_server.so)
 
 void run_bbc_server(const std::string &name = "BBCMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")

--- a/macros/run_bbcll1_server.C
+++ b/macros/run_bbcll1_server.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlbbcll1mon_server.so)
 
 void run_bbcll1_server(const std::string &name = "BBCLL1MON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")

--- a/macros/run_cemc_server.C
+++ b/macros/run_cemc_server.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlcemcmon_server.so)
 
 // void run_cemc_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")

--- a/macros/run_cemc_server_SEB00.C
+++ b/macros/run_cemc_server_SEB00.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlcemcmon_server.so)
 
 // this pretends to run a subevent from seb00  (packets 6001...6016)

--- a/macros/run_cemc_server_SEB01.C
+++ b/macros/run_cemc_server_SEB01.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlcemcmon_server.so)
 
 // this pretends to run a subevent from seb01 (packets 6017...6032)

--- a/macros/run_daq_server.C
+++ b/macros/run_daq_server.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonldaqmon_server.so)
 
 void run_daq_server(const std::string &name = "DAQMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")

--- a/macros/run_epd_server.C
+++ b/macros/run_epd_server.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlepdmon_server.so)
 
 void run_epd_server(const std::string &name = "EPDMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/cemc/sepd/onlmon_test/EMCAL_to_SEPD_test.prdf")

--- a/macros/run_example_server0.C
+++ b/macros/run_example_server0.C
@@ -6,6 +6,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlmymon_server.so)
 
 void run_example_server0(const std::string &name = "MYMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")

--- a/macros/run_example_server1.C
+++ b/macros/run_example_server1.C
@@ -6,6 +6,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlmymon_server.so)
 
 void run_example_server1(const std::string &name = "MYMON", unsigned int serverid = 1, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")

--- a/macros/run_hcal_server.C
+++ b/macros/run_hcal_server.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlhcalmon_server.so)
 
 void run_hcal_server(const std::string &name = "HCALMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/hcal/1008/LED/led-West-East-00001713-0000.prdf")

--- a/macros/run_mvtx_server.C
+++ b/macros/run_mvtx_server.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlmvtxmon_server.so)
 
 //void run_mvtx_server(const char *prdffile = "/sphenix/data/data01/mvtx/tb-1441-052019/longrun/longrun_00000872-0000.prdf")

--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -16,6 +16,8 @@ void tpcDrawInit(const int online = 0)
   cl->registerHisto("NorthSideADC", "TPCMON_0");
   cl->registerHisto("SouthSideADC", "TPCMON_0");
   cl->registerHisto("sample_size_hist","TPCMON_0");
+  cl->registerHisto("Check_Sum_Error","TPCMON_0");
+  cl->registerHisto("Check_Sums","TPCMON_0");
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
   // get my histos from server, the second parameter = 1

--- a/macros/run_tpc_server.C
+++ b/macros/run_tpc_server.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonltpcmon_server.so)
 
 void run_tpc_server(const std::string &name = "TPCMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphnxpro/tpc/chughes/prdf/00010169/TPC_ebdc00_pedestal-00010169-0000.prdf")

--- a/macros/run_tpc_server.C
+++ b/macros/run_tpc_server.C
@@ -6,7 +6,7 @@
 
 R__LOAD_LIBRARY(libonltpcmon_server.so)
 
-void run_tpc_server(const std::string &name = "TPCMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
+void run_tpc_server(const std::string &name = "TPCMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/data/data02/sphnxpro/tpc/chughes/prdf/00010169/TPC_ebdc00_pedestal-00010169-0000.prdf")
 {
   OnlMon *m = new TpcMon(name);                     // create subsystem Monitor object
   m->SetMonitorServerId(serverid);

--- a/macros/run_tpot_server.C
+++ b/macros/run_tpot_server.C
@@ -4,6 +4,7 @@
 
 #include <onlmon/OnlMonServer.h>
 
+// cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonltpotmon_server.so)
 
 void run_tpot_server(

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -6,6 +6,7 @@
 class Event;
 class TH1;
 class TH2;
+class TTree;
 
 class TpcMon : public OnlMon
 {
@@ -33,6 +34,8 @@ class TpcMon : public OnlMon
   TH2 *SouthSideADC = nullptr;
 
   TH1 *sample_size_hist = nullptr;
+  TH1 *Check_Sum_Error = nullptr;
+  TH1 *Check_Sums = nullptr;
 
   void Locate(int id, float *rbin, float *thbin);
 };

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -93,9 +93,22 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
   }
   else if (name == "TPCModules")
   {
-    TC[3] = new TCanvas(name.c_str(), "ADC Count by GEM Example", 1248, 598);
+    TC[3] = new TCanvas(name.c_str(), "ADC Count by GEM Example", 1250, 600);
+    gSystem->ProcessEvents();
     TC[3]->Divide(2,1);
     TC[3]->SetEditable(false);
+  }
+  else if (name == "TPCSampleSize")
+  {
+    TC[4] = new TCanvas(name.c_str(), "TPC Sample Size Distribution in Events", -xsize / 2, 0, xsize / 2, ysize );
+    gSystem->ProcessEvents();
+    TC[4]->SetEditable(false);
+  }
+  else if (name == "TPCCheckSumError")
+  {
+    TC[5] = new TCanvas(name.c_str(), "TPC CheckSumError Probability in Events", 1250, 600);
+    gSystem->ProcessEvents();
+    TC[5]->SetEditable(false);
   }
   return 0;
 }
@@ -119,6 +132,16 @@ int TpcMonDraw::Draw(const std::string &what)
     iret += DrawTPCModules(what);
     idraw++;
   }
+  if (what == "ALL" || what == "TPCSAMPLESIZE")
+  {
+    iret += DrawTPCSampleSize(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCCHECKSUMERROR")
+  {
+    iret += DrawTPCCheckSum(what);
+    idraw++;
+  }
   if (what == "ALL" || what == "HISTORY")
   {
     iret += DrawHistory(what);
@@ -137,6 +160,7 @@ int TpcMonDraw::DrawFirst(const std::string & /* what */)
   OnlMonClient *cl = OnlMonClient::instance();
   TH1 *tpcmon_hist1 =  cl->getHisto("TPCMON_0","tpcmon_hist1");
   TH1 *tpcmon_hist2 =  cl->getHisto("TPCMON_0","tpcmon_hist1");
+
   if (!gROOT->FindObject("TpcMon1"))
   {
     MakeCanvas("TpcMon1");
@@ -353,6 +377,55 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   TC[3]->Show();
   TC[3]->SetEditable(false);
   
+  return 0;
+}
+
+int TpcMonDraw::DrawTPCSampleSize(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+  TH1 *tpcmon_samplesizedist = (TH1*) cl->getHisto("TPCMON_0","sample_size_hist");
+
+  if (!gROOT->FindObject("TPCSampleSize"))
+  {
+    MakeCanvas("TPCSampleSize");
+  }
+
+  TC[4]->SetEditable(true);
+  TC[4]->Clear("D");
+  TC[4]->cd(1);
+  tpcmon_samplesizedist->DrawCopy("");
+  TC[4]->Update();
+  TC[4]->SetLogx();
+  TC[4]->Show();
+  TC[4]->SetEditable(false);
+
+  return 0;
+}
+
+int TpcMonDraw::DrawTPCCheckSum(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH1 *tpcmon_checksumerror = (TH1*) cl->getHisto("TPCMON_0", "Check_Sum_Error");
+  TH1 *tpcmon_checksums = (TH1*) cl->getHisto("TPCMON_0", "Check_Sums");
+
+  if (!gROOT->FindObject("TPCCheckSumError"))
+  {
+    MakeCanvas("TPCCheckSumError");
+  }
+
+  TC[5]->SetEditable(true);
+  TC[5]->Clear("D");
+  TC[5]->cd(1);
+  tpcmon_checksumerror->Divide(tpcmon_checksums);
+  tpcmon_checksumerror->GetYaxis()->SetRangeUser(0.0001,1);
+  tpcmon_checksumerror->DrawCopy("HIST");
+  TC[5]->Update();
+  //TC[5]->SetLogy();
+  TC[5]->Show();
+  TC[5]->SetEditable(false);
+
+
   return 0;
 }
 

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -30,8 +30,11 @@ class TpcMonDraw : public OnlMonDraw
   int DrawSecond(const std::string &what = "ALL");
   int DrawHistory(const std::string &what = "ALL");
   int DrawTPCModules(const std::string &what = "ALL");
+  int DrawTPCSampleSize(const std::string &what = "ALL");
+  int DrawTPCCheckSum(const std::string &what = "ALL");
+
   int TimeOffsetTicks = -1;
-  TCanvas *TC[4] = {nullptr};
+  TCanvas *TC[6] = {nullptr};
   TPad *transparent[3] = {nullptr};
   TPad *Pad[6] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
macros/run_tpc_server.C
subsystems/tpc/TpcMon.cc
subsystems/tpc/TpcMon.h
subsystems/tpc/TpcMonDraw.cc
subsystems/tpc/TpcMonDraw.h

**Changes:**

Added histogram for CheckSumError Probability vs FEE_Num*8 + SampaAddress
Cleaned up some cout statements

**TODO:**

get output from .prdfs into TPC Pie Chart
Add histos for the following:

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel
~~CheckSumError Probability vs FEE*8 + SAMPA~~
Stuck Channel Detection
BCO Plots?
