### PR TITLE
Adding pedestal subtracted raw ADC with negative x-axis values at Tom's request

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -51,10 +51,13 @@ void tpcDrawInit(const int online = 0)
 
     cl->registerHisto("RAWADC_1D_R1",TPCMON_STR);
     cl->registerHisto("MAXADC_1D_R1",TPCMON_STR);
+    cl->registerHisto("PEDEST_SUB_ADC_1D_R1",TPCMON_STR);
     cl->registerHisto("RAWADC_1D_R2",TPCMON_STR);
     cl->registerHisto("MAXADC_1D_R2",TPCMON_STR);
+    cl->registerHisto("PEDEST_SUB_ADC_1D_R2",TPCMON_STR)
     cl->registerHisto("RAWADC_1D_R3",TPCMON_STR);
     cl->registerHisto("MAXADC_1D_R3",TPCMON_STR);
+    cl->registerHisto("PEDEST_SUB_ADC_1D_R3",TPCMON_STR)
 
     cl->registerHisto("NorthSideADC_clusterZY", TPCMON_STR);
     cl->registerHisto("SouthSideADC_clusterZY", TPCMON_STR);

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -225,12 +225,15 @@ int TpcMon::Init()
   //________For 1D ADC spectra - Doing this the hard way because I'm not sure if I can have a TH1 array
   char RAWADC_1D_titlestr[100];
   char MAXADC_1D_titlestr[100];
+  char SUBADC_1D_titlestr[100];
 
   sprintf(RAWADC_1D_titlestr,"RAW ADC for Sector %i R1",MonitorServerId());
   sprintf(MAXADC_1D_titlestr,"MAX ADC in SLIDING WINDOW for Sector %i R1",MonitorServerId());
+  sprintf(SUBADC_1D_titlestr,"PEDEST_SUB RAW ADC for Sector %i R1",MonitorServerId()); 
 
   RAWADC_1D_R1 = new TH1F("RAWADC_1D_R1",RAWADC_1D_titlestr,1025,-0.5,1024.5);
   MAXADC_1D_R1 = new TH1F("MAXADC_1D_R1",MAXADC_1D_titlestr,1025,-0.5,1024.5);
+  PEDEST_SUB_1D_R1 = new TH1F("PEDEST_SUB_1D_R1",SUBADC_1D_titlestr,1125,-100.5,1024.5);
 
   RAWADC_1D_R1->SetYTitle("Entries");
   RAWADC_1D_R1->SetXTitle("ADC [ADU]");
@@ -238,17 +241,24 @@ int TpcMon::Init()
   MAXADC_1D_R1->SetYTitle("Entries");
   MAXADC_1D_R1->SetXTitle("(MAXADC-pedestal) [ADU]");
 
+  PEDEST_SUB_1D_R1->SetYTitle("Entries");
+  PEDEST_SUB_1D_R1->SetXTitle("(ADC-pedestal) [ADU]");
+
   MAXADC_1D_R1->Sumw2(kFALSE);
   RAWADC_1D_R1->Sumw2(kFALSE);
+  PEDEST_SUB_1D_R1->Sumw2(kFALSE);
 
   MAXADC_1D_R1->SetLineColor(2);
   RAWADC_1D_R1->SetLineColor(2);
+  PEDEST_SUB_1D_R1->SetLineColor(2);
 
   sprintf(RAWADC_1D_titlestr,"RAW ADC for Sector %i R2",MonitorServerId());
   sprintf(MAXADC_1D_titlestr,"MAX ADC for Sector %i R2",MonitorServerId());
+  sprintf(SUBADC_1D_titlestr,"PEDEST_SUB RAW ADC for Sector %i R2`",MonitorServerId()); 
 
   RAWADC_1D_R2 = new TH1F("RAWADC_1D_R2",RAWADC_1D_titlestr,1025,-0.5,1024.5);
   MAXADC_1D_R2 = new TH1F("MAXADC_1D_R2",MAXADC_1D_titlestr,1025,-0.5,1024.5);
+  PEDEST_SUB_1D_R2 = new TH1F("PEDEST_SUB_1D_R2",SUBADC_1D_titlestr,1125,-100.5,1024.5);
 
   RAWADC_1D_R2->SetYTitle("Entries");
   RAWADC_1D_R2->SetXTitle("ADC [ADU]");
@@ -256,17 +266,24 @@ int TpcMon::Init()
   MAXADC_1D_R2->SetYTitle("Entries");
   MAXADC_1D_R2->SetXTitle("(MAXADC-pedestal) [ADU]");
 
+  PEDEST_SUB_1D_R2->SetYTitle("Entries");
+  PEDEST_SUB_1D_R2->SetXTitle("(ADC-pedestal) [ADU]");
+
   MAXADC_1D_R2->Sumw2(kFALSE);
   RAWADC_1D_R2->Sumw2(kFALSE);
+  PEDEST_SUB_1D_R2->Sumw2(kFALSE);
 
   MAXADC_1D_R2->SetLineColor(3);
   RAWADC_1D_R2->SetLineColor(3);
+  PEDEST_SUB_1D_R2->SetLineColor(3);
 
   sprintf(RAWADC_1D_titlestr,"RAW ADC for Sector %i R3",MonitorServerId());
   sprintf(MAXADC_1D_titlestr,"MAX ADC for Sector %i R3",MonitorServerId());
+  sprintf(SUBADC_1D_titlestr,"PEDEST_SUB RAW ADC for Sector %i R3",MonitorServerId()); 
 
   RAWADC_1D_R3 = new TH1F("RAWADC_1D_R3",RAWADC_1D_titlestr,1025,-0.5,1024.5);
   MAXADC_1D_R3 = new TH1F("MAXADC_1D_R3",MAXADC_1D_titlestr,1025,-0.5,1024.5);
+  PEDEST_SUB_1D_R3 = new TH1F("PEDEST_SUB_1D_R3",SUBADC_1D_titlestr,1125,-100.5,1024.5);
 
   RAWADC_1D_R3->SetYTitle("Entries");
   RAWADC_1D_R3->SetXTitle("ADC [ADU]");
@@ -274,11 +291,16 @@ int TpcMon::Init()
   MAXADC_1D_R3->SetYTitle("Entries");
   MAXADC_1D_R3->SetXTitle("(MAXADC-pedestal) [ADU]");
 
+  PEDEST_SUB_1D_R3->SetYTitle("Entries");
+  PEDEST_SUB_1D_R3->SetXTitle("(ADC-pedestal) [ADU]");
+
   MAXADC_1D_R3->Sumw2(kFALSE);  // ADC vs Sample (small)
   RAWADC_1D_R3->Sumw2(kFALSE);
+  PEDEST_SUB_1D_R3->Sumw2(kFALSE);
 
   MAXADC_1D_R3->SetLineColor(4);
   RAWADC_1D_R3->SetLineColor(4);
+  PEDEST_SUB_1D_R3->SetLineColor(4);
 
   
   char Layer_ChannelPhi_ADC_weighted_title_str[256];
@@ -302,10 +324,13 @@ int TpcMon::Init()
   se->registerHisto(this, MAXADC);
   se->registerHisto(this, RAWADC_1D_R1);
   se->registerHisto(this, MAXADC_1D_R1);
+  se->registerHisto(this, PEDEST_SUB_1D_R1);
   se->registerHisto(this, RAWADC_1D_R2);
   se->registerHisto(this, MAXADC_1D_R2);
+  se->registerHisto(this, PEDEST_SUB_1D_R2);
   se->registerHisto(this, RAWADC_1D_R3);
   se->registerHisto(this, MAXADC_1D_R3);
+  se->registerHisto(this, PEDEST_SUB_1D_R3);
 
   se->registerHisto(this, NorthSideADC_clusterXY_R1);
   se->registerHisto(this, NorthSideADC_clusterXY_R2);
@@ -548,9 +573,9 @@ int TpcMon::process_event(Event *evt/* evt */)
             ADC_vs_SAMPLE -> Fill(s, adc);
             ADC_vs_SAMPLE_large -> Fill(s, adc);
 
-            if(Module_ID(fee)==0){RAWADC_1D_R1->Fill(adc);} //Raw 1D for R1
-            else if(Module_ID(fee)==1){RAWADC_1D_R2->Fill(adc);} //Raw 1D for R2
-            else if(Module_ID(fee)==2){RAWADC_1D_R3->Fill(adc);} //Raw 1D for R3
+            if(Module_ID(fee)==0){RAWADC_1D_R1->Fill(adc);PEDEST_SUB_1D_R1->Fill(adc-pedestal);} //Raw/pedest_sub 1D for R1
+            else if(Module_ID(fee)==1){RAWADC_1D_R2->Fill(adc);PEDEST_SUB_1D_R2->Fill(adc-pedestal);} //Raw/pedest_sub 1D for R2
+            else if(Module_ID(fee)==2){RAWADC_1D_R3->Fill(adc);PEDEST_SUB_1D_R3->Fill(adc-pedestal);} //Raw/pedest_sub 1D for R3
           }
 
           //increment 

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -89,12 +89,15 @@ class TpcMon : public OnlMon
 
   TH1 *RAWADC_1D_R1= nullptr;
   TH1 *MAXADC_1D_R1 = nullptr;
+  TH1 *PEDEST_SUB_1D_R1 = nullptr;
 
   TH1 *RAWADC_1D_R2= nullptr;
   TH1 *MAXADC_1D_R2 = nullptr;
+  TH1 *PEDEST_SUB_1D_R2 = nullptr;
 
   TH1 *RAWADC_1D_R3= nullptr;
   TH1 *MAXADC_1D_R3 = nullptr;
+  TH1 *PEDEST_SUB_1D_R3 = nullptr;
 
   TH2 *Layer_ChannelPhi_ADC_weighted = nullptr;
 

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -35,6 +35,7 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCMaxADCModule(const std::string &what = "ALL");
   int DrawTPCRawADC1D(const std::string &what = "ALL");
   int DrawTPCMaxADC1D(const std::string &what = "ALL");
+  int DrawTPCPedestSubADC1D(const std::string &what = "ALL");
   int DrawTPCXYclusters(const std::string &what = "ALL");
   int DrawTPCXYclusters_unweighted(const std::string &what = "ALL");
   int DrawTPCZYclusters(const std::string &what = "ALL");
@@ -42,8 +43,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCchannelphi_layer_weighted(const std::string &what = "ALL");
   time_t getTime();
   
-  TCanvas *TC[16] = {nullptr};
-  TPad *transparent[15] = {nullptr};
+  TCanvas *TC[17] = {nullptr};
+  TPad *transparent[16] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

subsystems/tpc/TpcMon.cc
subsystems/tpc/TpcMon.h
subsystems/tpc/TpcMonDraw.cc
subsystems/tpc/TpcMonDraw.h
macros/run_tpc_client.C

**Changes:**

Adds a 1D histo with RAWADC - PEDESTAL (previous was max of ADC in 10 sample window - pedestal), extending the x-axis to -100. 

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
