### PR TITLE
read number of smaples from packet

### DIFF
--- a/macros/CommonFuncs.C
+++ b/macros/CommonFuncs.C
@@ -3,10 +3,11 @@
 
 #include <onlmon/OnlMonClient.h>
 
+// cppcheck-suppress unknownMacro
+R__LOAD_LIBRARY(libonlmonclient.so)
 
 void CreateHostList(const int online = 0)
 {
-  cout << "online: " << online << endl;
   OnlMonClient *cl = OnlMonClient::instance();
   if (!online)
   {
@@ -67,30 +68,31 @@ void ClearCanvases()
 void CreateSubsysHostlist(const std::string &list, const int online)
 {
   if (online != 1)
-    {
-      CreateHostList(online);
-    }
+  {
+    CreateHostList(online);
+    return;
+  }
   OnlMonClient *cl = OnlMonClient::instance();  // get pointer to framewrk
   const char *hostlistdir = gSystem->Getenv("ONLMON_RUNDIR");
   char hostlistname[200];
-      if (hostlistdir)
-	{
-          char node[20];
-	  sprintf(hostlistname, "%s/%s", hostlistdir,list.c_str());
-	  cout << "trying to open " << hostlistname << endl;
-	  FILE *f = fopen(hostlistname, "r");
-	  if (! f)
-	    {
-	      CreateHostList(online);
-	      return;
-	    }
-	  while (fscanf(f, "%19s", &node[0]) != EOF)
-	    {
-	      cout << "adding " << node << endl;
-	      cl->AddServerHost(node);      // put monitoring machines in search list
-	    }
-	  fclose(f);
-	}
+  if (hostlistdir)
+  {
+    char node[20];
+    sprintf(hostlistname, "%s/%s", hostlistdir,list.c_str());
+    cout << "trying to open " << hostlistname << endl;
+    FILE *f = fopen(hostlistname, "r");
+    if (! f)
+    {
+      CreateHostList(online);
+      return;
+    }
+    while (fscanf(f, "%19s", &node[0]) != EOF)
+    {
+      cout << "adding " << node << endl;
+      cl->AddServerHost(node);      // put monitoring machines in search list
+    }
+    fclose(f);
+  }
 }
 
 #endif

--- a/subsystems/cemc/CemcMon.cc
+++ b/subsystems/cemc/CemcMon.cc
@@ -257,8 +257,8 @@ std::vector<float> CemcMon::getSignal(Packet *p, const int channel)
 std::vector<float> CemcMon::anaWaveformFast(Packet *p, const int channel)
 {
   std::vector<float> waveform;
-  waveform.reserve(m_nSamples);  
-  for ( int s = 0;  s < m_nSamples/*p->iValue(0,"SAMPLES")*/; s++) {
+  waveform.reserve(p->iValue(0,"SAMPLES"));
+  for ( int s = 0;  s < p->iValue(0,"SAMPLES"); s++) {
     waveform.push_back(p->iValue(s,channel));
   }
   std::vector<std::vector<float>> multiple_wfs;
@@ -276,8 +276,8 @@ std::vector<float> CemcMon::anaWaveformFast(Packet *p, const int channel)
 std::vector<float> CemcMon::anaWaveformTemp(Packet *p, const int channel)
 {
   std::vector<float> waveform;
-  waveform.reserve(m_nSamples);
-  for ( int s = 0;  s < m_nSamples/*p->iValue(0,"SAMPLES")*/; s++) {
+  waveform.reserve(p->iValue(0,"SAMPLES"));
+  for ( int s = 0;  s < p->iValue(0,"SAMPLES"); s++) {
     
     waveform.push_back(p->iValue(s,channel));
   }

--- a/subsystems/cemc/CemcMon.h
+++ b/subsystems/cemc/CemcMon.h
@@ -40,7 +40,6 @@ class CemcMon : public OnlMon
   const int Ntower = 64*2*192;
   const int packetlow = 6001;
   const int packethigh = 6128;
-  const int m_nSamples = 16;
   const int m_nChannels = 192;
   const int templateDepth = 10000;
   int eventCounter = 0;


### PR DESCRIPTION
This might fix the cemc waveform problem, the number of samples was hardcoded to 16 instead of getting this value from the packet (which is what the hcal monitoring does). This PR reverts to using the iValue for the number of channels again