### PR TITLE
Adding Diffuse Laser Histo: takes peak ADC b/w sample 310 & 350 and plots in XY weighted by ADC-ped.

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -28,6 +28,10 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("NorthSideADC_clusterXY_R2", TPCMON_STR);
     cl->registerHisto("NorthSideADC_clusterXY_R3", TPCMON_STR);
 
+    cl->registerHisto("NorthSideADC_clusterXY_R1_LASER", TPCMON_STR);
+    cl->registerHisto("NorthSideADC_clusterXY_R2_LASER", TPCMON_STR);
+    cl->registerHisto("NorthSideADC_clusterXY_R3_LASER", TPCMON_STR);
+
     cl->registerHisto("NorthSideADC_clusterXY_R1_unw", TPCMON_STR);
     cl->registerHisto("NorthSideADC_clusterXY_R2_unw", TPCMON_STR);
     cl->registerHisto("NorthSideADC_clusterXY_R3_unw", TPCMON_STR);
@@ -37,6 +41,10 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("SouthSideADC_clusterXY_R1", TPCMON_STR);
     cl->registerHisto("SouthSideADC_clusterXY_R2", TPCMON_STR);
     cl->registerHisto("SouthSideADC_clusterXY_R3", TPCMON_STR);
+
+    cl->registerHisto("SouthSideADC_clusterXY_R1_LASER", TPCMON_STR);
+    cl->registerHisto("SouthSideADC_clusterXY_R2_LASER", TPCMON_STR);
+    cl->registerHisto("SouthSideADC_clusterXY_R3_LASER", TPCMON_STR);
 
     cl->registerHisto("SouthSideADC_clusterXY_R1_unw", TPCMON_STR);
     cl->registerHisto("SouthSideADC_clusterXY_R2_unw", TPCMON_STR);

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -98,7 +98,6 @@ int TpcMon::Init()
   NorthSideADC_clusterXY_R3->SetXTitle("X [mm]");
   NorthSideADC_clusterXY_R3->SetYTitle("Y [mm]");
 
-
   //SouthSideADC_clusterXY_R1 = new TH2F("SouthSideADC_clusterXY_R1" , "ADC Peaks South Side", N_phi_binx_XY_R1, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
   SouthSideADC_clusterXY_R1 = new TH2F("SouthSideADC_clusterXY_R1" , "(ADC-Pedestal) > 5#sigma South Side", 400, -800, 800, 400, -800, 800);
   SouthSideADC_clusterXY_R1->SetXTitle("X [mm]");
@@ -113,6 +112,39 @@ int TpcMon::Init()
   SouthSideADC_clusterXY_R3 = new TH2F("SouthSideADC_clusterXY_R3" , "(ADC-Pedestal) > 5#sigma South Side", 400, -800, 800, 400, -800, 800);
   SouthSideADC_clusterXY_R3->SetXTitle("X [mm]");
   SouthSideADC_clusterXY_R3->SetYTitle("Y [mm]");
+
+  //____________________________________________________________________//
+
+  //TPC "cluster" XY heat maps DURING LASER TIME WEIGHTED
+  //
+  NorthSideADC_clusterXY_R1_LASER = new TH2F("NorthSideADC_clusterXY_R1_LASER" , "(ADC-Pedestal) > 5#sigma North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R1_LASER->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R1_LASER->SetYTitle("Y [mm]");
+
+  //
+  NorthSideADC_clusterXY_R2_LASER = new TH2F("NorthSideADC_clusterXY_R2_LASER" , "(ADC-Pedestal) > 5#sigma North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R2_LASER->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R2_LASER->SetYTitle("Y [mm]");
+
+  //
+  NorthSideADC_clusterXY_R3_LASER = new TH2F("NorthSideADC_clusterXY_R3_LASER" , "(ADC-Pedestal) > 5#sigma North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R3_LASER->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R3_LASER->SetYTitle("Y [mm]");
+
+  //
+  SouthSideADC_clusterXY_R1_LASER = new TH2F("SouthSideADC_clusterXY_R1_LASER" , "(ADC-Pedestal) > 5#sigma South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R1_LASER->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R1_LASER->SetYTitle("Y [mm]");
+
+  //
+  SouthSideADC_clusterXY_R2_LASER = new TH2F("SouthSideADC_clusterXY_R2_LASER" , "(ADC-Pedestal) > 5#sigma South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R2_LASER->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R2_LASER->SetYTitle("Y [mm]");
+
+  //  
+  SouthSideADC_clusterXY_R3_LASER = new TH2F("SouthSideADC_clusterXY_R3_LASER" , "(ADC-Pedestal) > 5#sigma South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R3_LASER->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R3_LASER->SetYTitle("Y [mm]");
 
   //____________________________________________________________________//
 
@@ -394,6 +426,14 @@ int TpcMon::Init()
   se->registerHisto(this, SouthSideADC_clusterXY_R2_unw);
   se->registerHisto(this, SouthSideADC_clusterXY_R3_unw);
 
+  se->registerHisto(this, NorthSideADC_clusterXY_R1_LASER);
+  se->registerHisto(this, NorthSideADC_clusterXY_R2_LASER);
+  se->registerHisto(this, NorthSideADC_clusterXY_R3_LASER);
+
+  se->registerHisto(this, SouthSideADC_clusterXY_R1_LASER);
+  se->registerHisto(this, SouthSideADC_clusterXY_R2_LASER);
+  se->registerHisto(this, SouthSideADC_clusterXY_R3_LASER);
+
   se->registerHisto(this, NorthSideADC_clusterZY);
   se->registerHisto(this, SouthSideADC_clusterZY);
 
@@ -580,6 +620,9 @@ int TpcMon::process_event(Event *evt/* evt */)
 
         float pedest_sub_wf_max = 0.;
 
+        int wf_max_laser_peak = 0;
+        float pedest_sub_wf_max_laser_peak = 0.;
+
         for( int s =0; s < nr_Samples ; s++ )
         {
           
@@ -590,6 +633,8 @@ int TpcMon::process_event(Event *evt/* evt */)
           Layer_ChannelPhi_ADC_weighted->Fill(padphi,layer,adc-pedestal);
 
           if( adc > wf_max){ wf_max = adc; t_max = s; pedest_sub_wf_max = adc - pedestal;}
+
+          if( (s> 310 && s < 350) && (adc > wf_max_laser_peak) ){ wf_max_laser_peak = adc; pedest_sub_wf_max_laser_peak = adc - pedestal; }   
 
           if( s >= 10 && s <= 19) // get first 10-19
           {
@@ -654,6 +699,20 @@ int TpcMon::process_event(Event *evt/* evt */)
           else if(Module_ID(fee)==2){SouthSideADC_clusterXY_R3->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterXY_R3_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R3
 
           if( t_max >= 10 && t_max <=255 ){z = -1030 + (t_max - 10)*(50 * 0.084);SouthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
+        }
+        //________________________________________________________________________________
+        //XY laser peak
+        if( (serverid < 12 && (pedest_sub_wf_max_laser_peak) > std::max(5.0*noise,20.)) && layer != 0 )
+        {
+          if(Module_ID(fee)==0){NorthSideADC_clusterXY_R1_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R1
+          else if(Module_ID(fee)==1){NorthSideADC_clusterXY_R2_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R2
+          else if(Module_ID(fee)==2){NorthSideADC_clusterXY_R3_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R3
+        }
+        else if( (serverid >=12 && (pedest_sub_wf_max_laser_peak) > std::max(5.0*noise,20.)) && layer != 0)
+        {
+          if(Module_ID(fee)==0){SouthSideADC_clusterXY_R1_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R1
+          else if(Module_ID(fee)==1){SouthSideADC_clusterXY_R2_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R2
+          else if(Module_ID(fee)==2){SouthSideADC_clusterXY_R3_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R3
         }
         //________________________________________________________________________________
 

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -58,6 +58,14 @@ class TpcMon : public OnlMon
   TH2 *SouthSideADC_clusterXY_R2 = nullptr;
   TH2 *SouthSideADC_clusterXY_R3 = nullptr;
 
+  TH2 *NorthSideADC_clusterXY_R1_LASER = nullptr;
+  TH2 *NorthSideADC_clusterXY_R2_LASER = nullptr;
+  TH2 *NorthSideADC_clusterXY_R3_LASER = nullptr;
+
+  TH2 *SouthSideADC_clusterXY_R1_LASER = nullptr;
+  TH2 *SouthSideADC_clusterXY_R2_LASER = nullptr;
+  TH2 *SouthSideADC_clusterXY_R3_LASER = nullptr;
+
   TH2 *NorthSideADC_clusterXY_R1_unw = nullptr;
   TH2 *NorthSideADC_clusterXY_R2_unw = nullptr;
   TH2 *NorthSideADC_clusterXY_R3_unw = nullptr;

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -174,7 +174,7 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
   }
   else if (name == "TPCClusterXY")
   {
-    TC[10] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)> 20 ADC for NS and SS, WEIGHTED", 1350, 700);
+    TC[10] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)>  (20 ADC || 5sigma) for NS and SS, WEIGHTED", 1350, 700);
     gSystem->ProcessEvents();
     //gStyle->SetPalette(57); //kBird CVD friendly
     TC[10]->Divide(2,1);
@@ -186,7 +186,7 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
   }
   else if (name == "TPCClusterXY_unw")
   {
-    TC[11] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)> 20 ADC for NS and SS, UNWEIGHTED", 1350, 700);
+    TC[11] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)>  (20 ADC || 5sigma) for NS and SS, UNWEIGHTED", 1350, 700);
     gSystem->ProcessEvents();
     //gStyle->SetPalette(57); //kBird CVD friendly
     TC[11]->Divide(2,1);
@@ -210,7 +210,7 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
 
   else if (name == "TPCClusterZY")
   {
-    TC[13] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)> 5#sigma for NS and SS, WEIGHTED", 1350, 700);
+    TC[13] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)> (20 ADC || 5sigma) for NS and SS, WEIGHTED", 1350, 700);
     gSystem->ProcessEvents();
     //gStyle->SetPalette(57); //kBird CVD friendly
     TC[13]->Divide(1,1);
@@ -223,7 +223,7 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
 
   else if (name == "TPCClusterZY_unw")
   {
-    TC[14] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)>  5#sigma for NS and SS, UNWEIGHTED", 1350, 700);
+    TC[14] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)> (20 ADC || 5sigma) for NS and SS, UNWEIGHTED", 1350, 700);
     gSystem->ProcessEvents();
     //gStyle->SetPalette(57); //kBird CVD friendly
     TC[14]->Divide(1,1);
@@ -311,6 +311,18 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     transparent[20] = new TPad("transparent20", "this does not show", 0, 0, 1, 1);
     transparent[20]->SetFillStyle(4000);
     transparent[20]->Draw();
+    TC[21]->SetEditable(false);
+  }
+  else if (name == "TPCClusterXY_laser")
+  {
+    TC[22] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)> (20 ADC || 5sigma) for NS and SS, LASER FLASH ONLY, WEIGHTED", 1350, 700);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[22]->Divide(2,1);
+    // this one is used to plot the run number on the canvas
+    transparent[21] = new TPad("transparent9", "this does not show", 0, 0, 1, 1);
+    transparent[21]->SetFillStyle(4000);
+    transparent[21]->Draw();
     TC[21]->SetEditable(false);
   }      
   return 0;
@@ -423,6 +435,11 @@ int TpcMonDraw::Draw(const std::string &what)
   if (what == "ALL" || what == "TPCPEDESTSUBADCVSSAMPLE_R3" )
   {
     iret += DrawTPCPedestSubADCSample_R3(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCLASERCLUSTERSXYWEIGTHED")
+  {
+    iret += DrawTPCXYlaserclusters(what);
     idraw++;
   }
   if (!idraw)
@@ -1105,8 +1122,8 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
   TH2 *tpcmon_NSTPC_clusXY[24][3] = {nullptr};
   TH2 *tpcmon_SSTPC_clusXY[24][3] = {nullptr};
 
-  dummy_his1_XY = new TH2F("dummy_his1_XY", "(ADC-Pedestal) > 5#sigma North Side, WEIGHTED", 400, -800, 800, 400, -800, 800); //dummy histos for titles
-  dummy_his2_XY = new TH2F("dummy_his2_XY", "(ADC-Pedestal) > 5#sigma South Side, WEIGHTED", 400, -800, 800, 400, -800, 800);
+  dummy_his1_XY = new TH2F("dummy_his1_XY", "(ADC-Pedestal) > (5#sigma||20ADC) North Side, WEIGHTED", 400, -800, 800, 400, -800, 800); //dummy histos for titles
+  dummy_his2_XY = new TH2F("dummy_his2_XY", "(ADC-Pedestal) > (5#sigma||20ADC) South Side, WEIGHTED", 400, -800, 800, 400, -800, 800);
 
   dummy_his1_XY->SetXTitle("X [mm]");
   dummy_his1_XY->SetYTitle("Y [mm]");
@@ -1169,7 +1186,7 @@ int TpcMonDraw::DrawTPCXYclusters(const std::string & /* what */)
   std::string runstring;
   time_t evttime = cl->EventTime("CURRENT");
   // fill run number and event time into string
-  runnostream << ThisName << "_ADC-Pedestal>5sigma WEIGHTED, Run" << cl->RunNumber()
+  runnostream << ThisName << "_ADC-Pedestal>(5sigma||20ADC) WEIGHTED, Run" << cl->RunNumber()
               << ", Time: " << ctime(&evttime);
   runstring = runnostream.str();
   transparent[9]->cd();
@@ -1273,8 +1290,8 @@ int TpcMonDraw::DrawTPCXYclusters_unweighted(const std::string & /* what */)
   TH2 *tpcmon_NSTPC_clusXY[24][3] = {nullptr};
   TH2 *tpcmon_SSTPC_clusXY[24][3] = {nullptr};
 
-  dummy_his1_XY_unw = new TH2F("dummy_his1_XY_unw", "(ADC-Pedestal) > 5#sigma North Side, UNWEIGHTED", 400, -800, 800, 400, -800, 800); //dummy histos for titles
-  dummy_his2_XY_unw = new TH2F("dummy_his2_XY_unw", "(ADC-Pedestal) > 5#sigma South Side, UNWEIGHTED", 400, -800, 800, 400, -800, 800);
+  dummy_his1_XY_unw = new TH2F("dummy_his1_XY_unw", "(ADC-Pedestal) > (5#sigma||20ADC) North Side, UNWEIGHTED", 400, -800, 800, 400, -800, 800); //dummy histos for titles
+  dummy_his2_XY_unw = new TH2F("dummy_his2_XY_unw", "(ADC-Pedestal) > (5#sigma||20ADC) South Side, UNWEIGHTED", 400, -800, 800, 400, -800, 800);
 
   dummy_his1_XY_unw->SetXTitle("X [mm]");
   dummy_his1_XY_unw->SetYTitle("Y [mm]");
@@ -1337,7 +1354,7 @@ int TpcMonDraw::DrawTPCXYclusters_unweighted(const std::string & /* what */)
   std::string runstring;
   time_t evttime = cl->EventTime("CURRENT");
   // fill run number and event time into string
-  runnostream << ThisName << "_ADC-Pedestal>5 sigma, UNWEIGHTED, Run " << cl->RunNumber()
+  runnostream << ThisName << "_ADC-Pedestal>(5sigma||20ADC), UNWEIGHTED, Run " << cl->RunNumber()
               << ", Time: " << ctime(&evttime);
   runstring = runnostream.str();
   transparent[10]->cd();
@@ -1501,7 +1518,7 @@ int TpcMonDraw::DrawTPCZYclusters(const std::string & /* what */)
   TH2 *tpcmon_NSTPC_clusZY[24] = {nullptr};
   TH2 *tpcmon_SSTPC_clusZY[24] = {nullptr};
 
-  dummy_his1_ZY = new TH2F("dummy_his1_ZY", "(ADC-Pedestal) > 5#sigma, WEIGHTED", 515, -1030, 1030, 400, -800, 800); //dummy histos for titles
+  dummy_his1_ZY = new TH2F("dummy_his1_ZY", "(ADC-Pedestal) > ((5#sigma||20ADC), WEIGHTED", 515, -1030, 1030, 400, -800, 800); //dummy histos for titles
   dummy_his1_ZY->SetXTitle("Z [mm]");
   dummy_his1_ZY->SetYTitle("Y [mm]");
 
@@ -1532,7 +1549,7 @@ int TpcMonDraw::DrawTPCZYclusters(const std::string & /* what */)
   std::string runstring;
   time_t evttime = cl->EventTime("CURRENT");
   // fill run number and event time into string
-  runnostream << ThisName << "_ADC-Pedestal>5 sigma, WEIGHTED, Run " << cl->RunNumber()
+  runnostream << ThisName << "_ADC-Pedestal>(5sigma||20ADC), WEIGHTED, Run " << cl->RunNumber()
               << ", Time: " << ctime(&evttime);
   runstring = runnostream.str();
   transparent[12]->cd();
@@ -1599,7 +1616,7 @@ int TpcMonDraw::DrawTPCZYclusters_unweighted(const std::string & /* what */)
   TH2 *tpcmon_NSTPC_clusZY_unw[24] = {nullptr};
   TH2 *tpcmon_SSTPC_clusZY_unw[24] = {nullptr};
 
-  dummy_his1_ZY_unw = new TH2F("dummy_his1_ZY_unw", "(ADC-Pedestal) > 5#sigma, UNWEIGHTED", 515, -1030, 1030, 400, -800, 800); //dummy histos for titles
+  dummy_his1_ZY_unw = new TH2F("dummy_his1_ZY_unw", "(ADC-Pedestal) > (5#sigma||20ADC), UNWEIGHTED", 515, -1030, 1030, 400, -800, 800); //dummy histos for titles
   dummy_his1_ZY_unw->SetXTitle("Z [mm]");
   dummy_his1_ZY_unw->SetYTitle("Y [mm]");
 
@@ -1630,7 +1647,7 @@ int TpcMonDraw::DrawTPCZYclusters_unweighted(const std::string & /* what */)
   std::string runstring;
   time_t evttime = cl->EventTime("CURRENT");
   // fill run number and event time into string
-  runnostream << ThisName << "_ADC-Pedestal>5 sigma, UNWEIGHTED, Run " << cl->RunNumber()
+  runnostream << ThisName << "_ADC-Pedestal>(5sigma||20ADC), UNWEIGHTED, Run " << cl->RunNumber()
               << ", Time: " << ctime(&evttime);
   runstring = runnostream.str();
   transparent[13]->cd();
@@ -2130,6 +2147,174 @@ int TpcMonDraw::DrawTPCPedestSubADCSample_R3(const std::string & /* what */)
   TC[21]->Update();
   TC[21]->Show();
   TC[21]->SetEditable(false);
+
+  return 0;
+}
+
+int TpcMonDraw::DrawTPCXYlaserclusters(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH2 *tpcmon_NSTPC_laser_clusXY[24][3] = {nullptr};
+  TH2 *tpcmon_SSTPC_laser_clusXY[24][3] = {nullptr};
+
+  dummy_his1_laser_XY = new TH2F("dummy_his1_laser_XY", "(ADC-Pedestal) > (5#sigma||20ADC) North Side, WEIGHTED", 400, -800, 800, 400, -800, 800); //dummy histos for titles
+  dummy_his2_laser_XY = new TH2F("dummy_his2_laser_XY", "(ADC-Pedestal) > (5#sigma||20ADC) South Side, WEIGHTED", 400, -800, 800, 400, -800, 800);
+
+  dummy_his1_laser_XY->SetXTitle("X [mm]");
+  dummy_his1_laser_XY->SetYTitle("Y [mm]");
+  dummy_his1_laser_XY->GetYaxis()->SetTitleSize(0.02);
+
+  dummy_his2_laser_XY->SetXTitle("-X [mm]"); //SS x is flipped from global coordinates
+  dummy_his2_laser_XY->SetYTitle("Y [mm]");
+  dummy_his2_laser_XY->GetYaxis()->SetTitleSize(0.02);
+
+  //the lines are for the sector boundaries
+  Double_t sec_gap_inner = (2*M_PI - 0.5024*12.0)/12.0;
+
+  Double_t sec_gap_outer = (2*M_PI - 0.5097*12.0)/12.0;
+
+  Double_t sec_gap = (sec_gap_inner + sec_gap_outer)/2.0;
+
+  Double_t sec_phi = (0.5024 + 0.5097)/2.0;
+
+  TLine *lines[12];
+
+  for(int ln=0;ln<12;ln++)
+  {
+    lines[ln] = new TLine(311.05*cos((sec_phi+sec_gap)/2.0+ln*(sec_phi+sec_gap)),311.05*sin((sec_phi+sec_gap)/2.0+ln*(sec_phi+sec_gap)),759.11*cos((sec_phi+sec_gap)/2.0+ln*(sec_phi+sec_gap)),759.11*sin((sec_phi+sec_gap)/2.0+ln*(sec_phi+sec_gap)));
+  }
+
+  TEllipse *e1 = new TEllipse(0.0,0.0,311.05,311.05);
+  TEllipse *e2 = new TEllipse(0.0,0.0,(402.49+411.53)/2.0,(402.49+411.53)/2.0);
+  TEllipse *e3 = new TEllipse(0.0,0.0,(583.67+574.75)/2.0,(583.67+574.75)/2.0);
+  TEllipse *e4 = new TEllipse(0.0,0.0,759.11,759.11);
+  //__________________
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_NSTPC_laser_clusXY[i][0] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R1_LASER");
+    tpcmon_NSTPC_laser_clusXY[i][1] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R2_LASER");
+    tpcmon_NSTPC_laser_clusXY[i][2] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R3_LASER");
+
+    tpcmon_SSTPC_laser_clusXY[i][0] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R1_LASER");
+    tpcmon_SSTPC_laser_clusXY[i][1] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R2_LASER");
+    tpcmon_SSTPC_laser_clusXY[i][2] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R3_LASER");
+  }
+
+  if (!gROOT->FindObject("TPCClusterXY_laser"))
+  {
+    MakeCanvas("TPCClusterXY_laser");
+  }  
+
+  TC[22]->SetEditable(true);
+  TC[22]->Clear("D");
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_ADC-Pedestal>(5sigma||20ADC) WEIGHTED, Run" << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  transparent[21]->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+  TC[22]->cd(1);
+  gStyle->SetOptStat(kFALSE);
+  gPad->SetTopMargin(0.15);
+  gPad->SetLogz(kTRUE);
+  dummy_his1_laser_XY->Draw("colzsame");
+
+  float NS_max = 0;
+  for( int i=0; i<12; i++ )
+  {
+    for( int j=0; j<3; j++ )
+    {
+      if( tpcmon_NSTPC_laser_clusXY[i][j] )
+      {
+        TC[22]->cd(1);
+        tpcmon_NSTPC_laser_clusXY[i][j] -> Draw("colzsame");
+        //gStyle->SetLogz(kTRUE);
+        if ( tpcmon_NSTPC_laser_clusXY[i][j]->GetBinContent(tpcmon_NSTPC_laser_clusXY[i][j]->GetMaximumBin()) > NS_max)
+        {
+          NS_max = tpcmon_NSTPC_laser_clusXY[i][j]->GetBinContent(tpcmon_NSTPC_laser_clusXY[i][j]->GetMaximumBin());
+          dummy_his1_laser_XY->SetMaximum( NS_max );
+        }
+        gStyle->SetPalette(57); //kBird CVD friendly
+      }
+
+    }
+  }
+  TC[22]->cd(1);
+  e1->SetFillStyle(0);
+  e2->SetFillStyle(0);
+  e3->SetFillStyle(0);
+  e4->SetFillStyle(0);
+
+  e1->Draw("same");
+  e2->Draw("same");
+  e3->Draw("same");
+  e4->Draw("same");
+  for(int ln2=0;ln2<12;ln2++)
+  {
+    lines[ln2]->Draw("same"); 
+  }
+  TC[22]->Update();
+
+  TC[22]->cd(2);
+  gStyle->SetOptStat(kFALSE);
+  gPad->SetTopMargin(0.15);
+  gPad->SetLogz(kTRUE);
+  dummy_his2_laser_XY->Draw("colzsame");
+
+  float SS_max = 0;
+  for( int i=0; i<12; i++ )
+  {
+    for( int j=0; j<3; j++ )
+    {
+      if( tpcmon_SSTPC_laser_clusXY[i+12][j] )
+      {
+        //std::cout<<"South Side Custer XY i: "<< i+12 <<", j: "<<j<<std::endl;
+        TC[22]->cd(2);
+        tpcmon_SSTPC_laser_clusXY[i+12][j] -> Draw("colzsame");
+        //gStyle->SetLogz(kTRUE);
+        if ( tpcmon_SSTPC_laser_clusXY[i+12][j]->GetBinContent(tpcmon_SSTPC_laser_clusXY[i+12][j]->GetMaximumBin()) > SS_max)
+        {
+          SS_max = tpcmon_SSTPC_laser_clusXY[i+12][j]->GetBinContent(tpcmon_SSTPC_laser_clusXY[i+12][j]->GetMaximumBin());
+          dummy_his2_laser_XY->SetMaximum( SS_max );
+        }
+        gStyle->SetPalette(57); //kBird CVD friendly
+      }
+    }
+
+  }
+  TC[22]->cd(2);
+  e1->SetFillStyle(0);
+  e2->SetFillStyle(0);
+  e3->SetFillStyle(0);
+  e4->SetFillStyle(0);
+
+  e1->Draw("same");
+  e2->Draw("same");
+  e3->Draw("same");
+  e4->Draw("same");
+  for(int ln2=0;ln2<12;ln2++)
+  {
+    lines[ln2]->Draw("same"); 
+  }
+
+  TC[22]->Update();
+  TC[22]->Show();
+  TC[22]->SetEditable(false);
 
   return 0;
 }

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -42,6 +42,7 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCMaxADC1D(const std::string &what = "ALL");
   int DrawTPCPedestSubADC1D(const std::string &what = "ALL");
   int DrawTPCXYclusters(const std::string &what = "ALL");
+  int DrawTPCXYlaserclusters(const std::string &what = "ALL");
   int DrawTPCXYclusters_unweighted(const std::string &what = "ALL");
   int DrawTPCZYclusters(const std::string &what = "ALL");
   int DrawTPCZYclusters_unweighted(const std::string &what = "ALL");
@@ -49,8 +50,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCNEventsvsEBDC(const std::string &wht = "ALL");
   time_t getTime();
   
-  TCanvas *TC[22] = {nullptr};
-  TPad *transparent[21] = {nullptr};
+  TCanvas *TC[23] = {nullptr};
+  TPad *transparent[22] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module
@@ -60,6 +61,9 @@ class TpcMonDraw : public OnlMonDraw
   //TPC Module
   TH2 *dummy_his1_XY = nullptr;
   TH2 *dummy_his2_XY = nullptr;
+
+  TH2 *dummy_his1_laser_XY = nullptr;
+  TH2 *dummy_his2_laser_XY = nullptr;
 
   TH2 *dummy_his1_ZY = nullptr;
 


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.h
subystems/tpc/TpcMon.cc
subystems/tpc/TpcMonDraw.h
subystems/tpc/TpcMonDraw.cc
macros/run_tpc_client.C

**Changes:**

Added plot which calculates peak ADC b/w samples 310 & 350 (as of 04/18/24, this is where diffuse laser pulse is located) and plots the XY weighted by ADC-Pedestal if ADC-Pedestal > MAX(5*sigma,20 ADC). Also adds some clarifying language in the plot titles with 5sigma||20 ADC 

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
