### PR TITLE
Tpot ref histograms

### DIFF
--- a/subsystems/tpot/TpotMonDraw.cc
+++ b/subsystems/tpot/TpotMonDraw.cc
@@ -268,8 +268,7 @@ int TpotMonDraw::Draw(const std::string &what)
 
   {
     // get counters
-    const auto cl = OnlMonClient::instance();
-    const auto m_counters = cl->getHisto("TPOTMON_0","m_counters");
+    const auto m_counters = get_histogram( "m_counters");
     if( m_counters && Verbosity() )
     {
       const int events = m_counters->GetBinContent( TpotMonDefs::kEventCounter );
@@ -493,8 +492,7 @@ int TpotMonDraw::draw_counters()
   if( Verbosity() ) std::cout << "TpotMonDraw::draw_counters" << std::endl;
 
   // get histograms
-  auto cl = OnlMonClient::instance();
-  auto m_counters =  cl->getHisto("TPOTMON_0","m_counters");
+  auto m_counters =  get_histogram( "m_counters");
 
   auto cv = get_canvas("TPOT_counters");
   auto transparent = get_transparent_pad( cv, "TPOT_counters");
@@ -527,9 +525,8 @@ int TpotMonDraw::draw_detector_occupancy()
   if( Verbosity() ) std::cout << "TpotMonDraw::draw_detector_occupancy" << std::endl;
 
   // get histograms
-  auto cl = OnlMonClient::instance();
-  auto m_detector_occupancy_phi =  cl->getHisto("TPOTMON_0","m_detector_occupancy_phi");
-  auto m_detector_occupancy_z =  cl->getHisto("TPOTMON_0","m_detector_occupancy_z");
+  auto m_detector_occupancy_phi =  get_histogram( "m_detector_occupancy_phi");
+  auto m_detector_occupancy_z =  get_histogram( "m_detector_occupancy_z");
 
   for( const auto& h:{m_detector_occupancy_phi,m_detector_occupancy_z} )
   { h->SetStats(0); }
@@ -576,9 +573,8 @@ int TpotMonDraw::draw_resist_occupancy()
   if( Verbosity() ) std::cout << "TpotMonDraw::draw_resist_occupancy" << std::endl;
 
   // get histograms
-  auto cl = OnlMonClient::instance();
-  auto m_resist_occupancy_phi =  cl->getHisto("TPOTMON_0","m_resist_occupancy_phi");
-  auto m_resist_occupancy_z =  cl->getHisto("TPOTMON_0","m_resist_occupancy_z");
+  auto m_resist_occupancy_phi =  get_histogram( "m_resist_occupancy_phi");
+  auto m_resist_occupancy_z =  get_histogram( "m_resist_occupancy_z");
   for( const auto& h:{m_resist_occupancy_phi,m_resist_occupancy_z} )
   { h->SetStats(0); }
 
@@ -634,16 +630,21 @@ void TpotMonDraw::draw_detnames_sphenix( const std::string& suffix)
 }
 
 //__________________________________________________________________________________
+TH1* TpotMonDraw::get_histogram( const std::string& name )
+{
+  auto cl = OnlMonClient::instance();
+  return cl->getHisto("TPOTMON_0", name );
+}
+
+//__________________________________________________________________________________
 TpotMonDraw::histogram_array_t TpotMonDraw::get_histograms( const std::string& name )
 {
   histogram_array_t out{{nullptr}};
-
-  auto cl = OnlMonClient::instance();
   for( size_t i=0; i<m_detnames_sphenix.size(); ++i)
   {
     const auto& detector_name=m_detnames_sphenix[i];
     const auto hname = name + "_" + detector_name;
-    out[i] =  cl->getHisto("TPOTMON_0", hname );
+    out[i] =  get_histogram(  hname );
     if( Verbosity() )
     { std::cout << "TpotMonDraw::get_histograms - " << hname << (out[i]?" found":" not found" ) << std::endl; }
   }

--- a/subsystems/tpot/TpotMonDraw.h
+++ b/subsystems/tpot/TpotMonDraw.h
@@ -69,6 +69,12 @@ class TpotMonDraw : public OnlMonDraw
   /// get detector dependent histogram array from base name
   histogram_array_t get_histograms( const std::string& name );  
 
+  /// get histogram by name
+  TH1* get_ref_histogram( const std::string& name );  
+
+  /// get detector dependent histogram array from base name
+  histogram_array_t get_ref_histograms( const std::string& name );  
+
   /// draw histogram array
   int draw_array( const std::string& name, const histogram_array_t&, unsigned int /*option*/ = DrawOptions::None );
   
@@ -93,6 +99,9 @@ class TpotMonDraw : public OnlMonDraw
   
   // sample window
   sample_window_t m_sample_window_signal = {20, 40};
+  
+  // reference histograms filename
+  std::string m_ref_histograms_filename;
   
   // reference histograms TFile
   std::unique_ptr<TFile> m_ref_histograms_tfile;

--- a/subsystems/tpot/TpotMonDraw.h
+++ b/subsystems/tpot/TpotMonDraw.h
@@ -7,6 +7,8 @@
 #include <micromegas/MicromegasMapping.h>
 #include <onlmon/OnlMonDraw.h>
 
+#include <TFile.h>
+
 #include <array>
 #include <memory>
 #include <string>  
@@ -61,6 +63,9 @@ class TpotMonDraw : public OnlMonDraw
     Colz = 1<<3
   };
   
+  /// get histogram by name
+  TH1* get_histogram( const std::string& name );  
+
   /// get detector dependent histogram array from base name
   histogram_array_t get_histograms( const std::string& name );  
 
@@ -88,6 +93,9 @@ class TpotMonDraw : public OnlMonDraw
   
   // sample window
   sample_window_t m_sample_window_signal = {20, 40};
+  
+  // reference histograms TFile
+  std::unique_ptr<TFile> m_ref_histograms_tfile;
   
   // canvases
   std::vector<TCanvas*> m_canvas;

--- a/subsystems/tpot/TpotMonDraw.h
+++ b/subsystems/tpot/TpotMonDraw.h
@@ -64,17 +64,27 @@ class TpotMonDraw : public OnlMonDraw
   };
   
   /// get histogram by name
-  TH1* get_histogram( const std::string& name );  
+  TH1* get_histogram( const std::string& name ) const; 
 
   /// get detector dependent histogram array from base name
-  histogram_array_t get_histograms( const std::string& name );  
+  histogram_array_t get_histograms( const std::string& name ) const;
 
   /// get histogram by name
-  TH1* get_ref_histogram( const std::string& name );  
+  TH1* get_ref_histogram( const std::string& name ) const;
 
   /// get detector dependent histogram array from base name
-  histogram_array_t get_ref_histograms( const std::string& name );  
+  histogram_array_t get_ref_histograms( const std::string& name ) const;  
 
+  /// get scale factor for reference histograms
+  /** the normaliztion factor is based on the ratio of number of events in the event counters histogram */
+  double get_ref_scale_factor() const;
+  
+  /// normalize reference histogram
+  /* 
+   * a copy of the source histogram is done. It must be deleted after the fact
+   */
+  TH1* normalize( TH1*, double scale = 1 ) const;
+  
   /// draw histogram array
   int draw_array( const std::string& name, const histogram_array_t&, unsigned int /*option*/ = DrawOptions::None );
   

--- a/subsystems/tpot/TpotMonDraw.h
+++ b/subsystems/tpot/TpotMonDraw.h
@@ -75,6 +75,9 @@ class TpotMonDraw : public OnlMonDraw
   /// get detector dependent histogram array from base name
   histogram_array_t get_ref_histograms( const std::string& name ) const;  
 
+  /// get detector dependent histogram array from base name
+  histogram_array_t get_ref_histograms_scaled( const std::string& name ) const;  
+
   /// get scale factor for reference histograms
   /** the normaliztion factor is based on the ratio of number of events in the event counters histogram */
   double get_ref_scale_factor() const;
@@ -86,8 +89,12 @@ class TpotMonDraw : public OnlMonDraw
   TH1* normalize( TH1*, double scale = 1 ) const;
   
   /// draw histogram array
-  int draw_array( const std::string& name, const histogram_array_t&, unsigned int /*option*/ = DrawOptions::None );
-  
+  int draw_array( const std::string& name, const histogram_array_t& array, unsigned int options = DrawOptions::None )
+  { return draw_array( name, array, {{nullptr}}, options ); } 
+
+  /// draw histogram array and reference histgorams
+  int draw_array( const std::string& name, const histogram_array_t&, const histogram_array_t& /*reference*/, unsigned int /*options*/ = DrawOptions::None );
+
   /// draw detector names in current canvas
   /** only works if canvas contains one of the properly formated TH2Poly histograms */
   void draw_detnames_sphenix( const std::string& suffix = std::string());

--- a/subsystems/tpot/TpotMonSetup.csh
+++ b/subsystems/tpot/TpotMonSetup.csh
@@ -1,1 +1,8 @@
+#! /bin/csh
+if (! $?TPOTCALIBREF ) then
+  setenv TPOTCALIBREF /home/phnxrc/operations/TPOT/onlmon_ref
+  echo "TPOTCALIBREF environment variable set to $TPOTCALIBREF"
+  exit
+endif
+
 setenv TPOTCALIB $ONLMON_CALIB/tpot

--- a/subsystems/tpot/TpotMonSetup.sh
+++ b/subsystems/tpot/TpotMonSetup.sh
@@ -1,1 +1,11 @@
+#! /bin/bash
+
+
+if [[ -z "$TPOTCALIBREF" ]]
+then
+  export TPOTCALIBREF=/home/phnxrc/operations/TPOT/onlmon_ref
+  echo "TPOTCALIBREF environment variable set to $TPOTCALIBREF"
+  return
+fi
+
 export TPOTCALIB=$ONLMON_CALIB/tpot


### PR DESCRIPTION
This PR implements reading reference histogram from a previously saved root file for TPOT, normalize them to the number of processed events, and draw them on top of the current histograms. 

@pinkenburg since I don't know of a default place where to put reference histograms, I have added an env variable in TpotMonSetup.sh/.csh, called TPOTCALIBREF and pointing to: /home/phnxrc/operations/TPOT/onlmon_ref for the time being. (which I think is available from anywhere online mon is running ?)

In any case: when the env variable is not found, or the TFile is not found, or the relevant histogram is not found, the code just skips drawing the reference histogram. 

What remains now is to produce a decent reference histograms file, with enough statistics. 
