### PR TITLE
Fixed Possible HCal Memory Leak

### DIFF
--- a/subsystems/hcal/HcalMon.cc
+++ b/subsystems/hcal/HcalMon.cc
@@ -267,8 +267,8 @@ int HcalMon::process_event(Event* e /* evt */)
 
       }  // channel loop
 
-      delete p;
     }  // if packet good
+    delete p;
   } // packet loop
 
   // sector loop


### PR DESCRIPTION
Packet deletion statement was dependent on an "if(p)" statement, meaning the packet was never deleted if it were null, which might have caused the memory leak. The way it's written now is congruent with the EMCal's, which does not see this issue. 