### PR TITLE
print message when trying to connect

### DIFF
--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -1056,6 +1056,7 @@ int OnlMonClient::UpdateServerHistoMap(const std::string &hname, const std::stri
   int foundit = 0;
   do
   {
+    std::cout << "Connecting to " << hostname << ", if it is frozen here - this is the one you need to restart" << std::endl;
     TSocket sock(hostname.c_str(), MoniPort);
     TMessage *mess;
     if (verbosity > 0)


### PR DESCRIPTION
This PR adds a printout when the client tries to connect to a server with a hint to restart it if it is stuck here. This should take out the guesswork
Connecting to seb16, if it is frozen here - this is the one you need to restart
