### PR TITLE
protect against running two copies in case it takes longer than 10 minutes to run

### DIFF
--- a/scripts/makehtml.sh
+++ b/scripts/makehtml.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
+[[ -e htmlrunning ]] && exit 0
+echo $$ > htmlrunning
 source ./setup_all.sh
 Xvfb :0 -nolisten tcp &
 export DISPLAY=unix:0
 perl makehtml.pl >& /sphenix/u/sphnxpro/makehmtl.log
 kill $!
+rm htmlrunning


### PR DESCRIPTION
It looks like we had multiple copies of this script running. It now touches a file at startup and removes it at exit, if it finds this file it quits