### PR TITLE
close canvases after saveplot

### DIFF
--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -436,6 +436,16 @@ int OnlMonClient::Draw(const char *who, const char *what)
 int OnlMonClient::SavePlot(const std::string &who, const std::string &what)
 {
   int iret = DoSomething(who, what, "SAVEPLOT");
+  TSeqCollection *allCanvases = gROOT->GetListOfCanvases();
+  TCanvas *canvas = nullptr;
+  while ((canvas = static_cast<TCanvas *>(allCanvases->First())))
+  {
+    if (verbosity > 0)
+    {
+      std::cout << "Deleting Canvas " << canvas->GetName() << std::endl;
+    }
+    delete canvas;
+  }
   //  gSystem->ProcessEvents();
   return iret;
 }


### PR DESCRIPTION
This PR closes all the canvases which pop up during saving the plots, so the shift crew doesn't have to