### PR TITLE
comment out wave form fitting

### DIFF
--- a/subsystems/cemc/CemcMon.cc
+++ b/subsystems/cemc/CemcMon.cc
@@ -359,16 +359,16 @@ int CemcMon::process_event(Event *e  /* evt */)
 
 	      h1_cemc_adc ->Fill(signalFast);
 	      
-	      if(!((eventCounter - 2)% 5000))
-		{
-		  std::vector<float> resultTemp = anaWaveformTemp(p, c);  // template waveform fitting
-		  float signalTemp = resultTemp.at(0);
-		  float timeTemp  = resultTemp.at(1);
-		  float pedestalTemp = resultTemp.at(2);
-		  h1_cemc_fitting_sigDiff -> Fill(signalFast/signalTemp);
-		  h1_cemc_fitting_pedDiff -> Fill(pedestalFast/pedestalTemp);
-		  h1_cemc_fitting_timeDiff -> Fill(timeFast - timeTemp - 6);
-		}
+	      // if(!((eventCounter - 2)% 5000))
+	      // 	{
+	      // 	  std::vector<float> resultTemp = anaWaveformTemp(p, c);  // template waveform fitting
+	      // 	  float signalTemp = resultTemp.at(0);
+	      // 	  float timeTemp  = resultTemp.at(1);
+	      // 	  float pedestalTemp = resultTemp.at(2);
+	      // 	  h1_cemc_fitting_sigDiff -> Fill(signalFast/signalTemp);
+	      // 	  h1_cemc_fitting_pedDiff -> Fill(pedestalFast/pedestalTemp);
+	      // 	  h1_cemc_fitting_timeDiff -> Fill(timeFast - timeTemp - 6);
+	      // 	}
 	      if (signalFast > hit_threshold)
 		{
 		  //h2_cemc_hits->Fill(eta_bin + 0.5, phi_bin + 0.5);


### PR DESCRIPTION
The cemc server crashes when the wave form fitting is called (once every 5k events, likely number of channels in packet need updating). This PR comments this out.