### PR TITLE
Making SampleSize monitor have Logy axes for each sector

### DIFF
--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -576,6 +576,7 @@ int TpcMonDraw::DrawTPCSampleSize(const std::string & /* what */)
       TC[4]->cd(i+5);
       tpcmon_samplesizedist[i]->DrawCopy("");
       gPad->SetLogx(kTRUE);
+      gPad->SetLogy(kTRUE);
     }
   }
 


### PR DESCRIPTION
**Files Affected:**

subsystems/tpc/TpcMonDraw.cc

**Changes:**

Added 1 line to make Sample Size histograms have logarithmic scale on their y axes for each sector.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart
Follow up with Christof about index bug in TpcMap.cc (Line 108, should be == 2)

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module