### PR TITLE
Changing back to looping over 24 EBDCs in client

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -16,13 +16,13 @@ void tpcDrawInit(const int online = 0)
 
   char TPCMON_STR[100];
   // TPC ADC pie chart
-  for( int i=0; i<3; i++ )
+  for( int i=0; i<24; i++ )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     std::cout<<"You registered the NSIDEADC/SSIDEADC "<<i<<" histo"<<std::endl;
 
-    if(i<12){ cl->registerHisto("NorthSideADC", TPCMON_STR); }
-    else { cl->registerHisto("SouthSideADC", TPCMON_STR); }
+    if(i<12){ cl->registerHisto("NorthSideADC", TPCMON_STR);}//cl->registerHisto("NorthSideADC_clusterXY", TPCMON_STR);}
+    else { cl->registerHisto("SouthSideADC", TPCMON_STR);}//cl->registerHisto("SouthSideADC_clusterXY", TPCMON_STR);}
 
     cl->registerHisto("sample_size_hist",TPCMON_STR);
     cl->registerHisto("Check_Sum_Error",TPCMON_STR);
@@ -45,7 +45,7 @@ void tpcDrawInit(const int online = 0)
   // get my histos from server, the second parameter = 1
   // says I know they are all on the same node
 
-  for( int i=0; i<3; i++ )
+  for( int i=0; i<24; i++ )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     cl->requestHistoBySubSystem(TPCMON_STR, 1);
@@ -61,7 +61,7 @@ void tpcDraw(const char *what = "ALL")
 
   char TPCMON_STR[100];
 
-  for( int i=0; i<3; i++ )
+  for( int i=0; i<24; i++ )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     cl->requestHistoBySubSystem(TPCMON_STR, 1);


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C

**Changes:**

Looping back over 24 EBDCs in run_client. Was 3 for local testing but when this is committed it should ALWAYS be 24.

**TODO:**

~~Need to merge histos from each ebdc into the pie chart
Did this for EBDC00 -11 -need to do for EBDC12 - 23
Also need to do this for other histograms (plot one one canvas)~~

Add histos for the following:

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
~CheckSumError Probability vs FEE*8 + SAMPA~
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
