### PR TITLE
remove unimplemented histo MVTXMON_General_General_Occupancy

### DIFF
--- a/macros/run_mvtx_client.C
+++ b/macros/run_mvtx_client.C
@@ -65,7 +65,7 @@ void mvtxDrawInit(const int online = 0)
 
     // fhr
     cl->registerHisto("MVTXMON_General_ErrorVsFeeid", instanceName);
-    cl->registerHisto("MVTXMON_General_General_Occupancy", instanceName);
+    //    cl->registerHisto("MVTXMON_General_General_Occupancy", instanceName);
     cl->registerHisto("MVTXMON_General_Noisy_Pixel", instanceName);
 
     for (int mLayer = 0; mLayer < 3; mLayer++)


### PR DESCRIPTION
The client registered a histogram which does notexist on the server side. This triggers a very expensive search every time the client gets called - please don't do that