### PR TITLE
Fixing issue w/ diffuse laser XY histogram - transparency object shared name with another

### DIFF
--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -320,7 +320,7 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     //gStyle->SetPalette(57); //kBird CVD friendly
     TC[22]->Divide(2,1);
     // this one is used to plot the run number on the canvas
-    transparent[21] = new TPad("transparent9", "this does not show", 0, 0, 1, 1);
+    transparent[21] = new TPad("transparent21", "this does not show", 0, 0, 1, 1);
     transparent[21]->SetFillStyle(4000);
     transparent[21]->Draw();
     TC[21]->SetEditable(false);


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMonDraw.cc

**Changes:**

line 328 changed to make transparent[21] named transparent21

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
