### PR TITLE
Looping over histograms for ADC pie chart (more efficient)

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -13,23 +13,36 @@ void tpcDrawInit(const int online = 0)
   // register histos we want with monitor name
   cl->registerHisto("tpcmon_hist1", "TPCMON_0");
   cl->registerHisto("tpcmon_hist2", "TPCMON_0");
-  cl->registerHisto("NorthSideADC", "TPCMON_0");
-  cl->registerHisto("SouthSideADC", "TPCMON_0");
+
   cl->registerHisto("sample_size_hist","TPCMON_0");
   cl->registerHisto("Check_Sum_Error","TPCMON_0");
   cl->registerHisto("Check_Sums","TPCMON_0");
   cl->registerHisto("ADC_vs_SAMPLE","TPCMON_0"); 
 
-  cl->registerHisto("NorthSideADC", "TPCMON_1");
-  cl->registerHisto("SouthSideADC", "TPCMON_1");
+  char TPCMON_STR[100];
+  // TPC ADC pie chart
+  for( int i=0; i<12; i++ )
+  {
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    std::cout<<"You registered the NSIDEADC/SSIDEADC "<<i<<" histo"<<std::endl;
+
+    cl->registerHisto("NorthSideADC", TPCMON_STR);
+    cl->registerHisto("SouthSideADC", TPCMON_STR);
+  } //
+
+
 
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
 
-  cl->requestHistoBySubSystem("TPCMON_0", 1);
-  cl->requestHistoBySubSystem("TPCMON_1", 1);
+  for( int i=0; i<12; i++ )
+  {
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    cl->requestHistoBySubSystem(TPCMON_STR, 1);
+  }
 
   OnlMonDraw *tpcmon = new TpcMonDraw("TPCMONDRAW");  // create Drawing Object
   cl->registerDrawer(tpcmon);             // register with client framework
@@ -39,8 +52,14 @@ void tpcDraw(const char *what = "ALL")
 {
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
 
-  cl->requestHistoBySubSystem("TPCMON_0",1);        // update histos
-  cl->requestHistoBySubSystem("TPCMON_1",1);        // update histos
+  char TPCMON_STR[100];
+
+  for( int i=0; i<12; i++ )
+  {
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    cl->requestHistoBySubSystem(TPCMON_STR, 1);
+  }
+
 
   cl->Draw("TPCMONDRAW", what);                     // Draw Histos of registered Drawers
 }

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -16,6 +16,7 @@
 #include <TMath.h>
 #include <TPaveLabel.h>
 #include <TStyle.h>
+#include <TString.h>
 
 #include <cstring>  // for memset
 #include <ctime>
@@ -268,11 +269,20 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
 {
   std::cout<<"This is Charles' temporary function 02.15.23 !!!!!"<<std::endl;
   OnlMonClient *cl = OnlMonClient::instance();
-  TH2 *tpcmon_NSIDEADC0 = (TH2*) cl->getHisto("TPCMON_0","NorthSideADC");
-  TH2 *tpcmon_SSIDEADC0 = (TH2*) cl->getHisto("TPCMON_0","SouthSideADC");
 
-  TH2 *tpcmon_NSIDEADC1 = (TH2*) cl->getHisto("TPCMON_1","NorthSideADC");
-  TH2 *tpcmon_SSIDEADC1 = (TH2*) cl->getHisto("TPCMON_1","SouthSideADC");
+  TH2 *tpcmon_NSIDEADC[12] = {nullptr};
+  TH2 *tpcmon_SSIDEADC[12] = {nullptr};
+
+  char TPCMON_STR[100];
+  // TPC ADC pie chart
+  for( int i=0; i<12; i++ ) //NS ONLY FOR NOW
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_NSIDEADC[i] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC");
+    tpcmon_SSIDEADC[i] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC");
+  }
+
 
   //TH2 *tpcmon_NSIDEADC1 = (TH2*) cl->getHisto("TPCMON_0","NorthSideADC");
   //TH2 *tpcmon_SSIDEADC1 = (TH2*) cl->getHisto("TPCMON_0","SouthSideADC");
@@ -343,13 +353,17 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   TC[3]->Clear("D");
   TC[3]->cd(1);
   dummy_his1->Draw("");
-  if (tpcmon_NSIDEADC0 && tpcmon_NSIDEADC1)
+ 
+  for( int i=0; i<12; i++ )
   {
-    //std::cout<<"Yes, there is a histogram to draw !!!! Charles 02.16.23"<<std::endl;
+    if( tpcmon_NSIDEADC[i] ){
+    std::cout<<"You have the NSIDEADC "<<i<<" histo"<<std::endl;
+    tpcmon_NSIDEADC[i] -> Draw("colpolzsame");
 
-    tpcmon_NSIDEADC0->DrawCopy("colpolzsame");
-    tpcmon_NSIDEADC1->DrawCopy("colpolzsame");
+    }
+
   }
+
   SS00->Draw("same");
   SS01->Draw("same");
   SS02->Draw("same");
@@ -365,11 +379,16 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
 
   TC[3]->cd(2);
   dummy_his2->Draw("");
-  if (tpcmon_SSIDEADC0 && tpcmon_SSIDEADC1)
+
+  for( int i=0; i<12; i++ )
   {
-    tpcmon_SSIDEADC0->DrawCopy("colpolzsame");
-    tpcmon_SSIDEADC1->DrawCopy("colpolzsame");
+    if( tpcmon_SSIDEADC[i] ){
+    tpcmon_SSIDEADC[i] -> Draw("colpolzsame");
+
+    }
+
   }
+
   NS18->Draw("same");
   NS17->Draw("same");
   NS16->Draw("same");
@@ -390,11 +409,11 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   dummy_his2->SetStats(0);
 
   //dynamically set heat map color scale to start at the minimum and end at the maximum
-  dummy_his1->SetMaximum(TMath::Max(tpcmon_SSIDEADC0->GetBinContent(tpcmon_SSIDEADC0->GetMaximumBin()),tpcmon_NSIDEADC0->GetBinContent(tpcmon_NSIDEADC0->GetMaximumBin())));
-  dummy_his1->SetMinimum(TMath::Min(tpcmon_SSIDEADC0->GetBinContent(tpcmon_SSIDEADC0->GetMinimumBin()),tpcmon_NSIDEADC0->GetBinContent(tpcmon_NSIDEADC0->GetMinimumBin())));
+  dummy_his1->SetMaximum(TMath::Max(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMaximumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMaximumBin())));
+  dummy_his1->SetMinimum(TMath::Min(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMinimumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMinimumBin())));
 
-  dummy_his2->SetMaximum(TMath::Max(tpcmon_SSIDEADC0->GetBinContent(tpcmon_SSIDEADC0->GetMaximumBin()),tpcmon_NSIDEADC0->GetBinContent(tpcmon_NSIDEADC0->GetMaximumBin())));
-  dummy_his2->SetMinimum(TMath::Min(tpcmon_SSIDEADC0->GetBinContent(tpcmon_SSIDEADC0->GetMinimumBin()),tpcmon_NSIDEADC0->GetBinContent(tpcmon_NSIDEADC0->GetMinimumBin())));
+  dummy_his2->SetMaximum(TMath::Max(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMaximumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMaximumBin())));
+  dummy_his2->SetMinimum(TMath::Min(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMinimumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMinimumBin())));
 
   TC[3]->Show();
   TC[3]->SetEditable(false);


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
subsystems/tpc/TpcMonDraw.cc

**Changes:**

Adding looping over histograms for filling pie chart in TpcMonDraw.cc - which makes it more efficient (Chris' suggestion). This should allow one to loop over 12 EBDCs at a time to fill pie chart.

**TODO:**

~~Need to merge histos from each ebdc into the pie chart~~
Did this for EBDC00 -11 -need to do for EBDC12 - 23
Also need to do this for other histograms (plot one one canvas)

**Add histos for the following:**

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel
~~CheckSumError Probability vs FEE*8 + SAMPA~~
Stuck Channel Detection
BCO Plots?
