### PR TITLE
Adding panels for 6 x 4 display for samplesize, checksum error, ADC vs sample

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -14,21 +14,20 @@ void tpcDrawInit(const int online = 0)
   cl->registerHisto("tpcmon_hist1", "TPCMON_0");
   cl->registerHisto("tpcmon_hist2", "TPCMON_0");
 
-  cl->registerHisto("sample_size_hist","TPCMON_0");
-  cl->registerHisto("Check_Sum_Error","TPCMON_0");
-  cl->registerHisto("Check_Sums","TPCMON_0");
-  cl->registerHisto("ADC_vs_SAMPLE","TPCMON_0"); 
-
   char TPCMON_STR[100];
   // TPC ADC pie chart
-  for( int i=0; i<12; i++ )
+  for( int i=0; i<5; i++ )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
-    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
     std::cout<<"You registered the NSIDEADC/SSIDEADC "<<i<<" histo"<<std::endl;
 
-    cl->registerHisto("NorthSideADC", TPCMON_STR);
-    cl->registerHisto("SouthSideADC", TPCMON_STR);
+    if(i<12){ cl->registerHisto("NorthSideADC", TPCMON_STR); }
+    else { cl->registerHisto("SouthSideADC", TPCMON_STR); }
+
+    cl->registerHisto("sample_size_hist",TPCMON_STR);
+    cl->registerHisto("Check_Sum_Error",TPCMON_STR);
+    cl->registerHisto("Check_Sums",TPCMON_STR);
+    cl->registerHisto("ADC_vs_SAMPLE",TPCMON_STR); 
   } //
 
 
@@ -38,7 +37,7 @@ void tpcDrawInit(const int online = 0)
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
 
-  for( int i=0; i<12; i++ )
+  for( int i=0; i<5; i++ )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     cl->requestHistoBySubSystem(TPCMON_STR, 1);
@@ -54,7 +53,7 @@ void tpcDraw(const char *what = "ALL")
 
   char TPCMON_STR[100];
 
-  for( int i=0; i<12; i++ )
+  for( int i=0; i<5; i++ )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     cl->requestHistoBySubSystem(TPCMON_STR, 1);

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -105,19 +105,22 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
   {
     TC[4] = new TCanvas(name.c_str(), "TPC Sample Size Distribution in Events", -xsize / 2, 0, xsize / 2, ysize );
     gSystem->ProcessEvents();
+    TC[4]->Divide(4,6);
     TC[4]->SetEditable(false);
   }
   else if (name == "TPCCheckSumError")
   {
     TC[5] = new TCanvas(name.c_str(), "TPC CheckSumError Probability in Events", 625, 600);
     gSystem->ProcessEvents();
+    TC[5]->Divide(4,6);
     TC[5]->SetEditable(false);
   }
   else if (name == "TPCADCSample")
   {
-    TC[6] = new TCanvas(name.c_str(), "TPC ADC vs Sample in Whole Sector", 625, 700);
+    TC[6] = new TCanvas(name.c_str(), "TPC ADC vs Sample in Whole Sector", 1000, 1200);
     gSystem->ProcessEvents();
     gStyle->SetPalette(57); //kBird CVD friendly
+    TC[6]->Divide(4,6);
     TC[6]->SetEditable(false);
   }
   return 0;
@@ -267,7 +270,6 @@ int TpcMonDraw::DrawSecond(const std::string & /* what */)
 
 int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
 {
-  std::cout<<"This is Charles' temporary function 02.15.23 !!!!!"<<std::endl;
   OnlMonClient *cl = OnlMonClient::instance();
 
   TH2 *tpcmon_NSIDEADC[12] = {nullptr};
@@ -275,12 +277,12 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
 
   char TPCMON_STR[100];
   // TPC ADC pie chart
-  for( int i=0; i<12; i++ ) //NS ONLY FOR NOW
+  for( int i=0; i<24; i++ ) 
   {
     //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
     sprintf(TPCMON_STR,"TPCMON_%i",i);
-    tpcmon_NSIDEADC[i] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC");
-    tpcmon_SSIDEADC[i] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC");
+    if(i<12){tpcmon_NSIDEADC[i] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC");}
+    else {tpcmon_SSIDEADC[i-12] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC");}
   }
 
 
@@ -357,9 +359,7 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   for( int i=0; i<12; i++ )
   {
     if( tpcmon_NSIDEADC[i] ){
-    std::cout<<"You have the NSIDEADC "<<i<<" histo"<<std::endl;
     tpcmon_NSIDEADC[i] -> Draw("colpolzsame");
-
     }
 
   }
@@ -409,11 +409,30 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   dummy_his2->SetStats(0);
 
   //dynamically set heat map color scale to start at the minimum and end at the maximum
-  dummy_his1->SetMaximum(TMath::Max(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMaximumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMaximumBin())));
-  dummy_his1->SetMinimum(TMath::Min(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMinimumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMinimumBin())));
+  if( tpcmon_NSIDEADC[0] && tpcmon_SSIDEADC[0] ) //you were able to draw North and South Side
+  {
+    dummy_his1->SetMaximum(TMath::Max(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMaximumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMaximumBin())));
+    dummy_his1->SetMinimum(TMath::Min(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMinimumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMinimumBin())));
 
-  dummy_his2->SetMaximum(TMath::Max(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMaximumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMaximumBin())));
-  dummy_his2->SetMinimum(TMath::Min(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMinimumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMinimumBin())));
+    dummy_his2->SetMaximum(TMath::Max(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMaximumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMaximumBin())));
+    dummy_his2->SetMinimum(TMath::Min(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMinimumBin()),tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMinimumBin())));
+  }
+  else if( tpcmon_NSIDEADC[0] ) //only North side
+  {
+    dummy_his1->SetMaximum(tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMaximumBin()));
+    dummy_his1->SetMinimum(tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMinimumBin()));
+
+    dummy_his2->SetMaximum(tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMaximumBin()));
+    dummy_his2->SetMinimum(tpcmon_NSIDEADC[0]->GetBinContent(tpcmon_NSIDEADC[0]->GetMinimumBin()));
+  }
+  else // South Side Only
+  {
+    dummy_his1->SetMaximum(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMaximumBin()));
+    dummy_his1->SetMinimum(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMinimumBin()));
+
+    dummy_his2->SetMaximum(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMaximumBin()));
+    dummy_his2->SetMinimum(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMinimumBin()));
+  }
 
   TC[3]->Show();
   TC[3]->SetEditable(false);
@@ -424,7 +443,16 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
 int TpcMonDraw::DrawTPCSampleSize(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH1 *tpcmon_samplesizedist = (TH1*) cl->getHisto("TPCMON_0","sample_size_hist");
+
+  TH1 *tpcmon_samplesizedist[24] = {nullptr};
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_samplesizedist[i] = (TH1*) cl->getHisto(TPCMON_STR,"sample_size_hist");
+  }
 
   if (!gROOT->FindObject("TPCSampleSize"))
   {
@@ -433,8 +461,15 @@ int TpcMonDraw::DrawTPCSampleSize(const std::string & /* what */)
 
   TC[4]->SetEditable(true);
   TC[4]->Clear("D");
-  TC[4]->cd(1);
-  tpcmon_samplesizedist->DrawCopy("");
+  for( int i=0; i<24; i++ ) 
+  {
+    if( tpcmon_samplesizedist[i] )
+    {
+      TC[4]->cd(i+1);
+      tpcmon_samplesizedist[i]->DrawCopy("");
+      gPad->SetLogx(kTRUE);
+    }
+  }
   TC[4]->Update();
   TC[4]->SetLogx();
   TC[4]->Show();
@@ -446,9 +481,18 @@ int TpcMonDraw::DrawTPCSampleSize(const std::string & /* what */)
 int TpcMonDraw::DrawTPCCheckSum(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
+  
+  TH1 *tpcmon_checksumerror[24] = {nullptr};
+  TH1 *tpcmon_checksums[24] = {nullptr};
 
-  TH1 *tpcmon_checksumerror = (TH1*) cl->getHisto("TPCMON_0", "Check_Sum_Error");
-  TH1 *tpcmon_checksums = (TH1*) cl->getHisto("TPCMON_0", "Check_Sums");
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_checksumerror[i] = (TH1*) cl->getHisto(TPCMON_STR,"Check_Sum_Error");
+    tpcmon_checksums[i] = (TH1*) cl->getHisto(TPCMON_STR,"Check_Sums");
+  }
 
   if (!gROOT->FindObject("TPCCheckSumError"))
   {
@@ -458,9 +502,19 @@ int TpcMonDraw::DrawTPCCheckSum(const std::string & /* what */)
   TC[5]->SetEditable(true);
   TC[5]->Clear("D");
   TC[5]->cd(1);
-  tpcmon_checksumerror->Divide(tpcmon_checksums);
-  tpcmon_checksumerror->GetYaxis()->SetRangeUser(0.0001,1);
-  tpcmon_checksumerror->DrawCopy("HIST");
+
+  for( int i=0; i<24; i++ )
+  {
+    if( tpcmon_checksumerror[i] && tpcmon_checksums[i] )
+    {
+      TC[5]->cd(i+1);
+
+      tpcmon_checksumerror[i]->Divide(tpcmon_checksums[i]);
+      tpcmon_checksumerror[i]->GetYaxis()->SetRangeUser(0.0001,1);
+      tpcmon_checksumerror[i]->DrawCopy("HIST");
+    }
+  }
+
   TC[5]->Update();
   //TC[5]->SetLogy();
   TC[5]->Show();
@@ -473,7 +527,17 @@ int TpcMonDraw::DrawTPCCheckSum(const std::string & /* what */)
 int TpcMonDraw::DrawTPCADCSample(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH2 *tpcmon_ADCSAMPLE = (TH2*) cl->getHisto("TPCMON_0","ADC_vs_SAMPLE");
+
+  TH2 *tpcmon_ADCSAMPLE[24] = {nullptr};
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_ADCSAMPLE[i] = (TH2*) cl->getHisto(TPCMON_STR,"ADC_vs_SAMPLE");
+  }
+
 
   if (!gROOT->FindObject("TPCADCSample"))
   {
@@ -482,8 +546,16 @@ int TpcMonDraw::DrawTPCADCSample(const std::string & /* what */)
 
   TC[6]->SetEditable(true);
   TC[6]->Clear("D");
-  TC[6]->cd(1);
-  tpcmon_ADCSAMPLE->Draw("colz");
+
+  for( int i=0; i<24; i++ )
+  {
+    if( tpcmon_ADCSAMPLE[i] ){
+      TC[6]->cd(i+1);
+      gPad->SetLogz(kTRUE);
+      tpcmon_ADCSAMPLE[i] -> DrawCopy("colz");
+    }
+  }
+
   TC[6]->Update();
   TC[6]->Show();
   TC[6]->SetEditable(false);


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
subsystems/tpc/TpcMonDraw.cc

**Changes:**

Added 6 x 4 display for samplesize, checksum error, ADC vs sample. This allows us to display these QA histos for each Sector of the TPC (previously only had one example)

**TODO:**

~~Need to merge histos from each ebdc into the pie chart
Did this for EBDC00 -11 -need to do for EBDC12 - 23
Also need to do this for other histograms (plot one one canvas)~~

Add histos for the following:

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel
~~CheckSumError Probability vs FEE*8 + SAMPA~~
Stuck Channel Detection
BCO Plots?

CLEAN UP HISTOS - MAKE HUMAN READABLE
