### PR TITLE
Fixing bug in PieChart/Xy plots + added functionality in XY

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -21,8 +21,17 @@ void tpcDrawInit(const int online = 0)
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     std::cout<<"You registered the NSIDEADC/SSIDEADC "<<i<<" histo"<<std::endl;
 
-    if(i<12){ cl->registerHisto("NorthSideADC", TPCMON_STR);cl->registerHisto("NorthSideADC_clusterXY", TPCMON_STR);}
-    else { cl->registerHisto("SouthSideADC", TPCMON_STR);cl->registerHisto("SouthSideADC_clusterXY", TPCMON_STR);}
+    cl->registerHisto("NorthSideADC", TPCMON_STR);
+
+    cl->registerHisto("NorthSideADC_clusterXY_R1", TPCMON_STR);
+    cl->registerHisto("NorthSideADC_clusterXY_R2", TPCMON_STR);
+    cl->registerHisto("NorthSideADC_clusterXY_R3", TPCMON_STR);
+
+    cl->registerHisto("SouthSideADC", TPCMON_STR);
+
+    cl->registerHisto("SouthSideADC_clusterXY_R1", TPCMON_STR);
+    cl->registerHisto("SouthSideADC_clusterXY_R2", TPCMON_STR);
+    cl->registerHisto("SouthSideADC_clusterXY_R3", TPCMON_STR);
 
     cl->registerHisto("sample_size_hist",TPCMON_STR);
     cl->registerHisto("Check_Sum_Error",TPCMON_STR);

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -78,13 +78,36 @@ int TpcMon::Init()
   //
 
   //TPC "cluster" XY heat maps
-  NorthSideADC_clusterXY = new TH2F("NorthSideADC_clusterXY" , "ADC Peaks North Side", 400, -800, 800, 400, -800, 800);
-  NorthSideADC_clusterXY->SetXTitle("X [mm]");
-  NorthSideADC_clusterXY->SetYTitle("Y [mm]");
+  //NorthSideADC_clusterXY_R1 = new TH2F("NorthSideADC_clusterXY_R1" , "ADC Peaks North Side", N_phi_binx_XY_R1, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  NorthSideADC_clusterXY_R1 = new TH2F("NorthSideADC_clusterXY_R1" , "(ADC-Pedestal) > 20 North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R1->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R1->SetYTitle("Y [mm]");
 
-  SouthSideADC_clusterXY = new TH2F("SouthSideADC_clusterXY" , "ADC Peaks South Side", 400, -800, 800, 400, -800, 800);
-  SouthSideADC_clusterXY->SetXTitle("X [mm]");
-  SouthSideADC_clusterXY->SetYTitle("Y [mm]");
+  //NorthSideADC_clusterXY_R2 = new TH2F("NorthSideADC_clusterXY_R2" , "ADC Peaks North Side", N_phi_binx_XY_R2, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  NorthSideADC_clusterXY_R2 = new TH2F("NorthSideADC_clusterXY_R2" , "(ADC-Pedestal) > 20 North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R2->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R2->SetYTitle("Y [mm]");
+
+  //NorthSideADC_clusterXY_R3 = new TH2F("NorthSideADC_clusterXY_R3" , "ADC Peaks North Side", N_phi_binx_XY_R3, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  NorthSideADC_clusterXY_R3 = new TH2F("NorthSideADC_clusterXY_R3" , "(ADC-Pedestal) > 20 North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R3->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R3->SetYTitle("Y [mm]");
+
+
+  //SouthSideADC_clusterXY_R1 = new TH2F("SouthSideADC_clusterXY_R1" , "ADC Peaks South Side", N_phi_binx_XY_R1, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  SouthSideADC_clusterXY_R1 = new TH2F("SouthSideADC_clusterXY_R1" , "(ADC-Pedestal) > 20 South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R1->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R1->SetYTitle("Y [mm]");
+
+  //SouthSideADC_clusterXY_R2 = new TH2F("SouthSideADC_clusterXY_R2" , "ADC Peaks South Side", N_phi_binx_XY_R2, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  SouthSideADC_clusterXY_R2 = new TH2F("SouthSideADC_clusterXY_R2" , "(ADC-Pedestal) > 20 South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R2->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R2->SetYTitle("Y [mm]");
+
+  //SouthSideADC_clusterXY_R3 = new TH2F("SouthSideADC_clusterXY_R3" , "ADC Peaks South Side", N_phi_binx_XY_R3, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);  
+  SouthSideADC_clusterXY_R3 = new TH2F("SouthSideADC_clusterXY_R3" , "(ADC-Pedestal) > 20 South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R3->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R3->SetYTitle("Y [mm]");
   //
 
   // ADC vs Sample
@@ -211,8 +234,14 @@ int TpcMon::Init()
   se->registerHisto(this, MAXADC_1D_R2);
   se->registerHisto(this, RAWADC_1D_R3);
   se->registerHisto(this, MAXADC_1D_R3);
-  se->registerHisto(this, NorthSideADC_clusterXY);
-  se->registerHisto(this, SouthSideADC_clusterXY);
+
+  se->registerHisto(this, NorthSideADC_clusterXY_R1);
+  se->registerHisto(this, NorthSideADC_clusterXY_R2);
+  se->registerHisto(this, NorthSideADC_clusterXY_R3);
+
+  se->registerHisto(this, SouthSideADC_clusterXY_R1);
+  se->registerHisto(this, SouthSideADC_clusterXY_R2);
+  se->registerHisto(this, SouthSideADC_clusterXY_R3);
 
   Reset();
   return 0;
@@ -318,7 +347,7 @@ int TpcMon::process_event(Event *evt/* evt */)
 
         // getting R and Phi coordinates
         double R = M.getR(feeM, channel);
-        double phi = M.getPhi(feeM, channel) + (serverid*side(serverid) - 12) * M_PI / 6 ;
+        double phi = M.getPhi(feeM, channel) + (serverid - 12*side(serverid)) * M_PI / 6 ;
 
         //std::cout<<"Sector = "<< serverid <<" FEE = "<<fee<<" channel = "<<channel<<std::endl;
 
@@ -329,11 +358,15 @@ int TpcMon::process_event(Event *evt/* evt */)
 
         if( nr_Samples > 5){if( (p->iValue(wf,mid) == p->iValue(wf,mid-1)) && (p->iValue(wf,mid) == p->iValue(wf,mid-2)) && (p->iValue(wf,mid) == p->iValue(wf,mid+1)) && (p->iValue(wf,mid) == p->iValue(wf,mid+2)) ){ is_channel_stuck = 1;};} //Compare 5 values to determine stuck !!
 
+        int wf_max = 0;
+
         for( int s =0; s < nr_Samples ; s++ ){
           
           //int t = s + 2 * (current_BCO - starting_BCO);
 
           int adc = p->iValue(wf,s);          
+
+          if( adc > wf_max){ wf_max = adc; }
 
           if( s >= 10 && s <= 19) // get first 10-19
           {
@@ -356,9 +389,6 @@ int TpcMon::process_event(Event *evt/* evt */)
                if(Module_ID(fee)==0){MAXADC_1D_R1->Fill(adc - pedestal);} //Raw 1D for R1
                else if(Module_ID(fee)==1){MAXADC_1D_R2->Fill(adc - pedestal);} //Raw 1D for R2
                else if(Module_ID(fee)==2){MAXADC_1D_R3->Fill(adc - pedestal);} //Raw 1D for R3
-
-               if( serverid < 12){NorthSideADC_clusterXY ->Fill(R*cos(phi),R*sin(phi),adc - pedestal );}
-               else if( serverid >=12){SouthSideADC_clusterXY ->Fill(R*cos(phi),R*sin(phi),adc - pedestal );}
             }
 
           }
@@ -377,6 +407,23 @@ int TpcMon::process_event(Event *evt/* evt */)
           else {South_Side_Arr[ Index_from_Module(serverid,fee) ] += adc;}
 
         } //nr samples
+
+        //for complicated XY stuff ____________________________________________________
+        //20 = 3-5 * sigma - hard-coded
+        if( serverid < 12 && (wf_max - pedestal) > 20)
+        {
+          if(Module_ID(fee)==0){NorthSideADC_clusterXY_R1->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R1
+          else if(Module_ID(fee)==1){NorthSideADC_clusterXY_R2->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R2
+          else if(Module_ID(fee)==2){NorthSideADC_clusterXY_R3->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R3
+        }
+        else if( serverid >=12 && (wf_max - pedestal) > 20)
+        {
+          if(Module_ID(fee)==0){SouthSideADC_clusterXY_R1->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R1
+          else if(Module_ID(fee)==1){SouthSideADC_clusterXY_R2->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R2
+          else if(Module_ID(fee)==2){SouthSideADC_clusterXY_R3->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R3
+        }
+        //________________________________________________________________________________
+
         is_channel_stuck = 0; //reset after looping through waveform samples
 
         store_ten.clear(); //clear this after every waveform

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -33,6 +33,27 @@ class TpcMon : public OnlMon
   const int N_thBins = 12; //(12 theta bins of uniform angle (360/12 = 30 degrees = TMath::Pi()/6 ~= 0.523 rad)
   const double rBin_edges[N_rBins+1] = {0.0, 0.256, 0.504, 0.752, 1.00}; //variable edges for radial dims
 
+  //for X-Y channel plot
+  static const int N_rBins_XY = 66; //From Evgeny code - global to all modules
+  const double r_bins[N_rBins_XY + 1] = {217.83,
+                                 223.83, 229.83, 235.83, 241.83, 247.83, 253.83, 259.83, 265.83, 271.83, 277.83, 283.83, 289.83, 295.83, 301.83, 306.83,
+                                 311.05, 317.92, 323.31, 329.27, 334.63, 340.59, 345.95, 351.91, 357.27, 363.23, 368.59, 374.55, 379.91, 385.87, 391.23, 397.19, 402.49,
+                                 411.53, 421.70, 431.90, 442.11, 452.32, 462.52, 472.73, 482.94, 493.14, 503.35, 513.56, 523.76, 533.97, 544.18, 554.39, 564.59, 574.76,
+                                 583.67, 594.59, 605.57, 616.54, 627.51, 638.48, 649.45, 660.42, 671.39, 682.36, 693.33, 704.30, 715.27, 726.24, 737.21, 748.18, 759.11}; // From Evgeny code - gloabl to all modules
+
+  static const int N_phi_binx_XY_R1 = 1152; // from Evgeny code (0 to 2pi)
+  static const int N_phi_binx_XY_R2 = 1536; // from Evgeny code (0 to 2pi)
+  static const int N_phi_binx_XY_R3 = 2304; // from Evgeny code (0 to 2pi)
+
+  TH2 *NorthSideADC_clusterXY_R1 = nullptr;
+  TH2 *NorthSideADC_clusterXY_R2 = nullptr;
+  TH2 *NorthSideADC_clusterXY_R3 = nullptr;
+
+  TH2 *SouthSideADC_clusterXY_R1 = nullptr;
+  TH2 *SouthSideADC_clusterXY_R2 = nullptr;
+  TH2 *SouthSideADC_clusterXY_R3 = nullptr;
+
+
   TH1 *tpchist1 = nullptr;
   TH2 *tpchist2 = nullptr;
   
@@ -55,9 +76,6 @@ class TpcMon : public OnlMon
 
   TH1 *RAWADC_1D_R3= nullptr;
   TH1 *MAXADC_1D_R3 = nullptr;
-
-  TH2 *NorthSideADC_clusterXY = nullptr;
-  TH2 *SouthSideADC_clusterXY = nullptr;
 
   TpcMap M; //declare Martin's map
 

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -330,8 +330,8 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
 
-  TH2 *tpcmon_NSIDEADC[12] = {nullptr};
-  TH2 *tpcmon_SSIDEADC[12] = {nullptr};
+  TH2 *tpcmon_NSIDEADC[24] = {nullptr};
+  TH2 *tpcmon_SSIDEADC[24] = {nullptr};
 
   char TPCMON_STR[100];
   // TPC ADC pie chart
@@ -339,8 +339,8 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   {
     //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
     sprintf(TPCMON_STR,"TPCMON_%i",i);
-    if(i<12){tpcmon_NSIDEADC[i] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC");}
-    else {tpcmon_SSIDEADC[i-12] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC");}
+    tpcmon_NSIDEADC[i] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC");
+    tpcmon_SSIDEADC[i] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC");
   }
 
 
@@ -417,12 +417,13 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   for( int i=0; i<12; i++ )
   {
     if( tpcmon_NSIDEADC[i] ){
+    TC[3]->cd(1);
     gStyle->SetPalette(57); //kBird CVD friendly
     tpcmon_NSIDEADC[i] -> Draw("colpolzsame");
     }
 
   }
-
+  TC[3]->cd(1);
   SS00->Draw("same");
   SS01->Draw("same");
   SS02->Draw("same");
@@ -441,14 +442,15 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
 
   for( int i=0; i<12; i++ )
   {
-    if( tpcmon_SSIDEADC[i] ){
+    if( tpcmon_SSIDEADC[i+12] ){
+    TC[3]->cd(2);
     gStyle->SetPalette(57); //kBird CVD friendly
-    tpcmon_SSIDEADC[i] -> Draw("colpolzsame");
+    tpcmon_SSIDEADC[i+12] -> Draw("colpolzsame");
 
     }
 
   }
-
+  TC[3]->cd(2);
   NS18->Draw("same");
   NS17->Draw("same");
   NS16->Draw("same");
@@ -793,17 +795,24 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
 
-  TH1 *tpcmon_NSTPC_clusXY[12] = {nullptr};
-  TH1 *tpcmon_SSTPC_clusXY[12] = {nullptr};
+  TH1 *tpcmon_NSTPC_clusXY[24][3] = {nullptr};
+  TH1 *tpcmon_SSTPC_clusXY[24][3] = {nullptr};
+
+  dummy_his1_XY = new TH2F("dummy_his1", "(ADC-Pedestal) > 20 North Side", 400, -800, 800, 400, -800, 800); //dummy histos for titles
+  dummy_his2_XY = new TH2F("dummy_his2", "(ADC-Pedestal) > 20 South Side", 400, -800, 800, 400, -800, 800);
 
   char TPCMON_STR[100];
   for( int i=0; i<24; i++ ) 
   {
     //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
     sprintf(TPCMON_STR,"TPCMON_%i",i);
-    if(i<12){tpcmon_NSTPC_clusXY[i]= (TH1*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY");}
-    else{tpcmon_SSTPC_clusXY[i-12]= (TH1*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY");}
+    tpcmon_NSTPC_clusXY[i][0] = (TH1*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R1");
+    tpcmon_NSTPC_clusXY[i][1] = (TH1*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R2");
+    tpcmon_NSTPC_clusXY[i][2] = (TH1*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R3");
 
+    tpcmon_SSTPC_clusXY[i][0] = (TH1*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R1");
+    tpcmon_SSTPC_clusXY[i][1] = (TH1*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R2");
+    tpcmon_SSTPC_clusXY[i][2] = (TH1*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R3");
   }
 
   if (!gROOT->FindObject("TPCClusterXY"))
@@ -813,29 +822,83 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
 
   TC[10]->SetEditable(true);
   TC[10]->Clear("D");
-  TC[10]->cd(1);
 
+  TC[10]->cd(1);
+  dummy_his1_XY->Draw("colzsame");
+
+  float NS_max = 0;
   for( int i=0; i<12; i++ )
   {
-    if( tpcmon_NSTPC_clusXY[i] ){
-    gStyle->SetPalette(57); //kBird CVD friendly
-    tpcmon_NSTPC_clusXY[i] -> Draw("colzsame");
+    for( int j=0; j<3; j++ )
+    {
+      if( tpcmon_NSTPC_clusXY[i][j] )
+      {
+        TC[10]->cd(1);
+        tpcmon_NSTPC_clusXY[i][j] -> Draw("colzsame");
+        if ( tpcmon_NSTPC_clusXY[i][0]->GetBinContent(tpcmon_NSTPC_clusXY[i][j]->GetMaximumBin()) > NS_max)
+        {
+          NS_max = tpcmon_NSTPC_clusXY[i][j]->GetBinContent(tpcmon_NSTPC_clusXY[i][j]->GetMaximumBin());
+          dummy_his1_XY->SetMaximum( NS_max );
+        }
+        gStyle->SetPalette(57); //kBird CVD friendly
+      }
     }
 
   }
 
   TC[10]->cd(2);
+  dummy_his2_XY->Draw("colzsame");
 
+  float SS_max = 0;
   for( int i=0; i<12; i++ )
   {
-    if( tpcmon_SSTPC_clusXY[i] ){
-    gStyle->SetPalette(57); //kBird CVD friendly
-    tpcmon_SSTPC_clusXY[i] -> Draw("colzsame");
+    for( int j=0; j<3; j++ )
+    {
+      if( tpcmon_SSTPC_clusXY[i][j] )
+      {
+        TC[10]->cd(1);
+        tpcmon_SSTPC_clusXY[i][j] -> Draw("colzsame");
+        if ( tpcmon_NSTPC_clusXY[i][j]->GetBinContent(tpcmon_SSTPC_clusXY[i][j]->GetMaximumBin()) > SS_max)
+        {
+          SS_max = tpcmon_SSTPC_clusXY[i][j]->GetBinContent(tpcmon_SSTPC_clusXY[i][j]->GetMaximumBin());
+          dummy_his2_XY->SetMaximum( SS_max );
+        }
+        gStyle->SetPalette(57); //kBird CVD friendly
+      }
     }
 
   }
 
+
   TC[10]->Update();
+/*
+  //dynamically set heat map color scale to start at the minimum and end at the maximum
+  if( tpcmon_NSTPC_clusXY[0][0] && tpcmon_SSTPC_clusXY[0][0] ) //you were able to draw North and South Side
+  {
+    dummy_his1_XY->SetMaximum(TMath::Max(tpcmon_SSTPC_clusXY[0][0]->GetBinContent(tpcmon_SSTPC_clusXY[0][0]->GetMaximumBin()),tpcmon_NSTPC_clusXY[0][0]->GetBinContent(tpcmon_NSTPC_clusXY[0][0]->GetMaximumBin())));
+    dummy_his1_XY->SetMinimum(TMath::Min(tpcmon_SSTPC_clusXY[0][0]->GetBinContent(tpcmon_SSTPC_clusXY[0][0]->GetMinimumBin()),tpcmon_NSTPC_clusXY[0][0]->GetBinContent(tpcmon_NSTPC_clusXY[0][0]->GetMinimumBin())));
+
+    dummy_his2_XY->SetMaximum(TMath::Max(tpcmon_SSTPC_clusXY[0][0]->GetBinContent(tpcmon_SSTPC_clusXY[0][0]->GetMaximumBin()),tpcmon_NSTPC_clusXY[0][0]->GetBinContent(tpcmon_NSTPC_clusXY[0][0]->GetMaximumBin())));
+    dummy_his2_XY->SetMinimum(TMath::Min(tpcmon_SSTPC_clusXY[0][0]->GetBinContent(tpcmon_SSTPC_clusXY[0][0]->GetMinimumBin()),tpcmon_NSTPC_clusXY[0][0]->GetBinContent(tpcmon_NSTPC_clusXY[0][0]->GetMinimumBin())));
+  }
+  else if( tpcmon_NSTPC_clusXY[0][0] ) //only North side
+  {
+    dummy_his1_XY->SetMaximum(tpcmon_NSTPC_clusXY[0][0]->GetBinContent(tpcmon_NSTPC_clusXY[0][0]->GetMaximumBin()));
+    dummy_his1_XY->SetMinimum(tpcmon_NSTPC_clusXY[0][0]->GetBinContent(tpcmon_NSTPC_clusXY[0][0]->GetMinimumBin()));
+
+    dummy_his2_XY->SetMaximum(tpcmon_NSTPC_clusXY[0][0]->GetBinContent(tpcmon_NSTPC_clusXY[0][0]->GetMaximumBin()));
+    dummy_his2_XY->SetMinimum(tpcmon_NSTPC_clusXY[0][0]->GetBinContent(tpcmon_NSTPC_clusXY[0][0]->GetMinimumBin()));
+  }
+  else // South Side Only
+  {
+    dummy_his1_XY->SetMaximum(tpcmon_SSTPC_clusXY[0][0]->GetBinContent(tpcmon_SSTPC_clusXY[0][0]->GetMaximumBin()));
+    dummy_his1_XY->SetMinimum(tpcmon_SSTPC_clusXY[0][0]->GetBinContent(tpcmon_SSTPC_clusXY[0][0]->GetMinimumBin()));
+
+    dummy_his2_XY->SetMaximum(tpcmon_SSTPC_clusXY[0][0]->GetBinContent(tpcmon_SSTPC_clusXY[0][0]->GetMaximumBin()));
+    dummy_his2_XY->SetMinimum(tpcmon_SSTPC_clusXY[0][0]->GetBinContent(tpcmon_SSTPC_clusXY[0][0]->GetMinimumBin()));
+  }
+*/
+
   TC[10]->Show();
   TC[10]->SetEditable(false);
 

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -48,6 +48,10 @@ class TpcMonDraw : public OnlMonDraw
   TH2 *dummy_his1 = nullptr;
   TH2 *dummy_his2 = nullptr;
 
+  //TPC Module
+  TH2 *dummy_his1_XY = nullptr;
+  TH2 *dummy_his2_XY = nullptr;
+
   TPaveLabel* NS18 = nullptr; //North Side labels
   TPaveLabel* NS17 = nullptr;
   TPaveLabel* NS16 = nullptr;


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
subsystems/tpc/TpcMon.cc
subsystems/tpc/TpcMon.h
subsystems/tpc/TpcMonDraw.cc
subsystems/tpc/TpcMonDraw.h

**Changes:**

Fixed bug in 2D event display - XY + added some functionality to have different module binning (not implemented now).

**TODO:**

~~Need to merge histos from each ebdc into the pie chart
Did this for EBDC00 -11 -need to do for EBDC12 - 23
Also need to do this for other histograms (plot one one canvas)~~

Add histos for the following:

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
~~CheckSumError Probability vs FEE*8 + SAMPA~~
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart
Follow up with Christof about index bug in TpcMap.cc (Line 108, should be == 2)

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module