### PR TITLE
enable MUTEX via #ifdef USE_MUTEX

### DIFF
--- a/onlmonserver/OnlMonServer.cc
+++ b/onlmonserver/OnlMonServer.cc
@@ -35,6 +35,8 @@
 #include <utility>  // for pair
 #include <vector>
 
+#define USE_MUTEX
+
 OnlMonServer *OnlMonServer::__instance = nullptr;
 
 // root TFile compression level
@@ -53,7 +55,9 @@ OnlMonServer *OnlMonServer::instance()
 OnlMonServer::OnlMonServer(const std::string &name)
   : OnlMonBase(name)
 {
+#ifdef USE_MUTEX
   pthread_mutex_init(&mutex, nullptr);
+#endif
   MsgSystem[ThisName] = new MessageSystem(ThisName);
   statusDB = new OnlMonStatusDB();
   RunStatusDB = new OnlMonStatusDB("onlmonrunstatus");
@@ -63,13 +67,18 @@ OnlMonServer::OnlMonServer(const std::string &name)
 
 OnlMonServer::~OnlMonServer()
 {
+#ifdef USE_MUTEX
   pthread_mutex_lock(&mutex);
+#endif
   if (int tret = pthread_cancel(serverthreadid))
   {
     std::cout << __PRETTY_FUNCTION__ << "pthread cancel returned error: " << tret << std::endl;
   }
   delete serverrunning;
+
+#ifdef USE_MUTEX
   pthread_mutex_destroy(&mutex);
+#endif
   while (MonitorList.begin() != MonitorList.end())
   {
     delete MonitorList.back();
@@ -109,14 +118,14 @@ void OnlMonServer::dumpHistos(const std::string &filename)
 {
   TFile *hfile = TFile::Open(filename.c_str(), "RECREATE", "Created by Online Monitor");
   for (auto &moniiter : MonitorHistoSet)
+  {
+    std::cout << "saving " << moniiter.first << std::endl;
+    for (auto &histiter : moniiter.second)
     {
-      std::cout << "saving " << moniiter.first << std::endl;
-      for (auto &histiter : moniiter.second)
-	{
-	  std::cout << "saving " << histiter.first << std::endl;
-	  histiter.second->Write();
-	}
+      std::cout << "saving " << histiter.first << std::endl;
+      histiter.second->Write();
     }
+  }
   hfile->Close();
   delete hfile;
   return;
@@ -513,25 +522,25 @@ void OnlMonServer::RunNumber(const int irun)
 int OnlMonServer::WriteHistoFile()
 {
   for (auto &moniiter : MonitorHistoSet)
+  {
+    std::string dirname = "./";
+    if (getenv("ONLMON_SAVEDIR"))
     {
-      std::string dirname = "./";
-      if (getenv("ONLMON_SAVEDIR"))
-	{
-	  dirname  = std::string(getenv("ONLMON_SAVEDIR")) + "/";
-	}
-      std::string filename = dirname + "Run_" + std::to_string(RunNumber()) + "-" + moniiter.first + ".root";
-      if (Verbosity() > 2)
-	{
-	  std::cout << "saving histos for " << moniiter.first << " in " << filename << std::endl;
-	}
-      TFile *hfile = TFile::Open(filename.c_str(), "RECREATE", "Created by Online Monitor");
-      for (auto &histiter : moniiter.second)
-	{
-	  histiter.second->Write();
-	}
-      hfile->Close();
-      delete hfile;
+      dirname = std::string(getenv("ONLMON_SAVEDIR")) + "/";
     }
+    std::string filename = dirname + "Run_" + std::to_string(RunNumber()) + "-" + moniiter.first + ".root";
+    if (Verbosity() > 2)
+    {
+      std::cout << "saving histos for " << moniiter.first << " in " << filename << std::endl;
+    }
+    TFile *hfile = TFile::Open(filename.c_str(), "RECREATE", "Created by Online Monitor");
+    for (auto &histiter : moniiter.second)
+    {
+      histiter.second->Write();
+    }
+    hfile->Close();
+    delete hfile;
+  }
   return 0;
 }
 
@@ -566,7 +575,6 @@ int OnlMonServer::send_message(const int severity, const std::string &err_messag
   int iret = iter->second->send_message(MSG_SOURCE_UNSPECIFIED, severity, err_message, msgtype);
   return iret;
 }
-
 
 int OnlMonServer::WriteLogFile(const std::string &name, const std::string &message) const
 {
@@ -1011,4 +1019,3 @@ int OnlMonServer::LookAtMe(OnlMon *Monitor, const int level, const std::string &
             << std::endl;
   return 0;
 }
-

--- a/onlmonserver/OnlMonServer.h
+++ b/onlmonserver/OnlMonServer.h
@@ -1,6 +1,8 @@
 #ifndef ONLMONSERVER_ONLMONSERVER_H
 #define ONLMONSERVER_ONLMONSERVER_H
 
+//#define USE_MUTEX
+
 #include "OnlMonBase.h"
 #include "OnlMonDefs.h"
 

--- a/onlmonserver/OnlMonServer.h
+++ b/onlmonserver/OnlMonServer.h
@@ -77,7 +77,10 @@ class OnlMonServer : public OnlMonBase
   std::string GetRunType() const { return RunType; }
 
   int send_message(const OnlMon *Monitor, const int msgsource, const int severity, const std::string &err_message, const int msgtype) const;
+
+#ifdef USE_MUTEX
   void GetMutex(pthread_mutex_t &lock) { lock = mutex; }
+#endif
   void SetThreadId(const pthread_t &id) { serverthreadid = id; }
 
   int LoadActivePackets();

--- a/onlmonserver/pmonitorInterface.cc
+++ b/onlmonserver/pmonitorInterface.cc
@@ -67,7 +67,9 @@ TH1 *FrameWorkVars = nullptr;
 int pinit()
 {
   OnlMonServer *Onlmonserver = OnlMonServer::instance();
+#ifdef USE_MUTEX
   Onlmonserver->GetMutex(mutex);
+#endif
   for (int i = 0; i < kMAXSIGNALS; i++)
   {
     gSystem->IgnoreSignal((ESignals) i);


### PR DESCRIPTION
Looks like root6 is finally threadsafe when it comes to historgrams. This PR disables the mutex, if one defines USE_MUTEX in OnlMonServer.h it will be back