### PR TITLE
Adding ADC vs SAMPLE for R1, R2, R3 only

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -48,6 +48,9 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("ADC_vs_SAMPLE",TPCMON_STR); 
     cl->registerHisto("ADC_vs_SAMPLE_large",TPCMON_STR);
     cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE",TPCMON_STR);
+    cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE_R1",TPCMON_STR);
+    cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE_R2",TPCMON_STR);
+    cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE_R3",TPCMON_STR);
     cl->registerHisto("MAXADC",TPCMON_STR);
 
     cl->registerHisto("RAWADC_1D_R1",TPCMON_STR);

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -178,9 +178,36 @@ int TpcMon::Init()
   char PEDEST_SUB_ADC_vs_SAMPLE_xaxis_str[100];
   sprintf(PEDEST_SUB_ADC_vs_SAMPLE_str,"ADC Counts vs Sample: SECTOR %i",MonitorServerId());
   sprintf(PEDEST_SUB_ADC_vs_SAMPLE_xaxis_str,"Sector %i: ADC Time bin [1/20MHz]",MonitorServerId());
-  PEDEST_SUB_ADC_vs_SAMPLE = new TH2F("PEDEST_SUB_ADC_vs_SAMPLE", ADC_vs_SAMPLE_str, 360, 0, 360, 281, -100, 1024);
-  PEDEST_SUB_ADC_vs_SAMPLE -> SetXTitle(ADC_vs_SAMPLE_xaxis_str);
-  PEDEST_SUB_ADC_vs_SAMPLE -> SetYTitle("ADC [ADU]");
+  PEDEST_SUB_ADC_vs_SAMPLE = new TH2F("PEDEST_SUB_ADC_vs_SAMPLE", PEDEST_SUB_ADC_vs_SAMPLE_str, 360, 0, 360, 281, -100, 1024);
+  PEDEST_SUB_ADC_vs_SAMPLE -> SetXTitle(PEDEST_SUB_ADC_vs_SAMPLE_xaxis_str);
+  PEDEST_SUB_ADC_vs_SAMPLE -> SetYTitle("ADC-ped. [ADU]");
+
+  // ADC vs Sample (small)
+  char PEDEST_SUB_ADC_vs_SAMPLE_R1_str[100];
+  char PEDEST_SUB_ADC_vs_SAMPLE_R1_xaxis_str[100];
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R1_str,"ADC Counts vs Sample: SECTOR %i R1",MonitorServerId());
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R1_xaxis_str,"Sector %i R1: ADC Time bin [1/20MHz]",MonitorServerId());
+  PEDEST_SUB_ADC_vs_SAMPLE_R1 = new TH2F("PEDEST_SUB_ADC_vs_SAMPLE_R1", PEDEST_SUB_ADC_vs_SAMPLE_R1_str, 360, 0, 360, 281, -100, 1024);
+  PEDEST_SUB_ADC_vs_SAMPLE_R1 -> SetXTitle(PEDEST_SUB_ADC_vs_SAMPLE_R1_xaxis_str);
+  PEDEST_SUB_ADC_vs_SAMPLE_R1 -> SetYTitle("ADC-ped. [ADU]");
+
+  // ADC vs Sample (small)
+  char PEDEST_SUB_ADC_vs_SAMPLE_R2_str[100];
+  char PEDEST_SUB_ADC_vs_SAMPLE_R2_xaxis_str[100];
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R2_str,"ADC Counts vs Sample: SECTOR %i R2",MonitorServerId());
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R2_xaxis_str,"Sector %i R2: ADC Time bin [1/20MHz]",MonitorServerId());
+  PEDEST_SUB_ADC_vs_SAMPLE_R2 = new TH2F("PEDEST_SUB_ADC_vs_SAMPLE_R2", PEDEST_SUB_ADC_vs_SAMPLE_R2_str, 360, 0, 360, 281, -100, 1024);
+  PEDEST_SUB_ADC_vs_SAMPLE_R2 -> SetXTitle(PEDEST_SUB_ADC_vs_SAMPLE_R2_xaxis_str);
+  PEDEST_SUB_ADC_vs_SAMPLE_R2 -> SetYTitle("ADC-ped. [ADU]");
+
+  // ADC vs Sample (small)
+  char PEDEST_SUB_ADC_vs_SAMPLE_R3_str[100];
+  char PEDEST_SUB_ADC_vs_SAMPLE_R3_xaxis_str[100];
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R3_str,"ADC Counts vs Sample: SECTOR %i R3",MonitorServerId());
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R3_xaxis_str,"Sector %i R3: ADC Time bin [1/20MHz]",MonitorServerId());
+  PEDEST_SUB_ADC_vs_SAMPLE_R3 = new TH2F("PEDEST_SUB_ADC_vs_SAMPLE_R3", PEDEST_SUB_ADC_vs_SAMPLE_R3_str, 360, 0, 360, 281, -100, 1024);
+  PEDEST_SUB_ADC_vs_SAMPLE_R3 -> SetXTitle(PEDEST_SUB_ADC_vs_SAMPLE_R3_xaxis_str);
+  PEDEST_SUB_ADC_vs_SAMPLE_R3 -> SetYTitle("ADC-ped. [ADU]");
 
   // ADC vs Sample (large)
   char ADC_vs_SAMPLE_large_str[100];
@@ -336,6 +363,9 @@ int TpcMon::Init()
   se->registerHisto(this, Check_Sums);
   se->registerHisto(this, ADC_vs_SAMPLE);
   se->registerHisto(this, PEDEST_SUB_ADC_vs_SAMPLE);
+  se->registerHisto(this, PEDEST_SUB_ADC_vs_SAMPLE_R1);
+  se->registerHisto(this, PEDEST_SUB_ADC_vs_SAMPLE_R2);
+  se->registerHisto(this, PEDEST_SUB_ADC_vs_SAMPLE_R3);
   se->registerHisto(this, ADC_vs_SAMPLE_large);
   se->registerHisto(this, MAXADC);
   se->registerHisto(this, RAWADC_1D_R1);
@@ -592,9 +622,9 @@ int TpcMon::process_event(Event *evt/* evt */)
             PEDEST_SUB_ADC_vs_SAMPLE -> Fill(s, adc-pedestal);
             ADC_vs_SAMPLE_large -> Fill(s, adc);
 
-            if(Module_ID(fee)==0){RAWADC_1D_R1->Fill(adc);PEDEST_SUB_1D_R1->Fill(adc-pedestal);} //Raw/pedest_sub 1D for R1
-            else if(Module_ID(fee)==1){RAWADC_1D_R2->Fill(adc);PEDEST_SUB_1D_R2->Fill(adc-pedestal);} //Raw/pedest_sub 1D for R2
-            else if(Module_ID(fee)==2){RAWADC_1D_R3->Fill(adc);PEDEST_SUB_1D_R3->Fill(adc-pedestal);} //Raw/pedest_sub 1D for R3
+            if(Module_ID(fee)==0){RAWADC_1D_R1->Fill(adc);PEDEST_SUB_1D_R1->Fill(adc-pedestal);PEDEST_SUB_ADC_vs_SAMPLE_R1->Fill(s,adc-pedestal);} //Raw/pedest_sub 1D for R1
+            else if(Module_ID(fee)==1){RAWADC_1D_R2->Fill(adc);PEDEST_SUB_1D_R2->Fill(adc-pedestal);PEDEST_SUB_ADC_vs_SAMPLE_R2->Fill(s,adc-pedestal);} //Raw/pedest_sub 1D for R2
+            else if(Module_ID(fee)==2){RAWADC_1D_R3->Fill(adc);PEDEST_SUB_1D_R3->Fill(adc-pedestal);PEDEST_SUB_ADC_vs_SAMPLE_R3->Fill(s,adc-pedestal);} //Raw/pedest_sub 1D for R3
           }
 
           //increment 

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -81,6 +81,9 @@ class TpcMon : public OnlMon
   TH2 *ADC_vs_SAMPLE = nullptr;
   TH2 *PEDEST_SUB_ADC_vs_SAMPLE = nullptr;
   TH2 *ADC_vs_SAMPLE_large = nullptr;
+  TH2 *PEDEST_SUB_ADC_vs_SAMPLE_R1 = nullptr;
+  TH2 *PEDEST_SUB_ADC_vs_SAMPLE_R2 = nullptr;
+  TH2 *PEDEST_SUB_ADC_vs_SAMPLE_R3 = nullptr;
 
   TH1 *sample_size_hist = nullptr;
   TH1 *Check_Sum_Error = nullptr;

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -280,7 +280,39 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     transparent[17]->Draw();
     TC[18]->SetEditable(false);
   } 
-  
+  else if (name == "TPCPedestSubADCSample_R1")
+  {
+    TC[19] = new TCanvas(name.c_str(), "TPC PEDEST SUB ADC vs Sample in R1 ONLY",-1, 0, xsize , ysize);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[19]->Divide(4,7);
+    transparent[18] = new TPad("transparent18", "this does not show", 0, 0, 1, 1);
+    transparent[18]->SetFillStyle(4000);
+    transparent[18]->Draw();
+    TC[19]->SetEditable(false);
+  }
+  else if (name == "TPCPedestSubADCSample_R2")
+  {
+    TC[20] = new TCanvas(name.c_str(), "TPC PEDEST SUB ADC vs Sample in R2 ONLY",-1, 0, xsize , ysize);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[20]->Divide(4,7);
+    transparent[19] = new TPad("transparent19", "this does not show", 0, 0, 1, 1);
+    transparent[19]->SetFillStyle(4000);
+    transparent[19]->Draw();
+    TC[20]->SetEditable(false);
+  }   
+  else if (name == "TPCPedestSubADCSample_R3")
+  {
+    TC[21] = new TCanvas(name.c_str(), "TPC PEDEST SUB ADC vs Sample in R3 ONLY",-1, 0, xsize , ysize);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[21]->Divide(4,7);
+    transparent[20] = new TPad("transparent20", "this does not show", 0, 0, 1, 1);
+    transparent[20]->SetFillStyle(4000);
+    transparent[20]->Draw();
+    TC[21]->SetEditable(false);
+  }      
   return 0;
 }
 
@@ -376,6 +408,21 @@ int TpcMonDraw::Draw(const std::string &what)
   if (what == "ALL" || what == "TPCPEDESTSUBADCVSSAMPLE")
   {
     iret += DrawTPCPedestSubADCSample(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCPEDESTSUBADCVSSAMPLE_R1" )
+  {
+    iret += DrawTPCPedestSubADCSample_R1(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCPEDESTSUBADCVSSAMPLE_R2" )
+  {
+    iret += DrawTPCPedestSubADCSample_R2(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCPEDESTSUBADCVSSAMPLE_R3" )
+  {
+    iret += DrawTPCPedestSubADCSample_R3(what);
     idraw++;
   }
   if (!idraw)
@@ -1916,7 +1963,176 @@ int TpcMonDraw::DrawTPCPedestSubADCSample(const std::string & /* what */)
   return 0;
 }
 
+int TpcMonDraw::DrawTPCPedestSubADCSample_R1(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
 
+  TH2 *tpcmon_PEDESTSUBADCSAMPLE_R1[24] = {nullptr};
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_PEDESTSUBADCSAMPLE_R1[i] = (TH2*) cl->getHisto(TPCMON_STR,"PEDEST_SUB_ADC_vs_SAMPLE_R1");
+  }
+
+
+  if (!gROOT->FindObject("TPCPedestSubADCSample_R1"))
+  {
+    MakeCanvas("TPCPedestSubADCSample_R1");
+  }  
+
+  TC[19]->SetEditable(true);
+  TC[19]->Clear("D");
+
+  for( int i=0; i<24; i++ )
+  {
+    if( tpcmon_PEDESTSUBADCSAMPLE_R1[i] )
+    {
+      TC[19]->cd(i+5);
+      gStyle->SetPalette(57); //kBird CVD friendly
+      gPad->SetLogz(kTRUE);
+      tpcmon_PEDESTSUBADCSAMPLE_R1[i] -> DrawCopy("colz");
+    }
+  }
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_PEDEST_SUB_ADC_vs_SAMPLE R1 ONLY Run " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  transparent[18]->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+
+  TC[19]->Update();
+  TC[19]->Show();
+  TC[19]->SetEditable(false);
+
+  return 0;
+}
+
+int TpcMonDraw::DrawTPCPedestSubADCSample_R2(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH2 *tpcmon_PEDESTSUBADCSAMPLE_R2[24] = {nullptr};
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_PEDESTSUBADCSAMPLE_R2[i] = (TH2*) cl->getHisto(TPCMON_STR,"PEDEST_SUB_ADC_vs_SAMPLE_R2");
+  }
+
+
+  if (!gROOT->FindObject("TPCPedestSubADCSample_R2"))
+  {
+    MakeCanvas("TPCPedestSubADCSample_R2");
+  }  
+
+  TC[20]->SetEditable(true);
+  TC[20]->Clear("D");
+
+  for( int i=0; i<24; i++ )
+  {
+    if( tpcmon_PEDESTSUBADCSAMPLE_R2[i] )
+    {
+      TC[20]->cd(i+5);
+      gStyle->SetPalette(57); //kBird CVD friendly
+      gPad->SetLogz(kTRUE);
+      tpcmon_PEDESTSUBADCSAMPLE_R2[i] -> DrawCopy("colz");
+    }
+  }
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_PEDEST_SUB_ADC_vs_SAMPLE R2 ONLY Run " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  transparent[19]->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+
+  TC[20]->Update();
+  TC[20]->Show();
+  TC[20]->SetEditable(false);
+
+  return 0;
+}
+
+int TpcMonDraw::DrawTPCPedestSubADCSample_R3(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH2 *tpcmon_PEDESTSUBADCSAMPLE_R3[24] = {nullptr};
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_PEDESTSUBADCSAMPLE_R3[i] = (TH2*) cl->getHisto(TPCMON_STR,"PEDEST_SUB_ADC_vs_SAMPLE_R3");
+  }
+
+
+  if (!gROOT->FindObject("TPCPedestSubADCSample_R3"))
+  {
+    MakeCanvas("TPCPedestSubADCSample_R3");
+  }  
+
+  TC[21]->SetEditable(true);
+  TC[21]->Clear("D");
+
+  for( int i=0; i<24; i++ )
+  {
+    if( tpcmon_PEDESTSUBADCSAMPLE_R3[i] )
+    {
+      TC[21]->cd(i+5);
+      gStyle->SetPalette(57); //kBird CVD friendly
+      gPad->SetLogz(kTRUE);
+      tpcmon_PEDESTSUBADCSAMPLE_R3[i] -> DrawCopy("colz");
+    }
+  }
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_PEDEST_SUB_ADC_vs_SAMPLE R3 ONLY Run " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  transparent[20]->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+
+  TC[21]->Update();
+  TC[21]->Show();
+  TC[21]->SetEditable(false);
+
+  return 0;
+}
 
 int TpcMonDraw::SavePlot(const std::string &what, const std::string &type)
 {

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -33,6 +33,9 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCCheckSum(const std::string &what = "ALL");
   int DrawTPCADCSample(const std::string &what = "ALL");
   int DrawTPCPedestSubADCSample(const std::string &what = "ALL");
+  int DrawTPCPedestSubADCSample_R1(const std::string &what = "ALL");
+  int DrawTPCPedestSubADCSample_R2(const std::string &what = "ALL");
+  int DrawTPCPedestSubADCSample_R3(const std::string &what = "ALL");
   int DrawTPCADCSampleLarge(const std::string &what = "ALL");
   int DrawTPCMaxADCModule(const std::string &what = "ALL");
   int DrawTPCRawADC1D(const std::string &what = "ALL");
@@ -46,8 +49,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCNEventsvsEBDC(const std::string &wht = "ALL");
   time_t getTime();
   
-  TCanvas *TC[19] = {nullptr};
-  TPad *transparent[18] = {nullptr};
+  TCanvas *TC[22] = {nullptr};
+  TPad *transparent[21] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.h
subystems/tpc/TpcMon.cc
subystems/tpc/TpcMonDraw.h
subystems/tpc/TpcMonDraw.cc
macros/run_tpc_client.C

**Changes:**

Added R1,R2, R3 only (module x module) Pedestal Subtracted ADC vs. SAMPLE. Pedestal comes from median in waveform.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
