### PR TITLE
Fixing SS drawing issue in XY plots and suppressing antenna drawing

### DIFF
--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -393,7 +393,20 @@ int TpcMon::process_event(Event *evt/* evt */)
 
         // getting R and Phi coordinates
         double R = M.getR(feeM, channel);
-        double phi = M.getPhi(feeM, channel) + (serverid - 12*side(serverid)) * M_PI / 6 ;
+        int layer = M.getLayer(feeM, channel);
+        double phi = 0;
+
+        //double phi = M.getPhi(feeM, channel) + (serverid - 12*side(serverid)) * M_PI / 6 ;
+
+        if( side(serverid) == 0 ) //NS
+        {
+          phi = M.getPhi(feeM, channel) + (serverid ) * M_PI / 6 ; 
+        }
+        else if( side(serverid) == 1 ) //SS
+        {
+          phi = M.getPhi(feeM, channel) + (18 - serverid ) * M_PI / 6 ; 
+        }
+
 
         //std::cout<<"Sector = "<< serverid <<" FEE = "<<fee<<" channel = "<<channel<<std::endl;
 
@@ -468,13 +481,13 @@ int TpcMon::process_event(Event *evt/* evt */)
 
         //for complicated XY stuff ____________________________________________________
         //20 = 3-5 * sigma - hard-coded
-        if( serverid < 12 && (wf_max - pedestal) > 20)
+        if( (serverid < 12 && (wf_max - pedestal) > 20) && layer != 0 )
         {
           if(Module_ID(fee)==0){NorthSideADC_clusterXY_R1->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);NorthSideADC_clusterXY_R1_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R1
           else if(Module_ID(fee)==1){NorthSideADC_clusterXY_R2->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);NorthSideADC_clusterXY_R2_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R2
           else if(Module_ID(fee)==2){NorthSideADC_clusterXY_R3->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);NorthSideADC_clusterXY_R3_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R3
         }
-        else if( serverid >=12 && (wf_max - pedestal) > 20)
+        else if( (serverid >=12 && (wf_max - pedestal) > 20) && layer != 0)
         {
           if(Module_ID(fee)==0){SouthSideADC_clusterXY_R1->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);SouthSideADC_clusterXY_R1_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R1
           else if(Module_ID(fee)==1){SouthSideADC_clusterXY_R2->Fill(R*cos(phi),R*sin(phi),wf_max - pedestal);SouthSideADC_clusterXY_R2_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R2


### PR DESCRIPTION
**Files Affected:**

subsystems/tpc/TpcMon.cc

**Changes:**

Previously SS XY plots drew the channels in the wrong phi coordinates. They started with 12 at phi = 0 and increased ccw. They should be starting with 12 at phi = 180 and increasing cw. This is now done. Additionally added a code snippet from Evgeny that suppresses drawing the antennas at layer 0.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart
Follow up with Christof about index bug in TpcMap.cc (Line 108, should be == 2)

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module