### PR TITLE
Trying wider binning in ZY plots

### DIFF
--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -149,14 +149,14 @@ int TpcMon::Init()
   //____________________________________________________________________//
 
   //TPC "cluster" ZY heat maps WEIGHTED
-   NorthSideADC_clusterZY = new TH2F("NorthSideADC_clusterZY" , "(ADC-Pedestal) > 20 North Side", 515, -1030, 1030, 400, -800, 800);
-   SouthSideADC_clusterZY = new TH2F("SouthSideADC_clusterZY" , "(ADC-Pedestal) > 20 North Side", 515, -1030, 1030, 400, -800, 800);
+   NorthSideADC_clusterZY = new TH2F("NorthSideADC_clusterZY" , "(ADC-Pedestal) > 20 North Side", 206, -1030, 1030, 400, -800, 800);
+   SouthSideADC_clusterZY = new TH2F("SouthSideADC_clusterZY" , "(ADC-Pedestal) > 20 North Side", 206, -1030, 1030, 400, -800, 800);
 
   //____________________________________________________________________//
 
   //TPC "cluster" ZY heat maps UNWEIGHTED
-   NorthSideADC_clusterZY_unw = new TH2F("NorthSideADC_clusterZY_unw" , "(ADC-Pedestal) > 20 South Side", 515, -1030, 1030, 400, -800, 800);
-   SouthSideADC_clusterZY_unw = new TH2F("SouthSideADC_clusterZY_unw" , "(ADC-Pedestal) > 20 South Side", 515, -1030, 1030, 400, -800, 800);
+   NorthSideADC_clusterZY_unw = new TH2F("NorthSideADC_clusterZY_unw" , "(ADC-Pedestal) > 20 South Side", 206, -1030, 1030, 400, -800, 800);
+   SouthSideADC_clusterZY_unw = new TH2F("SouthSideADC_clusterZY_unw" , "(ADC-Pedestal) > 20 South Side", 206, -1030, 1030, 400, -800, 800);
 
   //____________________________________________________________________//
 


### PR DESCRIPTION
**Files Affected:**

subsystems/tpc/TpcMon.cc

**Changes:**

Increased the z bin size in the ZY plots again. This is now a 10 mm bin size in Z.

**TODO:**

Add histos for the following:

~~Make plots nicer and with timestamps so we know they are fresh (see calo code)~~

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart
Follow up with Christof about index bug in TpcMap.cc (Line 108, should be == 2)

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
