### PR TITLE
Adding in Correct Phi Coordinate Mapping for XY plots

### DIFF
--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -405,8 +405,13 @@ int TpcMon::process_event(Event *evt/* evt */)
         // clockwise FEE mapping
         //int FEE_map[26]={5, 6, 1, 3, 2, 12, 10, 11, 9, 8, 7, 1, 2, 4, 8, 7, 6, 5, 4, 3, 1, 3, 2, 4, 6, 5};
         int FEE_R[26]={2, 2, 1, 1, 1, 3, 3, 3, 3, 3, 3, 2, 2, 1, 2, 2, 1, 1, 2, 2, 3, 3, 3, 3, 3, 3};
-        // conter clockwise FEE mapping (From Takao)
-        int FEE_map[26]={3, 2, 5, 3, 4, 0, 2, 1, 3, 4, 5, 7, 6, 2, 0, 1, 0, 1, 4, 5, 11, 9, 10, 8, 6, 7};
+        // counter clockwise FEE mapping (From Takao - DEPRECATED AS OF 08.29)
+        //int FEE_map[26]={3, 2, 5, 3, 4, 0, 2, 1, 3, 4, 5, 7, 6, 2, 0, 1, 0, 1, 4, 5, 11, 9, 10, 8, 6, 7};
+
+        // FEE mapping from Jin
+        int FEE_map[26]={4, 5, 0, 2, 1, 11, 9, 10, 8, 7, 6, 0, 1, 3, 7, 6, 5, 4, 3, 2, 0, 2, 1, 3, 5, 4};
+
+        
         //int pads_per_sector[3] = {96, 128, 192};
 
 


### PR DESCRIPTION
Files Affected:

    subsystems/tpc/TpcMon.cc

Changes:

    Adding in correct phi coordinate mapping for XY plots. This is based on the code [here](https://github.com/sPHENIX-Collaboration/analysis/blob/7cfeffab47860326f1b2d4bd04e19ed038af68e1/TPC/DAQ/macros/TPCEventDisplay_Updated_BCO.C#L101). Essentially, its a local phi flip.

TODO:

    Double check [about global phi flip](https://github.com/sPHENIX-Collaboration/analysis/blob/7cfeffab47860326f1b2d4bd04e19ed038af68e1/TPC/DAQ/macros/TPCEventDisplay_Updated_BCO.C#L325)

