### PR TITLE
use running mean to monitor the packet health, add packet warning

### DIFF
--- a/subsystems/hcal/HcalMon.h
+++ b/subsystems/hcal/HcalMon.h
@@ -57,6 +57,9 @@ class HcalMon : public OnlMon
 
   std::vector<runningMean*> rm_vector_sectAvg;
   std::vector<runningMean*> rm_vector_twr;
+  std::vector<runningMean*> rm_packet_number;
+  std::vector<runningMean*> rm_packet_length;
+  std::vector<runningMean*> rm_packet_chans;
 };
 
 #endif /* HCAL_HCALMON_H */


### PR DESCRIPTION
Now the packet average info are calculated using a running mean with depth 1000, so we won't get less sensitive as event number builds up. Added warning for packet health and event alignment.