### PR TITLE
Fixing issue w/ diffuse laser XY histogram - Canvas index && removing debug statements

### DIFF
--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -441,7 +441,6 @@ int TpcMonDraw::Draw(const std::string &what)
   {
     iret += DrawTPCXYlaserclusters(what);
     idraw++;
-    std::cout<<"You see the TPCLASERCLUSTERSXYWEIGTHED"<<std::endl; 
   }
   if (!idraw)
   {

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -323,7 +323,7 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     transparent[21] = new TPad("transparent21", "this does not show", 0, 0, 1, 1);
     transparent[21]->SetFillStyle(4000);
     transparent[21]->Draw();
-    TC[21]->SetEditable(false);
+    TC[22]->SetEditable(false);
   }      
   return 0;
 }
@@ -441,6 +441,7 @@ int TpcMonDraw::Draw(const std::string &what)
   {
     iret += DrawTPCXYlaserclusters(what);
     idraw++;
+    std::cout<<"You see the TPCLASERCLUSTERSXYWEIGTHED"<<std::endl; 
   }
   if (!idraw)
   {
@@ -2222,7 +2223,7 @@ int TpcMonDraw::DrawTPCXYlaserclusters(const std::string & /* what */)
   std::string runstring;
   time_t evttime = cl->EventTime("CURRENT");
   // fill run number and event time into string
-  runnostream << ThisName << "_ADC-Pedestal>(5sigma||20ADC) WEIGHTED, Run" << cl->RunNumber()
+  runnostream << ThisName << "_LASER_ADC-Pedestal>(5sigma||20ADC) WEIGHTED, Run" << cl->RunNumber()
               << ", Time: " << ctime(&evttime);
   runstring = runnostream.str();
   transparent[21]->cd();


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMonDraw.cc

**Changes:**

LIne 326 changed to TC[22] and debug statements removed

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

Persistent Scope Plot (ask Jin)
ADC vs ADC Bin per FEE
ADC vs Channel - Evgeny 2D plot in pad row coordinates
Stuck Channel Detection
BCO Plots?
Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
