### PR TITLE
align draw of SMD hit n/s hists

### DIFF
--- a/subsystems/zdc/ZdcMonDraw.cc
+++ b/subsystems/zdc/ZdcMonDraw.cc
@@ -369,14 +369,14 @@ int ZdcMonDraw::DrawFirst(const std::string & /* what */)
   }
 
   Pad[2]->cd();
-  if (smd_xy_north)
-  {
-    smd_xy_north->DrawCopy("colz");
-  }
-  Pad[3]->cd();
   if (smd_xy_south)
   {
     smd_xy_south->DrawCopy("colz");
+  }
+  Pad[3]->cd();
+  if (smd_xy_north)
+  {
+    smd_xy_north->DrawCopy("colz");
   }
 
   TText PrintRun;


### PR DESCRIPTION
Switch draw order of SMD hit n/s hists so they line up with ZDC ADC n/s hists above.