### PR TITLE
Adding second option for channel draw - unweighted by ADC-pedestal

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -17,7 +17,7 @@ void tpcDrawInit(const int online = 0)
   char TPCMON_STR[100];
   // TPC ADC pie chart
   for( int i=0; i<24; i++ )
-  //for( int i: {15} )
+  //for( int i: {1,20} )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     //std::cout<<"You registered the NSIDEADC/SSIDEADC "<<i<<" histo"<<std::endl;
@@ -28,11 +28,19 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("NorthSideADC_clusterXY_R2", TPCMON_STR);
     cl->registerHisto("NorthSideADC_clusterXY_R3", TPCMON_STR);
 
+    cl->registerHisto("NorthSideADC_clusterXY_R1_unw", TPCMON_STR);
+    cl->registerHisto("NorthSideADC_clusterXY_R2_unw", TPCMON_STR);
+    cl->registerHisto("NorthSideADC_clusterXY_R3_unw", TPCMON_STR);
+
     cl->registerHisto("SouthSideADC", TPCMON_STR);
 
     cl->registerHisto("SouthSideADC_clusterXY_R1", TPCMON_STR);
     cl->registerHisto("SouthSideADC_clusterXY_R2", TPCMON_STR);
     cl->registerHisto("SouthSideADC_clusterXY_R3", TPCMON_STR);
+
+    cl->registerHisto("SouthSideADC_clusterXY_R1_unw", TPCMON_STR);
+    cl->registerHisto("SouthSideADC_clusterXY_R2_unw", TPCMON_STR);
+    cl->registerHisto("SouthSideADC_clusterXY_R3_unw", TPCMON_STR);
 
     cl->registerHisto("sample_size_hist",TPCMON_STR);
     cl->registerHisto("Check_Sum_Error",TPCMON_STR);
@@ -56,7 +64,7 @@ void tpcDrawInit(const int online = 0)
   // says I know they are all on the same node
 
   for( int i=0; i<24; i++ )
-  //for( int i: {15} )
+  //for( int i: {1,20} )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     cl->requestHistoBySubSystem(TPCMON_STR, 1);
@@ -73,7 +81,7 @@ void tpcDraw(const char *what = "ALL")
   char TPCMON_STR[100];
 
   for( int i=0; i<24; i++ )
-  //for( int i: {15} )
+  //for( int i: {1,20} )
   {
     sprintf(TPCMON_STR,"TPCMON_%i",i);
     cl->requestHistoBySubSystem(TPCMON_STR, 1);

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -18,8 +18,10 @@
 #include <TH2.h>
 #include <TMath.h>
 #include <TTree.h>
+#include <TLatex.h>
 
 #include <cmath>
+#include <vector>
 #include <cstdio>  // for printf
 #include <fstream>
 #include <iostream>
@@ -77,37 +79,72 @@ int TpcMon::Init()
   SouthSideADC = new TH2F("SouthSideADC" , "ADC Counts South Side", N_thBins, -TMath::Pi()/12. , 23.*TMath::Pi()/12. , N_rBins , rBin_edges );
   //
 
-  //TPC "cluster" XY heat maps
+  //TPC "cluster" XY heat maps WEIGHTED
   //NorthSideADC_clusterXY_R1 = new TH2F("NorthSideADC_clusterXY_R1" , "ADC Peaks North Side", N_phi_binx_XY_R1, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
-  NorthSideADC_clusterXY_R1 = new TH2F("NorthSideADC_clusterXY_R1" , "(ADC-Pedestal) > 20 North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R1 = new TH2F("NorthSideADC_clusterXY_R1" , "(ADC-Pedestal) > 7#sigma North Side", 400, -800, 800, 400, -800, 800);
   NorthSideADC_clusterXY_R1->SetXTitle("X [mm]");
   NorthSideADC_clusterXY_R1->SetYTitle("Y [mm]");
 
   //NorthSideADC_clusterXY_R2 = new TH2F("NorthSideADC_clusterXY_R2" , "ADC Peaks North Side", N_phi_binx_XY_R2, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
-  NorthSideADC_clusterXY_R2 = new TH2F("NorthSideADC_clusterXY_R2" , "(ADC-Pedestal) > 20 North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R2 = new TH2F("NorthSideADC_clusterXY_R2" , "(ADC-Pedestal) > 7#sigma North Side", 400, -800, 800, 400, -800, 800);
   NorthSideADC_clusterXY_R2->SetXTitle("X [mm]");
   NorthSideADC_clusterXY_R2->SetYTitle("Y [mm]");
 
   //NorthSideADC_clusterXY_R3 = new TH2F("NorthSideADC_clusterXY_R3" , "ADC Peaks North Side", N_phi_binx_XY_R3, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
-  NorthSideADC_clusterXY_R3 = new TH2F("NorthSideADC_clusterXY_R3" , "(ADC-Pedestal) > 20 North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R3 = new TH2F("NorthSideADC_clusterXY_R3" , "(ADC-Pedestal) > 7#sigma North Side", 400, -800, 800, 400, -800, 800);
   NorthSideADC_clusterXY_R3->SetXTitle("X [mm]");
   NorthSideADC_clusterXY_R3->SetYTitle("Y [mm]");
 
 
   //SouthSideADC_clusterXY_R1 = new TH2F("SouthSideADC_clusterXY_R1" , "ADC Peaks South Side", N_phi_binx_XY_R1, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
-  SouthSideADC_clusterXY_R1 = new TH2F("SouthSideADC_clusterXY_R1" , "(ADC-Pedestal) > 20 South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R1 = new TH2F("SouthSideADC_clusterXY_R1" , "(ADC-Pedestal) >7#sigma South Side", 400, -800, 800, 400, -800, 800);
   SouthSideADC_clusterXY_R1->SetXTitle("X [mm]");
   SouthSideADC_clusterXY_R1->SetYTitle("Y [mm]");
 
   //SouthSideADC_clusterXY_R2 = new TH2F("SouthSideADC_clusterXY_R2" , "ADC Peaks South Side", N_phi_binx_XY_R2, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
-  SouthSideADC_clusterXY_R2 = new TH2F("SouthSideADC_clusterXY_R2" , "(ADC-Pedestal) > 20 South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R2 = new TH2F("SouthSideADC_clusterXY_R2" , "(ADC-Pedestal) > 7#sigma South Side", 400, -800, 800, 400, -800, 800);
   SouthSideADC_clusterXY_R2->SetXTitle("X [mm]");
   SouthSideADC_clusterXY_R2->SetYTitle("Y [mm]");
 
   //SouthSideADC_clusterXY_R3 = new TH2F("SouthSideADC_clusterXY_R3" , "ADC Peaks South Side", N_phi_binx_XY_R3, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);  
-  SouthSideADC_clusterXY_R3 = new TH2F("SouthSideADC_clusterXY_R3" , "(ADC-Pedestal) > 20 South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R3 = new TH2F("SouthSideADC_clusterXY_R3" , "(ADC-Pedestal) > 7#sigma South Side", 400, -800, 800, 400, -800, 800);
   SouthSideADC_clusterXY_R3->SetXTitle("X [mm]");
   SouthSideADC_clusterXY_R3->SetYTitle("Y [mm]");
+
+  //____________________________________________________________________//
+
+  //TPC "cluster" XY heat maps UNWEIGHTED
+  //NorthSideADC_clusterXY_R1 = new TH2F("NorthSideADC_clusterXY_R1" , "ADC Peaks North Side", N_phi_binx_XY_R1, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  NorthSideADC_clusterXY_R1_unw = new TH2F("NorthSideADC_clusterXY_R1_unw" , "(ADC-Pedestal) > 7#sigma North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R1_unw->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R1_unw->SetYTitle("Y [mm]");
+
+  //NorthSideADC_clusterXY_R2 = new TH2F("NorthSideADC_clusterXY_R2" , "ADC Peaks North Side", N_phi_binx_XY_R2, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  NorthSideADC_clusterXY_R2_unw = new TH2F("NorthSideADC_clusterXY_R2_unw" , "(ADC-Pedestal) > 7#sigma North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R2_unw->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R2_unw->SetYTitle("Y [mm]");
+
+  //NorthSideADC_clusterXY_R3 = new TH2F("NorthSideADC_clusterXY_R3" , "ADC Peaks North Side", N_phi_binx_XY_R3, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  NorthSideADC_clusterXY_R3_unw = new TH2F("NorthSideADC_clusterXY_R3_unw" , "(ADC-Pedestal) > 7#sigma North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R3_unw->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R3_unw->SetYTitle("Y [mm]");
+
+
+  //SouthSideADC_clusterXY_R1 = new TH2F("SouthSideADC_clusterXY_R1" , "ADC Peaks South Side", N_phi_binx_XY_R1, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  SouthSideADC_clusterXY_R1_unw = new TH2F("SouthSideADC_clusterXY_R1_unw" , "(ADC-Pedestal) >7#sigma South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R1_unw->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R1_unw->SetYTitle("Y [mm]");
+
+  //SouthSideADC_clusterXY_R2 = new TH2F("SouthSideADC_clusterXY_R2" , "ADC Peaks South Side", N_phi_binx_XY_R2, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  SouthSideADC_clusterXY_R2_unw = new TH2F("SouthSideADC_clusterXY_R2_unw" , "(ADC-Pedestal) > 7#sigma South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R2_unw->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R2_unw->SetYTitle("Y [mm]");
+
+  //SouthSideADC_clusterXY_R3 = new TH2F("SouthSideADC_clusterXY_R3" , "ADC Peaks South Side", N_phi_binx_XY_R3, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);  
+  SouthSideADC_clusterXY_R3_unw = new TH2F("SouthSideADC_clusterXY_R3_unw" , "(ADC-Pedestal) > 7#sigma South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R3_unw->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R3_unw->SetYTitle("Y [mm]");
+
   //
 
   // ADC vs Sample
@@ -243,6 +280,14 @@ int TpcMon::Init()
   se->registerHisto(this, SouthSideADC_clusterXY_R2);
   se->registerHisto(this, SouthSideADC_clusterXY_R3);
 
+  se->registerHisto(this, NorthSideADC_clusterXY_R1_unw);
+  se->registerHisto(this, NorthSideADC_clusterXY_R2_unw);
+  se->registerHisto(this, NorthSideADC_clusterXY_R3_unw);
+
+  se->registerHisto(this, SouthSideADC_clusterXY_R1_unw);
+  se->registerHisto(this, SouthSideADC_clusterXY_R2_unw);
+  se->registerHisto(this, SouthSideADC_clusterXY_R3_unw);
+
   Reset();
   return 0;
 }
@@ -282,6 +327,7 @@ int TpcMon::process_event(Event *evt/* evt */)
   float South_Side_Arr[36] = {0};
 
   std::vector<int> store_ten; 
+  std::vector<int> mean_and_stdev_vec;
 
   for( int packet = 4000; packet < 4232; packet++) //packet 4000 or 4001 = Sec 00, packet 4230 or 4231 = Sec 23
   {
@@ -353,18 +399,30 @@ int TpcMon::process_event(Event *evt/* evt */)
 
         int mid = floor(nr_Samples/2); //get median sample
 
-        int pedestal;
-        pedestal = (p->iValue(wf,0) + p->iValue(wf,1) + p->iValue(wf,2) + p->iValue(wf,3) + p->iValue(wf,4))/5 ; //(assumes sample is > 4)
+        if( nr_Samples > 9)
+        {
+          if( (p->iValue(wf,mid) == p->iValue(wf,mid-1)) && (p->iValue(wf,mid) == p->iValue(wf,mid-2)) && (p->iValue(wf,mid) == p->iValue(wf,mid+1)) && (p->iValue(wf,mid) == p->iValue(wf,mid+2)) )     
+          {
+            is_channel_stuck = 1;
+          }
+          for( int si=0;si < 10; si++ ) //get pedestal and noise before hand
+          {
+            mean_and_stdev_vec.push_back(p->iValue(wf,si));
+          }
+        } //Compare 5 values to determine stuck !!
 
-        if( nr_Samples > 5){if( (p->iValue(wf,mid) == p->iValue(wf,mid-1)) && (p->iValue(wf,mid) == p->iValue(wf,mid-2)) && (p->iValue(wf,mid) == p->iValue(wf,mid+1)) && (p->iValue(wf,mid) == p->iValue(wf,mid+2)) ){ is_channel_stuck = 1;};} //Compare 5 values to determine stuck !!
+        std::pair<float, float> result = calculateMeanAndStdDev(mean_and_stdev_vec);
+        int pedestal = result.first; //average/pedestal
+        int noise = result.second; //stdev/noise
 
         int wf_max = 0;
 
-        for( int s =0; s < nr_Samples ; s++ ){
+        for( int s =0; s < nr_Samples ; s++ )
+        {
           
           //int t = s + 2 * (current_BCO - starting_BCO);
 
-          int adc = p->iValue(wf,s);          
+          int adc = p->iValue(wf,s);       
 
           if( adc > wf_max){ wf_max = adc; }
 
@@ -410,23 +468,26 @@ int TpcMon::process_event(Event *evt/* evt */)
 
         //for complicated XY stuff ____________________________________________________
         //20 = 3-5 * sigma - hard-coded
-        if( serverid < 12 && (wf_max - pedestal) > 20)
+        if( serverid < 12 && (wf_max - pedestal) > 7*noise)
         {
-          if(Module_ID(fee)==0){NorthSideADC_clusterXY_R1->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R1
-          else if(Module_ID(fee)==1){NorthSideADC_clusterXY_R2->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R2
-          else if(Module_ID(fee)==2){NorthSideADC_clusterXY_R3->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R3
+          if(Module_ID(fee)==0){NorthSideADC_clusterXY_R1->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);NorthSideADC_clusterXY_R1_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R1
+          else if(Module_ID(fee)==1){NorthSideADC_clusterXY_R2->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);NorthSideADC_clusterXY_R2_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R2
+          else if(Module_ID(fee)==2){NorthSideADC_clusterXY_R3->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);NorthSideADC_clusterXY_R3_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R3
         }
-        else if( serverid >=12 && (wf_max - pedestal) > 20)
+        else if( serverid >=12 && (wf_max - pedestal) > 7*noise)
         {
-          if(Module_ID(fee)==0){SouthSideADC_clusterXY_R1->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R1
-          else if(Module_ID(fee)==1){SouthSideADC_clusterXY_R2->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R2
-          else if(Module_ID(fee)==2){SouthSideADC_clusterXY_R3->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);} //Raw 1D for R3
+          if(Module_ID(fee)==0){SouthSideADC_clusterXY_R1->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);SouthSideADC_clusterXY_R1_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R1
+          else if(Module_ID(fee)==1){SouthSideADC_clusterXY_R2->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);SouthSideADC_clusterXY_R2_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R2
+          else if(Module_ID(fee)==2){SouthSideADC_clusterXY_R3->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);SouthSideADC_clusterXY_R3_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R3
         }
         //________________________________________________________________________________
 
         is_channel_stuck = 0; //reset after looping through waveform samples
 
         store_ten.clear(); //clear this after every waveform
+        
+        mean_and_stdev_vec.clear(); //clear this after every waveform
+
 
       } //nr waveforms
       delete p;
@@ -544,6 +605,27 @@ bool TpcMon::side(int server_id)
   
   return side_id;
 }
+
+std::pair<float, float> TpcMon::calculateMeanAndStdDev(const std::vector<int>& values) {
+    // Calculate the mean
+    float sum = 0.0;
+    for (const auto& value : values) {
+        sum += value;
+    }
+    float mean = sum / values.size();
+
+    // Calculate the standard deviation
+    float squaredSum = 0.0;
+    for (const auto& value : values) {
+        double diff = value - mean;
+        squaredSum += diff * diff;
+    }
+    float variance = squaredSum / values.size();
+    float stdDev = std::sqrt(variance);
+
+    return std::make_pair(mean, stdDev);
+}
+
 
 
 int TpcMon::Reset()

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -7,6 +7,8 @@
 #include <tpc/TpcMap.h> //this needs to be pointed to coresoftware - not sure how to do that on EBDCXX...
 #include <memory>
 #include <string>
+#include <cmath>
+#include <vector>
 
 
 class Event;
@@ -53,6 +55,14 @@ class TpcMon : public OnlMon
   TH2 *SouthSideADC_clusterXY_R2 = nullptr;
   TH2 *SouthSideADC_clusterXY_R3 = nullptr;
 
+  TH2 *NorthSideADC_clusterXY_R1_unw = nullptr;
+  TH2 *NorthSideADC_clusterXY_R2_unw = nullptr;
+  TH2 *NorthSideADC_clusterXY_R3_unw = nullptr;
+
+  TH2 *SouthSideADC_clusterXY_R1_unw = nullptr;
+  TH2 *SouthSideADC_clusterXY_R2_unw = nullptr;
+  TH2 *SouthSideADC_clusterXY_R3_unw = nullptr;
+
 
   TH1 *tpchist1 = nullptr;
   TH2 *tpchist2 = nullptr;
@@ -90,6 +100,7 @@ class TpcMon : public OnlMon
   int Module_ID(int fee_id);
   int Max_Nine(int one, int two, int three, int four, int five, int six, int seven, int eight, int nine);
   bool side(int server_id);
+  std::pair<float, float> calculateMeanAndStdDev(const std::vector<int>& values);
 };
 
 #endif /* TPC_TPCMON_H */

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -17,6 +17,7 @@
 #include <TStyle.h>
 #include <TString.h>
 #include <TLegend.h>
+#include <TLatex.h>
 
 #include <cstring>  // for memset
 #include <ctime>
@@ -171,7 +172,7 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
   }
   else if (name == "TPCClusterXY")
   {
-    TC[10] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)>20 for NS and SS", 1350, 700);
+    TC[10] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)>7#sigma for NS and SS, WEIGHTED", 1350, 700);
     gSystem->ProcessEvents();
     //gStyle->SetPalette(57); //kBird CVD friendly
     TC[10]->Divide(2,1);
@@ -181,6 +182,19 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     transparent[9]->Draw();
     TC[10]->SetEditable(false);
   }
+  else if (name == "TPCClusterXY_unw")
+  {
+    TC[11] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)>7#sigma for NS and SS, UNWEIGHTED", 1350, 700);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[11]->Divide(2,1);
+    // this one is used to plot the run number on the canvas
+    transparent[10] = new TPad("transparent10", "this does not show", 0, 0, 1, 1);
+    transparent[10]->SetFillStyle(4000);
+    transparent[10]->Draw();
+    TC[11]->SetEditable(false);
+  }
+  
   
   return 0;
 }
@@ -234,9 +248,14 @@ int TpcMonDraw::Draw(const std::string &what)
     iret += DrawTPCMaxADC1D(what);
     idraw++;
   }
-  if (what == "ALL" || what == "TPCCLUSTERSXY")
+  if (what == "ALL" || what == "TPCCLUSTERSXYWEIGTHED")
   {
     iret += DrawTPCXYclusters(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCCLUSTERSXYUNWEIGTHED")
+  {
+    iret += DrawTPCXYclusters_unweighted(what);
     idraw++;
   }
   if (!idraw)
@@ -918,8 +937,8 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
   TH1 *tpcmon_NSTPC_clusXY[24][3] = {nullptr};
   TH1 *tpcmon_SSTPC_clusXY[24][3] = {nullptr};
 
-  dummy_his1_XY = new TH2F("dummy_his1_XY", "(ADC-Pedestal) > 20 North Side", 400, -800, 800, 400, -800, 800); //dummy histos for titles
-  dummy_his2_XY = new TH2F("dummy_his2_XY", "(ADC-Pedestal) > 20 South Side", 400, -800, 800, 400, -800, 800);
+  dummy_his1_XY = new TH2F("dummy_his1_XY", "(ADC-Pedestal) > 7#sigma North Side, WEIGHTED", 400, -800, 800, 400, -800, 800); //dummy histos for titles
+  dummy_his2_XY = new TH2F("dummy_his2_XY", "(ADC-Pedestal) > 7#sigma South Side, WEIGHTED", 400, -800, 800, 400, -800, 800);
 
   char TPCMON_STR[100];
   for( int i=0; i<24; i++ ) 
@@ -952,7 +971,7 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
   std::string runstring;
   time_t evttime = getTime();// cl->EventTime("CURRENT"); 
   // fill run number and event time into string
-  runnostream << ThisName << "_ADC-Pedestal>20 Run " << cl->RunNumber()
+  runnostream << ThisName << "_ADC-Pedestal>7*sigma Run, WEIGHTED " << cl->RunNumber()
               << ", Time: " << ctime(&evttime);
   runstring = runnostream.str();
   transparent[9]->cd();
@@ -960,6 +979,7 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
 
   TC[10]->cd(1);
   gPad->SetTopMargin(0.15);
+  gPad->SetLogz(kTRUE);
   dummy_his1_XY->Draw("colzsame");
 
   float NS_max = 0;
@@ -986,6 +1006,7 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
 
   TC[10]->cd(2);
   gPad->SetTopMargin(0.15);
+  gPad->SetLogz(kTRUE);
   dummy_his2_XY->Draw("colzsame");
 
   float SS_max = 0;
@@ -1014,6 +1035,115 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
   TC[10]->Update();
   TC[10]->Show();
   TC[10]->SetEditable(false);
+
+  return 0;
+}
+
+int TpcMonDraw::DrawTPCXYclusters_unweighted(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH1 *tpcmon_NSTPC_clusXY[24][3] = {nullptr};
+  TH1 *tpcmon_SSTPC_clusXY[24][3] = {nullptr};
+
+  dummy_his1_XY_unw = new TH2F("dummy_his1_XY_unw", "(ADC-Pedestal) > 7#sigma North Side, UNWEIGHTED", 400, -800, 800, 400, -800, 800); //dummy histos for titles
+  dummy_his2_XY_unw = new TH2F("dummy_his2_XY_unw", "(ADC-Pedestal) > 7#sigma South Side, UNWEIGHTED", 400, -800, 800, 400, -800, 800);
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_NSTPC_clusXY[i][0] = (TH1*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R1_unw");
+    tpcmon_NSTPC_clusXY[i][1] = (TH1*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R2_unw");
+    tpcmon_NSTPC_clusXY[i][2] = (TH1*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R3_unw");
+
+    tpcmon_SSTPC_clusXY[i][0] = (TH1*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R1_unw");
+    tpcmon_SSTPC_clusXY[i][1] = (TH1*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R2_unw");
+    tpcmon_SSTPC_clusXY[i][2] = (TH1*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R3_unw");
+  }
+
+  if (!gROOT->FindObject("TPCClusterXY_unw"))
+  {
+    MakeCanvas("TPCClusterXY_unw");
+  }  
+
+  TC[11]->SetEditable(true);
+  TC[11]->Clear("D");
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = getTime();// cl->EventTime("CURRENT"); 
+  // fill run number and event time into string
+  runnostream << ThisName << "_ADC-Pedestal>7*sigma Run, UNWEIGHTED " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  transparent[10]->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+  TC[11]->cd(1);
+  gPad->SetTopMargin(0.15);
+  //gPad->SetLogz(kTRUE);
+  dummy_his1_XY_unw->Draw("colzsame");
+
+  float NS_max = 0;
+  for( int i=0; i<12; i++ )
+  {
+    for( int j=0; j<3; j++ )
+    {
+      if( tpcmon_NSTPC_clusXY[i][j] )
+      {
+        TC[11]->cd(1);
+        tpcmon_NSTPC_clusXY[i][j] -> Draw("colzsame");
+        //gStyle->SetLogz(kTRUE);
+        if ( tpcmon_NSTPC_clusXY[i][0]->GetBinContent(tpcmon_NSTPC_clusXY[i][j]->GetMaximumBin()) > NS_max)
+        {
+          NS_max = tpcmon_NSTPC_clusXY[i][j]->GetBinContent(tpcmon_NSTPC_clusXY[i][j]->GetMaximumBin());
+          dummy_his1_XY_unw->SetMaximum( NS_max );
+        }
+        gStyle->SetPalette(57); //kBird CVD friendly
+      }
+    }
+
+  }
+  TC[11]->Update();
+
+  TC[11]->cd(2);
+  gPad->SetTopMargin(0.15);
+  dummy_his2_XY_unw->Draw("colzsame");
+  //gPad->SetLogz(kTRUE);
+
+  float SS_max = 0;
+  for( int i=0; i<12; i++ )
+  {
+    for( int j=0; j<3; j++ )
+    {
+      if( tpcmon_SSTPC_clusXY[i+12][j] )
+      {
+        //std::cout<<"South Side Custer XY i: "<< i+12 <<", j: "<<j<<std::endl;
+        TC[11]->cd(2);
+        tpcmon_SSTPC_clusXY[i+12][j] -> Draw("colzsame");
+        //gStyle->SetLogz(kTRUE);
+        if ( tpcmon_SSTPC_clusXY[i+12][j]->GetBinContent(tpcmon_SSTPC_clusXY[i+12][j]->GetMaximumBin()) > SS_max)
+        {
+          SS_max = tpcmon_SSTPC_clusXY[i+12][j]->GetBinContent(tpcmon_SSTPC_clusXY[i+12][j]->GetMaximumBin());
+          dummy_his2_XY_unw->SetMaximum( SS_max );
+        }
+        gStyle->SetPalette(57); //kBird CVD friendly
+      }
+    }
+
+  }
+
+
+  TC[11]->Update();
+  TC[11]->Show();
+  TC[11]->SetEditable(false);
 
   return 0;
 }

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -35,10 +35,11 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCRawADC1D(const std::string &what = "ALL");
   int DrawTPCMaxADC1D(const std::string &what = "ALL");
   int DrawTPCXYclusters(const std::string &what = "ALL");
+  int DrawTPCXYclusters_unweighted(const std::string &what = "ALL");
   time_t getTime();
   
-  TCanvas *TC[11] = {nullptr};
-  TPad *transparent[10] = {nullptr};
+  TCanvas *TC[12] = {nullptr};
+  TPad *transparent[11] = {nullptr};
   TPad *Pad[8] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module
@@ -48,6 +49,9 @@ class TpcMonDraw : public OnlMonDraw
   //TPC Module
   TH2 *dummy_his1_XY = nullptr;
   TH2 *dummy_his2_XY = nullptr;
+
+  TH2 *dummy_his1_XY_unw = nullptr;
+  TH2 *dummy_his2_XY_unw = nullptr;
 
   TPaveLabel* NS18 = nullptr; //North Side labels
   TPaveLabel* NS17 = nullptr;


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
subsystems/tpc/TpcMon.cc
subsystems/tpc/TpcMon.h
subsystems/tpc/TpcMonDraw.cc
subsystems/tpc/TpcMonDraw.h

**Changes:**

Adding another option for the channel X-Y plot, make it unweighted and linear scale. Also basing Fill threshold on 7 sigma above pedestal rather than a fixed 20 ADC. Sigma is evaluated on channel x channel basis. 

**TODO:**

~~Need to merge histos from each ebdc into the pie chart
Did this for EBDC00 -11 -need to do for EBDC12 - 23
Also need to do this for other histograms (plot one one canvas)~~

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
~~CheckSumError Probability vs FEE*8 + SAMPA~~
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart
Follow up with Christof about index bug in TpcMap.cc (Line 108, should be == 2)

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
