### PR TITLE
mlp - check for the legacy packet range was wrong. Fixed.

### DIFF
--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -370,7 +370,7 @@ int TpcMon::process_event(Event *evt/* evt */)
   if (evt->existPacket(4000))
     {
       Packet *p = evt->getPacket(4000);
-      if (p->getIdentifier() == IDTPCFEEV3 ) firstpacket = 4000;
+      if (p->getHitFormat() == IDTPCFEEV3 ) firstpacket = 4000;
       delete p;
     }
   int lastpacket = firstpacket+232;


### PR DESCRIPTION
the check 
`if (p->getIdentifier() == IDTPCFEEV3 ) firstpacket = 4000;`
is wrong. `getIdentifier()` returns the packet id. What we want is to see that the hitformat is IDTPCFEEV3, presumably as an idiot check that we are really looking at a TPC packet. So we should compare `p->getHitFormat()`.
I would remove this in the future - this will break the day when we get a new hitformat, say, IDTPCFEEV4.

