### PR TITLE
Adding an Event Counter for each EBDC histogram + Pedestal Subtracted ADC vs. SAMPLE plots

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -46,7 +46,8 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("Check_Sum_Error",TPCMON_STR);
     cl->registerHisto("Check_Sums",TPCMON_STR);
     cl->registerHisto("ADC_vs_SAMPLE",TPCMON_STR); 
-    cl->registerHisto("ADC_vs_SAMPLE_large",TPCMON_STR); 
+    cl->registerHisto("ADC_vs_SAMPLE_large",TPCMON_STR);
+    cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE",TPCMON_STR);
     cl->registerHisto("MAXADC",TPCMON_STR);
 
     cl->registerHisto("RAWADC_1D_R1",TPCMON_STR);

--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -66,6 +66,7 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("SouthSideADC_clusterZY_unw",TPCMON_STR);
 
     cl->registerHisto("Layer_ChannelPhi_ADC_weighted",TPCMON_STR);
+    cl->registerHisto("NEvents_vs_EBDC",TPCMON_STR);
   } //
 
 

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -308,7 +308,13 @@ int TpcMon::Init()
   // x-axis is channel phi, y-axis is channel layer, z axis is ADC weithing
   Layer_ChannelPhi_ADC_weighted = new TH2F("Layer_ChannelPhi_ADC_weighted",Layer_ChannelPhi_ADC_weighted_title_str,4610,-2305.5,2304.5,61,-0.5,59.5);
   Layer_ChannelPhi_ADC_weighted->SetXTitle("Channel # (#phi bin)");
-  Layer_ChannelPhi_ADC_weighted->SetYTitle("Layer");  
+  Layer_ChannelPhi_ADC_weighted->SetYTitle("Layer");
+
+  char NEvents_vs_EBDC_title_str[256];
+  sprintf(NEvents_vs_EBDC_title_str,"N_{Events} vs EBDC");
+  NEvents_vs_EBDC = new TH1F("NEvents_vs_EBDC",NEvents_vs_EBDC_title_str,24,-0.5,23.5);
+  NEvents_vs_EBDC->SetXTitle("EBDC #");
+  NEvents_vs_EBDC->SetYTitle("N_{Events}");  
 
   OnlMonServer *se = OnlMonServer::instance();
   // register histograms with server otherwise client won't get them
@@ -355,6 +361,7 @@ int TpcMon::Init()
   se->registerHisto(this, SouthSideADC_clusterZY_unw);
 
   se->registerHisto(this, Layer_ChannelPhi_ADC_weighted); 
+  se->registerHisto(this, NEvents_vs_EBDC);
 
   Reset();
   return 0;
@@ -411,6 +418,7 @@ int TpcMon::process_event(Event *evt/* evt */)
     }
   int lastpacket = firstpacket+232;
 
+  NEvents_vs_EBDC->Fill(serverid);
   
   for( int packet = firstpacket; packet < lastpacket; packet++) //packet 4001 or 4002 = Sec 00, packet 4231 or 4232 = Sec 23
   {

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -173,6 +173,15 @@ int TpcMon::Init()
   ADC_vs_SAMPLE -> SetXTitle(ADC_vs_SAMPLE_xaxis_str);
   ADC_vs_SAMPLE -> SetYTitle("ADC [ADU]");
 
+  // ADC vs Sample (small)
+  char PEDEST_SUB_ADC_vs_SAMPLE_str[100];
+  char PEDEST_SUB_ADC_vs_SAMPLE_xaxis_str[100];
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_str,"ADC Counts vs Sample: SECTOR %i",MonitorServerId());
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_xaxis_str,"Sector %i: ADC Time bin [1/20MHz]",MonitorServerId());
+  PEDEST_SUB_ADC_vs_SAMPLE = new TH2F("PEDEST_SUB_ADC_vs_SAMPLE", ADC_vs_SAMPLE_str, 360, 0, 360, 281, -100, 1024);
+  PEDEST_SUB_ADC_vs_SAMPLE -> SetXTitle(ADC_vs_SAMPLE_xaxis_str);
+  PEDEST_SUB_ADC_vs_SAMPLE -> SetYTitle("ADC [ADU]");
+
   // ADC vs Sample (large)
   char ADC_vs_SAMPLE_large_str[100];
   char ADC_vs_SAMPLE_xaxis_large_str[100];
@@ -326,6 +335,7 @@ int TpcMon::Init()
   se->registerHisto(this, Check_Sum_Error);
   se->registerHisto(this, Check_Sums);
   se->registerHisto(this, ADC_vs_SAMPLE);
+  se->registerHisto(this, PEDEST_SUB_ADC_vs_SAMPLE);
   se->registerHisto(this, ADC_vs_SAMPLE_large);
   se->registerHisto(this, MAXADC);
   se->registerHisto(this, RAWADC_1D_R1);
@@ -418,7 +428,7 @@ int TpcMon::process_event(Event *evt/* evt */)
     }
   int lastpacket = firstpacket+232;
 
-  NEvents_vs_EBDC->Fill(serverid);
+  NEvents_vs_EBDC->Fill(MonitorServerId());
   
   for( int packet = firstpacket; packet < lastpacket; packet++) //packet 4001 or 4002 = Sec 00, packet 4231 or 4232 = Sec 23
   {
@@ -579,6 +589,7 @@ int TpcMon::process_event(Event *evt/* evt */)
           if( checksumError == 0 && is_channel_stuck == 0)
           {
             ADC_vs_SAMPLE -> Fill(s, adc);
+            PEDEST_SUB_ADC_vs_SAMPLE -> Fill(s, adc-pedestal);
             ADC_vs_SAMPLE_large -> Fill(s, adc);
 
             if(Module_ID(fee)==0){RAWADC_1D_R1->Fill(adc);PEDEST_SUB_1D_R1->Fill(adc-pedestal);} //Raw/pedest_sub 1D for R1

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -79,6 +79,7 @@ class TpcMon : public OnlMon
   TH2 *SouthSideADC = nullptr;
 
   TH2 *ADC_vs_SAMPLE = nullptr;
+  TH2 *PEDEST_SUB_ADC_vs_SAMPLE = nullptr;
   TH2 *ADC_vs_SAMPLE_large = nullptr;
 
   TH1 *sample_size_hist = nullptr;

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -100,6 +100,7 @@ class TpcMon : public OnlMon
   TH1 *PEDEST_SUB_1D_R3 = nullptr;
 
   TH2 *Layer_ChannelPhi_ADC_weighted = nullptr;
+  TH1 *NEvents_vs_EBDC = nullptr;
 
   TpcMap M; //declare Martin's map
 

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -256,6 +256,18 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     transparent[15]->SetFillStyle(4000);
     transparent[15]->Draw();
     TC[16]->SetEditable(false);
+  }
+  else if (name == "TPCNEventsEBDC")
+  {
+    TC[17] = new TCanvas(name.c_str(), "TPC NUMBER EVENTS vs EBDC",1350,700);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[17]->Divide(1,1);
+    // this one is used to plot the run number on the canvas
+    transparent[16] = new TPad("transparent14", "this does not show", 0, 0, 1, 1);
+    transparent[16]->SetFillStyle(4000);
+    transparent[16]->Draw();
+    TC[17]->SetEditable(false);
   } 
   
   return 0;
@@ -345,7 +357,11 @@ int TpcMonDraw::Draw(const std::string &what)
     iret += DrawTPCPedestSubADC1D(what);
     idraw++;
   }
- 
+  if (what == "ALL" || what == "TPCNEVENTSEBDC")
+  {
+    iret += DrawTPCNEventsvsEBDC(what);
+    idraw++;
+  } 
   if (!idraw)
   {
     std::cout << __PRETTY_FUNCTION__ << " Unimplemented Drawing option: " << what << std::endl;
@@ -1756,6 +1772,77 @@ int TpcMonDraw::DrawTPCPedestSubADC1D(const std::string & /* what */)
 
   return 0;
 }
+
+int TpcMonDraw::DrawTPCNEventsvsEBDC(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH1 *tpcmoneventsebdc[24] = {nullptr};
+
+  char TPCMON_STR[100];
+
+  dummy_his1_NEvents_EBDC = new TH1F("dummy_his1_Nevents_EBDC", "N_{Events} vs EBDC", 24, -0.5, 23.5); //dummy histos for titles
+  dummy_his1_NEvents_EBDC->SetXTitle("EBDC #");
+  dummy_his1_NEvents_EBDC->SetYTitle("N_{Events}");
+
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmoneventsebdc[i] = (TH1*) cl->getHisto(TPCMON_STR,"NEvents_vs_EBDC");
+  }
+
+  if (!gROOT->FindObject("TPCNEventsEBDC"))
+  {
+    MakeCanvas("TPCNEventsEBDC");
+  }  
+
+  TC[17]->SetEditable(true);
+  TC[17]->Clear("D");
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_N_Events_vs_EBDC " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  transparent[16]->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+  TC[17]->cd(1);
+  gStyle->SetOptStat(kFALSE);
+  gPad->SetTopMargin(0.15);
+  dummy_his1_NEvents_EBDC->Draw("HISTsame");
+
+  float max = 0;
+  for( int i=0; i<24; i++ )
+  {
+    if( tpcmoneventsebdc[i] )
+    {
+      TC[17]->cd(1);
+      tpcmoneventsebdc[i] -> Draw("HISTsame");
+      if( tpcmoneventsebdc[i]->GetBinContent(  tpcmoneventsebdc[i]->GetMaximumBin()) > max ) 
+      {
+        max =  tpcmoneventsebdc[i]->GetBinContent( tpcmoneventsebdc[i]->GetMaximumBin());
+        dummy_his1_NEvents_EBDC->SetMaximum( max*(1.3) );
+      }
+
+    }
+  }
+  TC[17]->Update();
+
+  TC[17]->Show();
+  TC[17]->SetEditable(false);
+
+  return 0;
+}
+
 
 
 int TpcMonDraw::SavePlot(const std::string &what, const std::string &type)

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -264,10 +264,21 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     //gStyle->SetPalette(57); //kBird CVD friendly
     TC[17]->Divide(1,1);
     // this one is used to plot the run number on the canvas
-    transparent[16] = new TPad("transparent14", "this does not show", 0, 0, 1, 1);
+    transparent[16] = new TPad("transparent16", "this does not show", 0, 0, 1, 1);
     transparent[16]->SetFillStyle(4000);
     transparent[16]->Draw();
     TC[17]->SetEditable(false);
+  }
+  else if (name == "TPCPedestSubADCSample")
+  {
+    TC[18] = new TCanvas(name.c_str(), "TPC PEDEST SUB ADC vs Sample in Whole Sector",-1, 0, xsize , ysize);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[18]->Divide(4,7);
+    transparent[17] = new TPad("transparent17", "this does not show", 0, 0, 1, 1);
+    transparent[17]->SetFillStyle(4000);
+    transparent[17]->Draw();
+    TC[18]->SetEditable(false);
   } 
   
   return 0;
@@ -362,6 +373,11 @@ int TpcMonDraw::Draw(const std::string &what)
     iret += DrawTPCNEventsvsEBDC(what);
     idraw++;
   } 
+  if (what == "ALL" || what == "TPCPEDESTSUBADCVSSAMPLE")
+  {
+    iret += DrawTPCPedestSubADCSample(what);
+    idraw++;
+  }
   if (!idraw)
   {
     std::cout << __PRETTY_FUNCTION__ << " Unimplemented Drawing option: " << what << std::endl;
@@ -1839,6 +1855,63 @@ int TpcMonDraw::DrawTPCNEventsvsEBDC(const std::string & /* what */)
 
   TC[17]->Show();
   TC[17]->SetEditable(false);
+
+  return 0;
+}
+
+int TpcMonDraw::DrawTPCPedestSubADCSample(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH2 *tpcmon_PEDESTSUBADCSAMPLE[24] = {nullptr};
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_PEDESTSUBADCSAMPLE[i] = (TH2*) cl->getHisto(TPCMON_STR,"PEDEST_SUB_ADC_vs_SAMPLE");
+  }
+
+
+  if (!gROOT->FindObject("TPCPedestSubADCSample"))
+  {
+    MakeCanvas("TPCPedestSubADCSample");
+  }  
+
+  TC[18]->SetEditable(true);
+  TC[18]->Clear("D");
+
+  for( int i=0; i<24; i++ )
+  {
+    if( tpcmon_PEDESTSUBADCSAMPLE[i] )
+    {
+      TC[18]->cd(i+5);
+      gStyle->SetPalette(57); //kBird CVD friendly
+      gPad->SetLogz(kTRUE);
+      tpcmon_PEDESTSUBADCSAMPLE[i] -> DrawCopy("colz");
+    }
+  }
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_PEDEST_SUB_ADC_vs_SAMPLE Run " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  transparent[17]->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+
+  TC[18]->Update();
+  TC[18]->Show();
+  TC[18]->SetEditable(false);
 
   return 0;
 }

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -32,6 +32,7 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCSampleSize(const std::string &what = "ALL");
   int DrawTPCCheckSum(const std::string &what = "ALL");
   int DrawTPCADCSample(const std::string &what = "ALL");
+  int DrawTPCPedestSubADCSample(const std::string &what = "ALL");
   int DrawTPCADCSampleLarge(const std::string &what = "ALL");
   int DrawTPCMaxADCModule(const std::string &what = "ALL");
   int DrawTPCRawADC1D(const std::string &what = "ALL");
@@ -45,8 +46,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCNEventsvsEBDC(const std::string &wht = "ALL");
   time_t getTime();
   
-  TCanvas *TC[18] = {nullptr};
-  TPad *transparent[17] = {nullptr};
+  TCanvas *TC[19] = {nullptr};
+  TPad *transparent[18] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -9,6 +9,7 @@ class TCanvas;
 class TGraphErrors;
 class TPad;
 class TH2;
+class TH1;
 class TPaveLabel;
 
 class TpcMonDraw : public OnlMonDraw
@@ -41,10 +42,11 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCZYclusters(const std::string &what = "ALL");
   int DrawTPCZYclusters_unweighted(const std::string &what = "ALL");
   int DrawTPCchannelphi_layer_weighted(const std::string &what = "ALL");
+  int DrawTPCNEventsvsEBDC(const std::string &wht = "ALL");
   time_t getTime();
   
-  TCanvas *TC[17] = {nullptr};
-  TPad *transparent[16] = {nullptr};
+  TCanvas *TC[18] = {nullptr};
+  TPad *transparent[17] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module
@@ -63,6 +65,7 @@ class TpcMonDraw : public OnlMonDraw
   TH2 *dummy_his1_ZY_unw = nullptr;
 
   TH2 *dummy_his1_channelphi_layer_w = nullptr;
+  TH1 *dummy_his1_NEvents_EBDC = nullptr;
 
   TPaveLabel* NS18 = nullptr; //North Side labels
   TPaveLabel* NS17 = nullptr;


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.h
subystems/tpc/TpcMon.cc
subystems/tpc/TpcMonDraw.h
subystems/tpc/TpcMonDraw.cc
macros/run_tpc_client.C

**Changes:**

Added an N_Events vs EBDC histogram + Sector x Sector Pedestal Subtracted ADC vs. SAMPLE. Pedestal comes from median in waveform.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
