### PR TITLE
Fixing bugs in client macro and draw executable

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -54,10 +54,10 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("PEDEST_SUB_ADC_1D_R1",TPCMON_STR);
     cl->registerHisto("RAWADC_1D_R2",TPCMON_STR);
     cl->registerHisto("MAXADC_1D_R2",TPCMON_STR);
-    cl->registerHisto("PEDEST_SUB_ADC_1D_R2",TPCMON_STR)
+    cl->registerHisto("PEDEST_SUB_ADC_1D_R2",TPCMON_STR);
     cl->registerHisto("RAWADC_1D_R3",TPCMON_STR);
     cl->registerHisto("MAXADC_1D_R3",TPCMON_STR);
-    cl->registerHisto("PEDEST_SUB_ADC_1D_R3",TPCMON_STR)
+    cl->registerHisto("PEDEST_SUB_ADC_1D_R3",TPCMON_STR);
 
     cl->registerHisto("NorthSideADC_clusterZY", TPCMON_STR);
     cl->registerHisto("SouthSideADC_clusterZY", TPCMON_STR);

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -1693,9 +1693,9 @@ int TpcMonDraw::DrawTPCPedestSubADC1D(const std::string & /* what */)
   {
     //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
     sprintf(TPCMON_STR,"TPCMON_%i",i);
-    tpcmon_PEDESTSUBADC1D[i][0] = (TH1*) cl->getHisto(TPCMON_STR,"PEDEST_SUB_ADC_1D_R1");
-    tpcmon_PEDESTSUBADC1D[i][1] = (TH1*) cl->getHisto(TPCMON_STR,"PEDEST_SUB_ADC_1D_R2");
-    tpcmon_PEDESTSUBADC1D[i][2] = (TH1*) cl->getHisto(TPCMON_STR,"PEDEST_SUB_ADC_1D_R3");
+    tpcmon_PEDESTSUBADC1D[i][0] = (TH1*) cl->getHisto(TPCMON_STR,"PEDEST_SUB_1D_R1");
+    tpcmon_PEDESTSUBADC1D[i][1] = (TH1*) cl->getHisto(TPCMON_STR,"PEDEST_SUB_1D_R2");
+    tpcmon_PEDESTSUBADC1D[i][2] = (TH1*) cl->getHisto(TPCMON_STR,"PEDEST_SUB_1D_R3");
   }
 
 


### PR DESCRIPTION
**Files Affected:**

subsystems/tpc/TpcMonDraw.cc
macros/run_tpc_client.C

**Changes:**

in TpcMonDraw.cc - Make sure histo name for pedestal subtracted 1D ADC was correct (lines 1696 - 1698)
in run_tpc_client.C - forgot semi-colons (lines 57 & 60)

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
