### PR TITLE
modernize makefiles

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ dnl   no point in suppressing warnings people should
 dnl   at least see them, so here we go for g++: -Wall
 if test $ac_cv_cxx_compiler_gnu = yes; then
 dnl  CXXFLAGS="$CXXFLAGS -Wall"
-  CXXFLAGS="$CXXFLAGS -Wno-deprecated-declarations -Wall -Werror -Wextra -Wshadow -Woverloaded-virtual"
+  CXXFLAGS="$CXXFLAGS -Wall -Wextra -Wshadow -Werror"
 fi
 
 ROOTLIBS="`$ROOTSYS/bin/root-config --glibs`"

--- a/onlmonclient/Makefile.am
+++ b/onlmonclient/Makefile.am
@@ -2,15 +2,9 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
-  -I$(OPT_SPHENIX)/include \
+  -isystem$(ONLINE_MAIN)/include \
+  -isystem$(OPT_SPHENIX)/include \
   -isystem$(ROOTSYS)/include 
-
-RINCLUDES = \
-  -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
-  -I$(OPT_SPHENIX)/include \
-  -I$(ROOTSYS)/include 
 
 BUILT_SOURCES = \
   testexternals.cc

--- a/onlmondatabase/Makefile.am
+++ b/onlmondatabase/Makefile.am
@@ -4,8 +4,8 @@ AM_LDFLAGS = -L$(libdir)
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
-  -I$(OPT_SPHENIX)/include \
+  -isystem$(ONLINE_MAIN)/include \
+  -isystem$(OPT_SPHENIX)/include \
   -isystem$(ROOTSYS)/include 
 
 BUILT_SOURCES = \

--- a/onlmonserver/Makefile.am
+++ b/onlmonserver/Makefile.am
@@ -2,15 +2,9 @@ AUTOMAKE_OPTIONS = foreign
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
-  -I$(OPT_SPHENIX)/include \
+  -isystem$(ONLINE_MAIN)/include \
+  -isystem$(OPT_SPHENIX)/include \
   -isystem$(ROOTSYS)/include
-
-RINCLUDES = \
-  -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
-  -I$(OPT_SPHENIX)/include \
-  -I$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \
   libonlmonserver.la \

--- a/onlmonutils/Makefile.am
+++ b/onlmonutils/Makefile.am
@@ -6,7 +6,7 @@ BUILT_SOURCES = \
 AM_CPPFLAGS = \
   -I$(includedir) \
   -I$(ONLMON_MAIN)/include \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/bbc/Makefile.am
+++ b/subsystems/bbc/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/cemc/Makefile.am
+++ b/subsystems/cemc/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/daq/Makefile.am
+++ b/subsystems/daq/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/example/Makefile.am
+++ b/subsystems/example/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/hcal/Makefile.am
+++ b/subsystems/hcal/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/intt/Makefile.am
+++ b/subsystems/intt/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/ll1/Makefile.am
+++ b/subsystems/ll1/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/mvtx/Makefile.am
+++ b/subsystems/mvtx/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/pktsize/Makefile.am
+++ b/subsystems/pktsize/Makefile.am
@@ -5,8 +5,8 @@ BUILT_SOURCES = \
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
-  -I$(OPT_SPHENIX)/include \
+  -isystem$(ONLINE_MAIN)/include \
+  -isystem$(OPT_SPHENIX)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/sepd/Makefile.am
+++ b/subsystems/sepd/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/spin/Makefile.am
+++ b/subsystems/spin/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/tpc/Makefile.am
+++ b/subsystems/tpc/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \

--- a/subsystems/tpot/Makefile.am
+++ b/subsystems/tpot/Makefile.am
@@ -7,8 +7,8 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
-  -I$(OFFLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
+  -isystem$(OFFLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 AM_LDFLAGS = \

--- a/subsystems/zdc/Makefile.am
+++ b/subsystems/zdc/Makefile.am
@@ -7,7 +7,7 @@ SUBDIRS = calib
 
 AM_CPPFLAGS = \
   -I$(includedir) \
-  -I$(ONLINE_MAIN)/include \
+  -isystem$(ONLINE_MAIN)/include \
   -isystem$(ROOTSYS)/include
 
 lib_LTLIBRARIES = \


### PR DESCRIPTION
This PR updates the Makefile.am's to use -isystem so we don't debug includes from e.g. odbc