### PR TITLE
Fixing the client for real this time

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -51,13 +51,13 @@ void tpcDrawInit(const int online = 0)
 
     cl->registerHisto("RAWADC_1D_R1",TPCMON_STR);
     cl->registerHisto("MAXADC_1D_R1",TPCMON_STR);
-    cl->registerHisto("PEDEST_SUB_ADC_1D_R1",TPCMON_STR);
+    cl->registerHisto("PEDEST_SUB_1D_R1",TPCMON_STR);
     cl->registerHisto("RAWADC_1D_R2",TPCMON_STR);
     cl->registerHisto("MAXADC_1D_R2",TPCMON_STR);
-    cl->registerHisto("PEDEST_SUB_ADC_1D_R2",TPCMON_STR);
+    cl->registerHisto("PEDEST_SUB_1D_R2",TPCMON_STR);
     cl->registerHisto("RAWADC_1D_R3",TPCMON_STR);
     cl->registerHisto("MAXADC_1D_R3",TPCMON_STR);
-    cl->registerHisto("PEDEST_SUB_ADC_1D_R3",TPCMON_STR);
+    cl->registerHisto("PEDEST_SUB_1D_R3",TPCMON_STR);
 
     cl->registerHisto("NorthSideADC_clusterZY", TPCMON_STR);
     cl->registerHisto("SouthSideADC_clusterZY", TPCMON_STR);


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C

**Changes:**

run_tpc_client.C - lines 54,57,60, making this be the ACTUAL name of histogram

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
