### PR TITLE
Adding 1D histos per module for RAWADC and (LocalMAXADC-pedestal)

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -16,7 +16,7 @@ void tpcDrawInit(const int online = 0)
 
   char TPCMON_STR[100];
   // TPC ADC pie chart
-  for( int i=0; i<24; i++ )
+  for( int i=0; i<3; i++ )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     std::cout<<"You registered the NSIDEADC/SSIDEADC "<<i<<" histo"<<std::endl;
@@ -29,6 +29,13 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("Check_Sums",TPCMON_STR);
     cl->registerHisto("ADC_vs_SAMPLE",TPCMON_STR); 
     cl->registerHisto("MAXADC",TPCMON_STR);
+
+    cl->registerHisto("RAWADC_1D_R1",TPCMON_STR);
+    cl->registerHisto("MAXADC_1D_R1",TPCMON_STR);
+    cl->registerHisto("RAWADC_1D_R2",TPCMON_STR);
+    cl->registerHisto("MAXADC_1D_R2",TPCMON_STR);
+    cl->registerHisto("RAWADC_1D_R3",TPCMON_STR);
+    cl->registerHisto("MAXADC_1D_R3",TPCMON_STR);
   } //
 
 
@@ -38,7 +45,7 @@ void tpcDrawInit(const int online = 0)
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
 
-  for( int i=0; i<24; i++ )
+  for( int i=0; i<3; i++ )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     cl->requestHistoBySubSystem(TPCMON_STR, 1);
@@ -54,7 +61,7 @@ void tpcDraw(const char *what = "ALL")
 
   char TPCMON_STR[100];
 
-  for( int i=0; i<24; i++ )
+  for( int i=0; i<3; i++ )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     cl->requestHistoBySubSystem(TPCMON_STR, 1);

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -41,6 +41,15 @@ class TpcMon : public OnlMon
 
   TH2 *MAXADC = nullptr;
 
+  TH1 *RAWADC_1D_R1= nullptr;
+  TH1 *MAXADC_1D_R1 = nullptr;
+
+  TH1 *RAWADC_1D_R2= nullptr;
+  TH1 *MAXADC_1D_R2 = nullptr;
+
+  TH1 *RAWADC_1D_R3= nullptr;
+  TH1 *MAXADC_1D_R3 = nullptr;
+
   int starting_BCO;
   int rollover_value;
   int current_BCOBIN;
@@ -50,6 +59,7 @@ class TpcMon : public OnlMon
   void Locate(int id, float *rbin, float *thbin);
   int Index_from_Module(int sec_id, int fee_id);
   int Module_ID(int fee_id);
+  int Max_Nine(int one, int two, int three, int four, int five, int six, int seven, int eight, int nine);
 };
 
 #endif /* TPC_TPCMON_H */

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -34,9 +34,11 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCCheckSum(const std::string &what = "ALL");
   int DrawTPCADCSample(const std::string &what = "ALL");
   int DrawTPCMaxADCModule(const std::string &what = "ALL");
+  int DrawTPCRawADC1D(const std::string &what = "ALL");
+  int DrawTPCMaxADC1D(const std::string &what = "ALL");
 
   int TimeOffsetTicks = -1;
-  TCanvas *TC[8] = {nullptr};
+  TCanvas *TC[10] = {nullptr};
   TPad *transparent[3] = {nullptr};
   TPad *Pad[6] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
subsystems/tpc/TpcMon.cc
subsystems/tpc/TpcMon.h
subsystems/tpc/TpcMonDraw.cc
subsystems/tpc/TpcMonDraw.h

**Changes:**

Added 1D raw ADCs where there are 3 traces (R1 - red, R2 - green, R3 - blue) in each sector panel. Added 1D sliding window (10 wide, stride =1) Local max ADC - pedestal where there are 3 traces also in the same scheme.

**TODO:**

~~Need to merge histos from each ebdc into the pie chart
Did this for EBDC00 -11 -need to do for EBDC12 - 23
Also need to do this for other histograms (plot one one canvas)~~

Add histos for the following:

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
~~CheckSumError Probability vs FEE*8 + SAMPA~~
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
