### PR TITLE
zdc: drawing smd_values, smd_values_good, and smd_values_small in ZdcMonDraw.

### DIFF
--- a/macros/run_zdc_client.C
+++ b/macros/run_zdc_client.C
@@ -14,6 +14,25 @@ void zdcDrawInit(const int online = 0)
   // register histos we want with monitor name
   cl->registerHisto("zdc_adc_north","ZDCMON_0");
   cl->registerHisto("zdc_adc_south","ZDCMON_0");
+  // smd
+  // north smd
+  cl->registerHisto("smd_hor_north", "ZDCMON_0");
+  cl->registerHisto("smd_ver_north", "ZDCMON_0");
+  cl->registerHisto("smd_sum_hor_north", "ZDCMON_0");
+  cl->registerHisto("smd_sum_ver_north", "ZDCMON_0");
+  cl->registerHisto("smd_hor_north_small", "ZDCMON_0");
+  cl->registerHisto("smd_ver_north_small", "ZDCMON_0");
+  cl->registerHisto("smd_hor_north_good", "ZDCMON_0");
+  cl->registerHisto("smd_ver_north_good", "ZDCMON_0");
+  // south smd
+  cl->registerHisto("smd_hor_south", "ZDCMON_0");
+  cl->registerHisto("smd_ver_south", "ZDCMON_0");
+  cl->registerHisto("smd_sum_hor_south", "ZDCMON_0");
+  cl->registerHisto("smd_sum_ver_south", "ZDCMON_0");
+  // smd values
+  cl->registerHisto("smd_value", "ZDCMON_0");
+  cl->registerHisto("smd_value_good", "ZDCMON_0");
+  cl->registerHisto("smd_value_small", "ZDCMON_0");
 
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);

--- a/macros/run_zdc_client.C
+++ b/macros/run_zdc_client.C
@@ -33,6 +33,13 @@ void zdcDrawInit(const int online = 0)
   cl->registerHisto("smd_value", "ZDCMON_0");
   cl->registerHisto("smd_value_good", "ZDCMON_0");
   cl->registerHisto("smd_value_small", "ZDCMON_0");
+  cl->registerHisto("smd_xy_north", "ZDCMON_0")
+  cl->registerHisto("smd_xy_south", "ZDCMON_0")
+
+  cl->registerHisto("smd_yt_north", "ZDCMON_0")
+  cl->registerHisto("smd_yt_south", "ZDCMON_0")
+  cl->registerHisto("smd_xt_north", "ZDCMON_0")
+  cl->registerHisto("smd_xt_south", "ZDCMON_0")
 
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);

--- a/macros/run_zdc_client.C
+++ b/macros/run_zdc_client.C
@@ -36,11 +36,6 @@ void zdcDrawInit(const int online = 0)
   cl->registerHisto("smd_xy_north", "ZDCMON_0")
   cl->registerHisto("smd_xy_south", "ZDCMON_0")
 
-  cl->registerHisto("smd_yt_north", "ZDCMON_0")
-  cl->registerHisto("smd_yt_south", "ZDCMON_0")
-  cl->registerHisto("smd_xt_north", "ZDCMON_0")
-  cl->registerHisto("smd_xt_south", "ZDCMON_0")
-
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
 

--- a/macros/run_zdc_client.C
+++ b/macros/run_zdc_client.C
@@ -37,8 +37,8 @@ void zdcDrawInit(const int online = 0)
   cl->AddServerHost("localhost");  // check local host first
   CreateHostList(online);
 
- // get my histos from server, the second parameter = 1 
-// says I know they are all on the same node
+  // get my histos from server, the second parameter = 1 
+  // says I know they are all on the same node
   cl->requestHistoBySubSystem("ZDCMON_0", 1);
   OnlMonDraw *zdcmon = new ZdcMonDraw("ZDCMONDRAW");    // create Drawing Object
   cl->registerDrawer(zdcmon);              // register with client framework

--- a/subsystems/zdc/ZdcMon.cc
+++ b/subsystems/zdc/ZdcMon.cc
@@ -134,10 +134,6 @@ int ZdcMon::Init()
   smd_xy_north = new TH2F("smd_xy_north", "SMD hit position north", 110, -5.5, 5.5, 119, -5.92, 5.92);
   smd_xy_south = new TH2F("smd_xy_south", "SMD hit position south", 110, -5.5, 5.5, 119, -5.92, 5.92);
 
-  smd_yt_south = new TH2F("smd_yt_south", "Time dep. of y in SMD south", 100, 0, 100000, 296, -5.92, 5.92);
-  smd_xt_south = new TH2F("smd_xt_south", "Time dep. of x in SMD south", 100, 0, 100000, 220, -5.5, 5.5);
-  smd_yt_north = new TH2F("smd_yt_north", "Time dep. of y in SMD north", 100, 0, 100000, 296, -5.92, 5.92);
-  smd_xt_north = new TH2F("smd_xt_north", "Time dep. of x in SMD north", 100, 0, 100000, 220, -5.5, 5.5);
 
   OnlMonServer *se = OnlMonServer::instance();
   //register histograms with server otherwise client won't get them
@@ -165,10 +161,6 @@ int ZdcMon::Init()
   se->registerHisto(this, smd_xy_north);
   se->registerHisto(this, smd_xy_south);
 
-  se->registerHisto(this, smd_yt_north);
-  se->registerHisto(this, smd_yt_south);
-  se->registerHisto(this, smd_xt_north);
-  se->registerHisto(this, smd_xt_south);
 
     
   WaveformProcessingFast = new CaloWaveformFitting();
@@ -378,23 +370,6 @@ int ZdcMon::process_event(Event *e /* evt */)
       }
     }
     if (fill_hor_north && fill_ver_north && zdc_adc[4]>40 ){smd_xy_north->Fill( smd_pos[3], smd_pos[2]);}
-
-    if (fill_hor_south)
-    {
-      smd_yt_south->Fill(nevt, smd_pos[0]);
-    }
-    if (fill_ver_south)
-    {
-      smd_xt_south->Fill(nevt, smd_pos[1]);
-    }
-    if (fill_hor_north)
-    {
-      smd_yt_north->Fill(nevt, smd_pos[2]);
-    }
-    if (fill_ver_north)
-    {
-      smd_xt_north->Fill(nevt, smd_pos[3]);
-    }
 
     // PHENIX had: if (ped_zdc_north && ped_smd_vnorth && ovfbool[0] && ovfbool[4] && !smd_ovld_north && fired_smd_ver && !did_laser_fire)
     if (fired_smd_ver_n && ped_smd_vnorth && !smd_ovld_north)

--- a/subsystems/zdc/ZdcMon.cc
+++ b/subsystems/zdc/ZdcMon.cc
@@ -131,6 +131,8 @@ int ZdcMon::Init()
   smd_value = new TH2F("smd_value", "SMD channel# vs value", 1024, 0, 4096, 32, 0, 32);
   smd_value_good = new TH2F("smd_value_good", "SMD channel# vs value", 1024, 0, 4096, 16, 0, 16);
   smd_value_small = new TH2F("smd_value_small", "SMD channel# vs value", 1024, 0, 4096, 16, 0, 16);
+  smd_xy_north = new TH2F("smd_xy_north", "SMD hit position north", 110, -5.5, 5.5, 119, -5.92, 5.92);
+  smd_xy_south = new TH2F("smd_xy_south", "SMD hit position south", 110, -5.5, 5.5, 119, -5.92, 5.92);
 
   OnlMonServer *se = OnlMonServer::instance();
   //register histograms with server otherwise client won't get them
@@ -155,6 +157,8 @@ int ZdcMon::Init()
   se->registerHisto(this, smd_value);
   se->registerHisto(this, smd_value_good);
   se->registerHisto(this, smd_value_small);
+  se->registerHisto(this, smd_xy_north);
+  se->registerHisto(this, smd_xy_south);
 
     
   WaveformProcessingFast = new CaloWaveformFitting();
@@ -207,7 +211,7 @@ int ZdcMon::process_event(Event *e /* evt */)
   if (p)
   {
   
-    // zdc_adc
+    // in this for loop we get: zdc_adc and smd_adc
     for (int c = 0; c < p->iValue(0, "CHANNELS"); c++)
     {
       std::vector<float> resultFast = anaWaveformFast(p, c);  // fast waveform fitting
@@ -223,8 +227,6 @@ int ZdcMon::process_event(Event *e /* evt */)
 
       if (c < 16) {zdc_adc[c] = signal;}
       else {smd_adc[c - 16] = signal;}
-      
-
 
       if (mod != 0) continue;
       
@@ -247,8 +249,6 @@ int ZdcMon::process_event(Event *e /* evt */)
 
     
 
-
-
     }  // channel loop end
 
     // call the functions
@@ -260,6 +260,11 @@ int ZdcMon::process_event(Event *e /* evt */)
     // BOOLEANS, INTs AND OTHER DEFINITIONS
 
     
+    bool fill_hor_south = false;
+    bool fill_ver_south = false;
+
+    bool fill_hor_north = false;
+    bool fill_ver_north = false;
 
     int s_ver = 0;
     int s_hor = 0;
@@ -388,6 +393,8 @@ int ZdcMon::process_event(Event *e /* evt */)
       }
     }
 
+    if (fill_hor_south && fill_ver_south && zdc_adc[0]>40 ) {smd_xy_south->Fill(smd_pos[1], smd_pos[0]);}
+    if (fill_hor_north && fill_ver_north && zdc_adc[4]>40 ){smd_xy_north->Fill( smd_pos[3], smd_pos[2]);}
 
 
 

--- a/subsystems/zdc/ZdcMon.cc
+++ b/subsystems/zdc/ZdcMon.cc
@@ -134,6 +134,11 @@ int ZdcMon::Init()
   smd_xy_north = new TH2F("smd_xy_north", "SMD hit position north", 110, -5.5, 5.5, 119, -5.92, 5.92);
   smd_xy_south = new TH2F("smd_xy_south", "SMD hit position south", 110, -5.5, 5.5, 119, -5.92, 5.92);
 
+  smd_yt_south = new TH2F("smd_yt_south", "Time dep. of y in SMD south", 100, 0, 100000, 296, -5.92, 5.92);
+  smd_xt_south = new TH2F("smd_xt_south", "Time dep. of x in SMD south", 100, 0, 100000, 220, -5.5, 5.5);
+  smd_yt_north = new TH2F("smd_yt_north", "Time dep. of y in SMD north", 100, 0, 100000, 296, -5.92, 5.92);
+  smd_xt_north = new TH2F("smd_xt_north", "Time dep. of x in SMD north", 100, 0, 100000, 220, -5.5, 5.5);
+
   OnlMonServer *se = OnlMonServer::instance();
   //register histograms with server otherwise client won't get them
   se->registerHisto(this, zdc_adc_north );
@@ -159,6 +164,11 @@ int ZdcMon::Init()
   se->registerHisto(this, smd_value_small);
   se->registerHisto(this, smd_xy_north);
   se->registerHisto(this, smd_xy_south);
+
+  se->registerHisto(this, smd_yt_north);
+  se->registerHisto(this, smd_yt_south);
+  se->registerHisto(this, smd_xt_north);
+  se->registerHisto(this, smd_xt_south);
 
     
   WaveformProcessingFast = new CaloWaveformFitting();
@@ -312,6 +322,8 @@ int ZdcMon::process_event(Event *e /* evt */)
     // PHENIX had: if ( ped_zdc_south && !did_laser_fire && fired_smd_hor_s && fired_smd_ver_s && ovfbool[0] && ovfbool[4] && !smd_ovld_south)
     if (fired_smd_hor_s && fired_smd_ver_s && !smd_ovld_south)
     {
+      fill_hor_south = true;
+      fill_ver_south = true;
       smd_hor_south->Fill( smd_pos[0] );
       smd_ver_south->Fill( smd_pos[1] );
       for (int i = 0 ; i < 8; i++)
@@ -336,11 +348,12 @@ int ZdcMon::process_event(Event *e /* evt */)
         }
       // }
     }
+    if (fill_hor_south && fill_ver_south && zdc_adc[0]>40 ) {smd_xy_south->Fill(smd_pos[1], smd_pos[0]);}
 
     // PHENIX had: if (ped_zdc_north && ped_smd_hnorth && ovfbool[0] && ovfbool[4] && !smd_ovld_north &&  fired_smd_hor_n && !did_laser_fire)
     if ( fired_smd_hor_n && ped_smd_hnorth && !smd_ovld_north)
     {
-      // fill_hor_north = true;
+      fill_hor_north = true;
       smd_hor_north->Fill( smd_pos[2] );
       // zdc_hor_north->Fill( zdc_adc[4] / ADC_to_GeV_north, smd_pos[2] );
       for (int i = 0; i < 8; i++)
@@ -363,6 +376,24 @@ int ZdcMon::process_event(Event *e /* evt */)
           smd_value_small->Fill(smd_adc[i + 16], float(i) + 16.);
         }
       }
+    }
+    if (fill_hor_north && fill_ver_north && zdc_adc[4]>40 ){smd_xy_north->Fill( smd_pos[3], smd_pos[2]);}
+
+    if (fill_hor_south)
+    {
+      smd_yt_south->Fill(nevt, smd_pos[0]);
+    }
+    if (fill_ver_south)
+    {
+      smd_xt_south->Fill(nevt, smd_pos[1]);
+    }
+    if (fill_hor_north)
+    {
+      smd_yt_north->Fill(nevt, smd_pos[2]);
+    }
+    if (fill_ver_north)
+    {
+      smd_xt_north->Fill(nevt, smd_pos[3]);
     }
 
     // PHENIX had: if (ped_zdc_north && ped_smd_vnorth && ovfbool[0] && ovfbool[4] && !smd_ovld_north && fired_smd_ver && !did_laser_fire)
@@ -392,9 +423,6 @@ int ZdcMon::process_event(Event *e /* evt */)
         }
       }
     }
-
-    if (fill_hor_south && fill_ver_south && zdc_adc[0]>40 ) {smd_xy_south->Fill(smd_pos[1], smd_pos[0]);}
-    if (fill_hor_north && fill_ver_north && zdc_adc[4]>40 ){smd_xy_north->Fill( smd_pos[3], smd_pos[2]);}
 
 
 

--- a/subsystems/zdc/ZdcMon.h
+++ b/subsystems/zdc/ZdcMon.h
@@ -52,6 +52,8 @@ class ZdcMon : public OnlMon
   TH2 *smd_value = nullptr;
   TH2 *smd_value_good = nullptr;
   TH2 *smd_value_small = nullptr;
+  TH2 * smd_xy_north = nullptr;
+  TH2 * smd_xy_south = nullptr;
 
   float smd_adc[32] = {0.0f};
   float zdc_adc[16] = {0.0f};

--- a/subsystems/zdc/ZdcMon.h
+++ b/subsystems/zdc/ZdcMon.h
@@ -55,6 +55,11 @@ class ZdcMon : public OnlMon
   TH2 * smd_xy_north = nullptr;
   TH2 * smd_xy_south = nullptr;
 
+  TH2 * smd_yt_south;
+  TH2 * smd_xt_south;
+  TH2 * smd_yt_north;
+  TH2 * smd_xt_north;
+
   float smd_adc[32] = {0.0f};
   float zdc_adc[16] = {0.0f};
   float smd_sum[4] = {0.0f}; 

--- a/subsystems/zdc/ZdcMon.h
+++ b/subsystems/zdc/ZdcMon.h
@@ -52,8 +52,8 @@ class ZdcMon : public OnlMon
   TH2 *smd_value = nullptr;
   TH2 *smd_value_good = nullptr;
   TH2 *smd_value_small = nullptr;
-  TH2 * smd_xy_north = nullptr;
-  TH2 * smd_xy_south = nullptr;
+  TH2 *smd_xy_north = nullptr;
+  TH2 *smd_xy_south = nullptr;
 
   
   float smd_adc[32] = {0.0f};

--- a/subsystems/zdc/ZdcMon.h
+++ b/subsystems/zdc/ZdcMon.h
@@ -55,11 +55,7 @@ class ZdcMon : public OnlMon
   TH2 * smd_xy_north = nullptr;
   TH2 * smd_xy_south = nullptr;
 
-  TH2 * smd_yt_south;
-  TH2 * smd_xt_south;
-  TH2 * smd_yt_north;
-  TH2 * smd_xt_north;
-
+  
   float smd_adc[32] = {0.0f};
   float zdc_adc[16] = {0.0f};
   float smd_sum[4] = {0.0f}; 

--- a/subsystems/zdc/ZdcMon.h
+++ b/subsystems/zdc/ZdcMon.h
@@ -51,9 +51,9 @@ class ZdcMon : public OnlMon
   TH1 *smd_sum_hor_south = nullptr;
   TH1 *smd_sum_ver_south = nullptr;
   // smd values
-  TH1 *smd_value = nullptr;
-  TH1 *smd_value_good = nullptr;
-  TH1 *smd_value_small = nullptr;
+  TH2 *smd_value = nullptr;
+  TH2 *smd_value_good = nullptr;
+  TH2 *smd_value_small = nullptr;
 
   float smd_adc[32] = {0.0f};
   float zdc_adc[16] = {0.0f};

--- a/subsystems/zdc/ZdcMon.h
+++ b/subsystems/zdc/ZdcMon.h
@@ -49,9 +49,9 @@ class ZdcMon : public OnlMon
   TH1 *smd_sum_hor_south = nullptr;
   TH1 *smd_sum_ver_south = nullptr;
   // smd values
-  TH1 *smd_value = nullptr;
-  TH1 *smd_value_good = nullptr;
-  TH1 *smd_value_small = nullptr;
+  TH2 *smd_value = nullptr;
+  TH2 *smd_value_good = nullptr;
+  TH2 *smd_value_small = nullptr;
 
   float smd_adc[32] = {0.0f};
   float zdc_adc[16] = {0.0f};

--- a/subsystems/zdc/ZdcMonDraw.cc
+++ b/subsystems/zdc/ZdcMonDraw.cc
@@ -32,7 +32,7 @@ int ZdcMonDraw::Init()
   return 0;
 }
 
-int ZdcMonDraw::MakeCanvas(const std::string &name)
+int ZdcMonDraw::MakeCanvas1(const std::string &name)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   int xsize = cl->GetDisplaySizeX();
@@ -71,9 +71,18 @@ int ZdcMonDraw::MakeCanvas(const std::string &name)
     transparent[1]->Draw();
     TC[1]->SetEditable(false);
   }
+  return 0;
+  
+}
+
+int ZdcMonDraw::MakeCanvas2(const std::string &name)
+{
   // for smd_value, smd_value_good, smd_value_small
-  else if (name == "SmdValues")
+  if (name == "SmdValues")
   {
+    OnlMonClient *cl = OnlMonClient::instance();
+    int xsize = cl->GetDisplaySizeX();
+    int ysize = cl->GetDisplaySizeY();
     // xpos negative: do not draw menu bar
     TC[2] = new TCanvas(name.c_str(), "ZdcMon2 Example Monitor", -xsize / 2, 0, xsize / 2, ysize);
     gSystem->ProcessEvents();
@@ -90,6 +99,7 @@ int ZdcMonDraw::MakeCanvas(const std::string &name)
     TC[2]->SetEditable(false);
   }
   return 0;
+
 }
 
 
@@ -122,7 +132,7 @@ int ZdcMonDraw::DrawFirst(const std::string & /* what */)
   TH1 *zdc_adc_north = cl->getHisto("ZDCMON_0","zdc_adc_north");
   if (!gROOT->FindObject("ZdcMon1"))
   {
-    MakeCanvas("ZdcMon1");
+    MakeCanvas1("ZdcMon1");
   }
   TC[0]->SetEditable(true);
   TC[0]->Clear("D");
@@ -175,7 +185,7 @@ int ZdcMonDraw::DrawSecond(const std::string & /* what */)
   TH1 *zdc_adc_north = cl->getHisto("ZDCMON_0","zdc_adc_north");
   if (!gROOT->FindObject("ZdcMon2"))
   {
-    MakeCanvas("ZdcMon2");
+    MakeCanvas1("ZdcMon2");
   }
   TC[1]->SetEditable(true);
   TC[1]->Clear("D");
@@ -224,7 +234,7 @@ int ZdcMonDraw::DrawSmdValues(const std::string & /* what */)
 
   if (!gROOT->FindObject("SmdValues"))
   {
-    MakeCanvas("SmdValues");
+    MakeCanvas2("SmdValues");
   }
   TC[2]->SetEditable(true);
   TC[2]->Clear("D");

--- a/subsystems/zdc/ZdcMonDraw.cc
+++ b/subsystems/zdc/ZdcMonDraw.cc
@@ -8,6 +8,7 @@
 #include <TDatime.h>
 #include <TGraphErrors.h>
 #include <TH1.h>
+#include <TH2.h>
 #include <TPad.h>
 #include <TROOT.h>
 #include <TSystem.h>
@@ -217,9 +218,9 @@ int ZdcMonDraw::DrawSecond(const std::string & /* what */)
 int ZdcMonDraw::DrawSmdValues(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TH2 *smd_value = cl->getHisto("ZDCMON_0","smd_value");
-  TH2 *smd_value_good = cl->getHisto("ZDCMON_0","smd_value_good");
-  TH2 *smd_value_small = cl->getHisto("ZDCMON_0","smd_value_small");
+  TH2 *smd_value = (TH2*) cl->getHisto("ZDCMON_0","smd_value");
+  TH2 *smd_value_good = (TH2*) cl->getHisto("ZDCMON_0","smd_value_good");
+  TH2 *smd_value_small = (TH2*) cl->getHisto("ZDCMON_0","smd_value_small");
 
   if (!gROOT->FindObject("SmdValues"))
   {

--- a/subsystems/zdc/ZdcMonDraw.cc
+++ b/subsystems/zdc/ZdcMonDraw.cc
@@ -70,7 +70,7 @@ int ZdcMonDraw::MakeCanvas(const std::string &name)
     transparent[1]->Draw();
     TC[1]->SetEditable(false);
   }
-  // for smd_values, smd_values_good, smd_values_small
+  // for smd_value, smd_value_good, smd_value_small
   else if (name == "SmdValues")
   {
     // xpos negative: do not draw menu bar
@@ -228,9 +228,9 @@ int ZdcMonDraw::DrawSmdValues(const std::string & /* what */)
   TC[2]->SetEditable(true);
   TC[2]->Clear("D");
   Pad[4]->cd();
-  if (smd_values)
+  if (smd_value)
   {
-    smd_values->DrawCopy();
+    smd_value->DrawCopy();
   }
   else
   {

--- a/subsystems/zdc/ZdcMonDraw.cc
+++ b/subsystems/zdc/ZdcMonDraw.cc
@@ -70,8 +70,27 @@ int ZdcMonDraw::MakeCanvas(const std::string &name)
     transparent[1]->Draw();
     TC[1]->SetEditable(false);
   }
+  // for smd_values, smd_values_good, smd_values_small
+  else if (name == "SmdValues")
+  {
+    // xpos negative: do not draw menu bar
+    TC[2] = new TCanvas(name.c_str(), "ZdcMon2 Example Monitor", -xsize / 2, 0, xsize / 2, ysize);
+    gSystem->ProcessEvents();
+    Pad[4] = new TPad("zdcpad4", "who needs this?", 0.1, 0.5, 0.9, 0.9, 0);
+    Pad[5] = new TPad("zdcpad5", "who needs this?", 0.1, 0.05, 0.9, 0.45, 0);
+    Pad[6] = new TPad("zdcpad6", "who needs this?", 0.1, 0.05, 0.9, 0.45, 0);
+    Pad[4]->Draw();
+    Pad[5]->Draw();
+    Pad[6]->Draw();
+    // this one is used to plot the run number on the canvas
+    transparent[2] = new TPad("transparent1", "this does not show", 0, 0, 1, 1);
+    transparent[2]->SetFillStyle(4000);
+    transparent[2]->Draw();
+    TC[2]->SetEditable(false);
+  }
   return 0;
 }
+
 
 int ZdcMonDraw::Draw(const std::string &what)
 {
@@ -195,6 +214,60 @@ int ZdcMonDraw::DrawSecond(const std::string & /* what */)
   return 0;
 }
 
+void ZdcMonDraw::DrawSmdValues(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+  TH2 *smd_value = cl->getHisto("ZDCMON_0","smd_value");
+  TH2 *smd_value_good = cl->getHisto("ZDCMON_0","smd_value_good");
+  TH2 *smd_value_small = cl->getHisto("ZDCMON_0","smd_value_small");
+
+  if (!gROOT->FindObject("SmdValues"))
+  {
+    MakeCanvas("SmdValues");
+  }
+  TC[2]->SetEditable(true);
+  TC[2]->Clear("D");
+  Pad[4]->cd();
+  if (smd_values)
+  {
+    smd_values->DrawCopy();
+  }
+  else
+  {
+    DrawDeadServer(transparent[2]);
+    TC[2]->SetEditable(false);
+    return -1;
+  }
+  Pad[5]->cd();
+  if (smd_value_good)
+  {
+    smd_value_good->DrawCopy();
+  }
+  Pad[6]->cd();
+  if (smd_value_good)
+  {
+    smd_value_small->DrawCopy();
+  }
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_2 Run " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  transparent[2]->cd();
+  PrintRun.DrawText(0.5, 1., runstring.c_str());
+  TC[2]->Update();
+  TC[2]->Show();
+  TC[2]->SetEditable(false);
+  return 0;
+}
+
 int ZdcMonDraw::SavePlot(const std::string &what, const std::string &type)
 {
 
@@ -236,6 +309,9 @@ int ZdcMonDraw::MakeHtml(const std::string &what)
   // idem for 2nd canvas.
   pngfile = cl->htmlRegisterPage(*this, "Second Canvas", "2", "png");
   cl->CanvasToPng(TC[1], pngfile);
+  // idem for 3rd canvas.
+  pngfile = cl->htmlRegisterPage(*this, "Third Canvas", "3", "png");
+  cl->CanvasToPng(TC[2], pngfile);
   // Now register also EXPERTS html pages, under the EXPERTS subfolder.
 
   std::string logfile = cl->htmlRegisterPage(*this, "EXPERTS/Log", "log", "html");
@@ -252,5 +328,12 @@ int ZdcMonDraw::MakeHtml(const std::string &what)
   out2 << "<P>Some status output would go here." << std::endl;
   out2.close();
   cl->SaveLogFile(*this);
+
+  std::string logfile = cl->htmlRegisterPage(*this, "EXPERTS/Log", "log", "html");
+  std::ofstream out(logfile.c_str());
+  out3 << "<HTML><HEAD><TITLE>Log file for run " << cl->RunNumber()
+      << "</TITLE></HEAD>" << std::endl;
+  out3 << "<P>Some SmdValues-related-output would go here." << std::endl;
+  out3.close();
   return 0;
 }

--- a/subsystems/zdc/ZdcMonDraw.cc
+++ b/subsystems/zdc/ZdcMonDraw.cc
@@ -214,7 +214,7 @@ int ZdcMonDraw::DrawSecond(const std::string & /* what */)
   return 0;
 }
 
-void ZdcMonDraw::DrawSmdValues(const std::string & /* what */)
+int ZdcMonDraw::DrawSmdValues(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
   TH2 *smd_value = cl->getHisto("ZDCMON_0","smd_value");
@@ -329,8 +329,8 @@ int ZdcMonDraw::MakeHtml(const std::string &what)
   out2.close();
   cl->SaveLogFile(*this);
 
-  std::string logfile = cl->htmlRegisterPage(*this, "EXPERTS/Log", "log", "html");
-  std::ofstream out(logfile.c_str());
+  std::string smdvaluesplots = cl->htmlRegisterPage(*this, "EXPERTS/Log", "log", "html");
+  std::ofstream out3(smdvaluesplots.c_str());
   out3 << "<HTML><HEAD><TITLE>Log file for run " << cl->RunNumber()
       << "</TITLE></HEAD>" << std::endl;
   out3 << "<P>Some SmdValues-related-output would go here." << std::endl;

--- a/subsystems/zdc/ZdcMonDraw.h
+++ b/subsystems/zdc/ZdcMonDraw.h
@@ -26,7 +26,7 @@ class ZdcMonDraw : public OnlMonDraw
 
  protected:
   int MakeCanvas1(const std::string &name);
-  int MakeCanvas1(const std::string &name);
+  int MakeCanvas2(const std::string &name);
   int DrawFirst(const std::string &what = "ALL");
   int DrawSecond(const std::string &what = "ALL");
   int DrawSmdValues(const std::string &what = "ALL");

--- a/subsystems/zdc/ZdcMonDraw.h
+++ b/subsystems/zdc/ZdcMonDraw.h
@@ -25,7 +25,8 @@ class ZdcMonDraw : public OnlMonDraw
   int SavePlot(const std::string &what = "ALL", const std::string &type = "png") override;
 
  protected:
-  int MakeCanvas(const std::string &name);
+  int MakeCanvas1(const std::string &name);
+  int MakeCanvas1(const std::string &name);
   int DrawFirst(const std::string &what = "ALL");
   int DrawSecond(const std::string &what = "ALL");
   int DrawSmdValues(const std::string &what = "ALL");

--- a/subsystems/zdc/ZdcMonDraw.h
+++ b/subsystems/zdc/ZdcMonDraw.h
@@ -9,6 +9,8 @@ class OnlMonDB;
 class TCanvas;
 class TGraphErrors;
 class TPad;
+const int NUM_CANV = 3;
+const int NUM_PAD = 7;
 
 class ZdcMonDraw : public OnlMonDraw
 {
@@ -26,9 +28,10 @@ class ZdcMonDraw : public OnlMonDraw
   int MakeCanvas(const std::string &name);
   int DrawFirst(const std::string &what = "ALL");
   int DrawSecond(const std::string &what = "ALL");
-  TCanvas *TC[2] = {nullptr};
-  TPad *transparent[2] = {nullptr};
-  TPad *Pad[4] = {nullptr};
+  int DrawSmdValues(const std::string &what = "ALL");
+  TCanvas *TC[NUM_CANV] = {nullptr};
+  TPad *transparent[NUM_CANV] = {nullptr};
+  TPad *Pad[NUM_PAD] = {nullptr};
 };
 
 #endif /* ZDC_ZDCMONDRAW_H */


### PR DESCRIPTION
From the histos that were recently put in ZdcMon, three of them were now added (drawn) in the ZdcMonDraw file. Note, I had to register them in _macros/run_zdc_client.C_. Furthermore, _smd_xy_north_ and _smd_xy_south histos_ were added into ZdcMon.