### PR TITLE
Getting Sum of ADC counts from .prdf events into TPC Pie Chart Display

### DIFF
--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -37,7 +37,10 @@ class TpcMon : public OnlMon
   TH1 *Check_Sum_Error = nullptr;
   TH1 *Check_Sums = nullptr;
 
+  int serverid = MonitorServerId();
+
   void Locate(int id, float *rbin, float *thbin);
+  int Index_from_Module(int sec_id, int fee_id);
 };
 
 #endif /* TPC_TPCMON_H */

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -106,7 +106,7 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
   }
   else if (name == "TPCCheckSumError")
   {
-    TC[5] = new TCanvas(name.c_str(), "TPC CheckSumError Probability in Events", 1250, 600);
+    TC[5] = new TCanvas(name.c_str(), "TPC CheckSumError Probability in Events", 625, 600);
     gSystem->ProcessEvents();
     TC[5]->SetEditable(false);
   }


### PR DESCRIPTION
**Files Affected:**

subsystems/tpc/TpcMon.cc
subsystems/tpc/TpcMon.h
subsystems/tpc/TpcMonDraw.cc

**Changes:**

In event loop, looping over packets, waveforms, samples, get ADC and increment array at correct index by that ADC.
Also fixed an issue with plotting the pie chart where the North_Side_Arr was being drawn with South Side coordinates.

**TODO:**

~~get output from .prdfs into TPC Pie Chart~~
Need to merge histos from each ebdc into the pie chart

Add histos for the following:

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel
~~CheckSumError Probability vs FEE*8 + SAMPA~~
Stuck Channel Detection
BCO Plots?
