### PR TITLE
Fixing bug where only North Side is Drawn on Pie Charts

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -17,9 +17,10 @@ void tpcDrawInit(const int online = 0)
   char TPCMON_STR[100];
   // TPC ADC pie chart
   for( int i=0; i<24; i++ )
+  //for( int i: {15} )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
-    std::cout<<"You registered the NSIDEADC/SSIDEADC "<<i<<" histo"<<std::endl;
+    //std::cout<<"You registered the NSIDEADC/SSIDEADC "<<i<<" histo"<<std::endl;
 
     cl->registerHisto("NorthSideADC", TPCMON_STR);
 
@@ -55,6 +56,7 @@ void tpcDrawInit(const int online = 0)
   // says I know they are all on the same node
 
   for( int i=0; i<24; i++ )
+  //for( int i: {15} )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     cl->requestHistoBySubSystem(TPCMON_STR, 1);
@@ -71,6 +73,7 @@ void tpcDraw(const char *what = "ALL")
   char TPCMON_STR[100];
 
   for( int i=0; i<24; i++ )
+  //for( int i: {15} )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     cl->requestHistoBySubSystem(TPCMON_STR, 1);

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -404,7 +404,7 @@ int TpcMon::process_event(Event *evt/* evt */)
 
           //increment 
           if(serverid >= 0 && serverid < 12 ){ North_Side_Arr[ Index_from_Module(serverid,fee) ] += adc;}
-          else {South_Side_Arr[ Index_from_Module(serverid,fee) ] += adc;}
+          else {South_Side_Arr[ Index_from_Module(serverid,fee)-36 ] += adc;}
 
         } //nr samples
 

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -412,14 +412,14 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   TC[3]->SetEditable(true);
   TC[3]->Clear("D");
   TC[3]->cd(1);
-  dummy_his1->Draw("");
+  dummy_his1->Draw("colpolzsame");
  
   for( int i=0; i<12; i++ )
   {
     if( tpcmon_NSIDEADC[i] ){
     TC[3]->cd(1);
-    gStyle->SetPalette(57); //kBird CVD friendly
     tpcmon_NSIDEADC[i] -> Draw("colpolzsame");
+    gStyle->SetPalette(57); //kBird CVD friendly
     }
 
   }
@@ -438,15 +438,23 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   SS11->Draw("same");
 
   TC[3]->cd(2);
-  dummy_his2->Draw("");
+  dummy_his2->Draw("colpolzsame");
 
+  //float SS_max = 0;
   for( int i=0; i<12; i++ )
   {
     if( tpcmon_SSIDEADC[i+12] ){
+    //std::cout<<"tpcmon_SSIDEADC i: "<< i+12 <<std::endl;
     TC[3]->cd(2);
-    gStyle->SetPalette(57); //kBird CVD friendly
     tpcmon_SSIDEADC[i+12] -> Draw("colpolzsame");
-
+/*
+    if ( tpcmon_SSIDEADC[i+12]->GetBinContent(tpcmon_SSIDEADC[i+12]->GetMaximumBin()) > SS_max)
+      {
+        SS_max = tpcmon_SSIDEADC[i+12]->GetBinContent(tpcmon_SSIDEADC[i+12]->GetMaximumBin());
+        tpcmon_SSIDEADC[i+12]->SetMaximum( SS_max );
+      }
+*/
+    gStyle->SetPalette(57); //kBird CVD friendly
     }
 
   }
@@ -470,7 +478,7 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   //turn off stats box
   dummy_his1->SetStats(0);
   dummy_his2->SetStats(0);
-
+/*
   //dynamically set heat map color scale to start at the minimum and end at the maximum
   if( tpcmon_NSIDEADC[0] && tpcmon_SSIDEADC[0] ) //you were able to draw North and South Side
   {
@@ -496,7 +504,7 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
     dummy_his2->SetMaximum(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMaximumBin()));
     dummy_his2->SetMinimum(tpcmon_SSIDEADC[0]->GetBinContent(tpcmon_SSIDEADC[0]->GetMinimumBin()));
   }
-
+*/
   TC[3]->Show();
   TC[3]->SetEditable(false);
   
@@ -671,7 +679,7 @@ int TpcMonDraw::DrawTPCMaxADCModule(const std::string & /* what */)
 
 int TpcMonDraw::DrawTPCRawADC1D(const std::string & /* what */)
 {
-  std::cout<<"Made it inside DrawTPCRawADC1D"<<std::endl;
+  //std::cout<<"Made it inside DrawTPCRawADC1D"<<std::endl;
   OnlMonClient *cl = OnlMonClient::instance();
 
   TH1 *tpcmon_RAWADC1D[24][3] = {nullptr};
@@ -732,7 +740,7 @@ int TpcMonDraw::DrawTPCRawADC1D(const std::string & /* what */)
 
 int TpcMonDraw::DrawTPCMaxADC1D(const std::string & /* what */)
 {
-  std::cout<<"Made it inside DrawTPCMaxADC1D"<<std::endl;
+  //std::cout<<"Made it inside DrawTPCMaxADC1D"<<std::endl;
   OnlMonClient *cl = OnlMonClient::instance();
 
   TH1 *tpcmon_MAXADC1D[24][3] = {nullptr};
@@ -798,8 +806,8 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
   TH1 *tpcmon_NSTPC_clusXY[24][3] = {nullptr};
   TH1 *tpcmon_SSTPC_clusXY[24][3] = {nullptr};
 
-  dummy_his1_XY = new TH2F("dummy_his1", "(ADC-Pedestal) > 20 North Side", 400, -800, 800, 400, -800, 800); //dummy histos for titles
-  dummy_his2_XY = new TH2F("dummy_his2", "(ADC-Pedestal) > 20 South Side", 400, -800, 800, 400, -800, 800);
+  dummy_his1_XY = new TH2F("dummy_his1_XY", "(ADC-Pedestal) > 20 North Side", 400, -800, 800, 400, -800, 800); //dummy histos for titles
+  dummy_his2_XY = new TH2F("dummy_his2_XY", "(ADC-Pedestal) > 20 South Side", 400, -800, 800, 400, -800, 800);
 
   char TPCMON_STR[100];
   for( int i=0; i<24; i++ ) 
@@ -835,6 +843,7 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
       {
         TC[10]->cd(1);
         tpcmon_NSTPC_clusXY[i][j] -> Draw("colzsame");
+        //gStyle->SetLogz(kTRUE);
         if ( tpcmon_NSTPC_clusXY[i][0]->GetBinContent(tpcmon_NSTPC_clusXY[i][j]->GetMaximumBin()) > NS_max)
         {
           NS_max = tpcmon_NSTPC_clusXY[i][j]->GetBinContent(tpcmon_NSTPC_clusXY[i][j]->GetMaximumBin());
@@ -854,13 +863,15 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
   {
     for( int j=0; j<3; j++ )
     {
-      if( tpcmon_SSTPC_clusXY[i][j] )
+      if( tpcmon_SSTPC_clusXY[i+12][j] )
       {
-        TC[10]->cd(1);
-        tpcmon_SSTPC_clusXY[i][j] -> Draw("colzsame");
-        if ( tpcmon_NSTPC_clusXY[i][j]->GetBinContent(tpcmon_SSTPC_clusXY[i][j]->GetMaximumBin()) > SS_max)
+        //std::cout<<"South Side Custer XY i: "<< i+12 <<", j: "<<j<<std::endl;
+        TC[10]->cd(2);
+        tpcmon_SSTPC_clusXY[i+12][j] -> Draw("colzsame");
+        //gStyle->SetLogz(kTRUE);
+        if ( tpcmon_SSTPC_clusXY[i+12][j]->GetBinContent(tpcmon_SSTPC_clusXY[i+12][j]->GetMaximumBin()) > SS_max)
         {
-          SS_max = tpcmon_SSTPC_clusXY[i][j]->GetBinContent(tpcmon_SSTPC_clusXY[i][j]->GetMaximumBin());
+          SS_max = tpcmon_SSTPC_clusXY[i+12][j]->GetBinContent(tpcmon_SSTPC_clusXY[i+12][j]->GetMaximumBin());
           dummy_his2_XY->SetMaximum( SS_max );
         }
         gStyle->SetPalette(57); //kBird CVD friendly


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
subsystems/tpc/TpcMon.cc
subsystems/tpc/TpcMonDraw.cc

**Changes:**

Fixing bug in TpcMon/MonDraw where only North Side was drawn in pie plots. Now both sides should be drawn.

**TODO:**

~~Need to merge histos from each ebdc into the pie chart
Did this for EBDC00 -11 -need to do for EBDC12 - 23
Also need to do this for other histograms (plot one one canvas)~~

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
~~CheckSumError Probability vs FEE*8 + SAMPA~~
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart
Follow up with Christof about index bug in TpcMap.cc (Line 108, should be == 2)

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
