### PR TITLE
Hide uncalibrated channels

### DIFF
--- a/subsystems/tpot/TpotMon.cc
+++ b/subsystems/tpot/TpotMon.cc
@@ -74,16 +74,12 @@ int TpotMon::Init()
   // setup calibrations
   if( std::ifstream( m_calibration_filename.c_str() ).good() )
   {
-
     m_calibration_data.read( m_calibration_filename );
-
   } else {
-
     std::cout << "TpotMon::Init -"
       << " file " << m_calibration_filename << " cannot be opened."
       << " No calibration loaded"
       << std::endl;
-
   }
 
   // server instance
@@ -302,7 +298,7 @@ int TpotMon::process_event(Event* event)
       for( int is = 0; is < samples; ++is )
       {
         const auto adc =  packet->iValue( i, is );
-        const bool is_signal = (adc > pedestal + m_n_sigma*rms);
+        const bool is_signal = rms>0 && (adc> pedestal+m_n_sigma*rms);
         if( is_signal ) detector_histograms.m_counts_sample->Fill( is );
         detector_histograms.m_adc_sample->Fill( is, adc );
         detector_histograms.m_hit_charge->Fill( adc );
@@ -313,7 +309,7 @@ int TpotMon::process_event(Event* event)
       for( int is = std::max<int>(0,m_sample_window_signal.first); is < std::min<int>(samples,m_sample_window_signal.second); ++is )
       {
         const auto adc =  packet->iValue( i, is );
-        if( adc > pedestal + m_n_sigma*rms)
+        if( rms>0 && adc>pedestal + m_n_sigma*rms)
         {
           is_signal = true;
           break;


### PR DESCRIPTION
Channels for which the calibration has failed (rms = 0) are also masked out in the online monitoring. This prevents them appearing as hot channels in the histograms 