### PR TITLE
m_MonitorFetchedSet needs to be cleared when new subsystem is requested

### DIFF
--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -209,6 +209,15 @@ void OnlMonClient::registerHisto(const std::string &hname, const std::string &su
 
 int OnlMonClient::requestHistoBySubSystem(const std::string &subsys, int getall)
 {
+  std::string mysubsys = subsys.substr(0,subsys.find('_'));
+  for (auto frwrkiter : m_MonitorFetchedSet)
+  {
+    if (frwrkiter.find(mysubsys) == std::string::npos)
+      {
+	m_MonitorFetchedSet.clear();
+	break;
+      }
+  }
   int iret = 0;
   std::map<const std::string, ClientHistoList *>::const_iterator histoiter;
   std::map<const std::string, ClientHistoList *>::const_iterator histonewiter;


### PR DESCRIPTION
This PR fixes the problem with the run number propagating from one system to another