### PR TITLE
Add a delete statement in a loop the probably needed to be there

### DIFF
--- a/subsystems/intt/InttMon.cc
+++ b/subsystems/intt/InttMon.cc
@@ -120,6 +120,8 @@ int InttMon::process_event(Event* evt)
 			}
 			HitMap->AddBinContent(bin);
 		}
+
+		delete p;
 	}
 
 	NumEvents->AddBinContent(1);


### PR DESCRIPTION
Caller is responsible for deleting the packet retrieved from the evt pointer as I understand it, this was in the process_event loop in the server