### PR TITLE
Implemented BCO difference plot for INTT

### DIFF
--- a/macros/run_intt_client.C
+++ b/macros/run_intt_client.C
@@ -16,8 +16,9 @@ void inttDrawInit(const int online = 0)
 
   for(int felix = 0; felix < INTT::FELIX; ++felix)
   {
-    cl->registerHisto("InttNumEvents",	Form("INTTMON_%d", felix));
-    cl->registerHisto("InttMap",	Form("INTTMON_%d", felix));
+    cl->registerHisto("InttNumEvents",  Form("INTTMON_%d", felix));
+    cl->registerHisto("InttMap",        Form("INTTMON_%d", felix));
+    cl->registerHisto("InttBcoDiffMap", Form("INTTMON_%d", felix));
   }
   //cl->registerHisto("InttHitMapRef",	"INTTMON_0");
 

--- a/subsystems/intt/InttMon.h
+++ b/subsystems/intt/InttMon.h
@@ -37,6 +37,7 @@ class InttMon : public OnlMon
 
   //for testing/debugging without unpacker, remove later
   int MiscDebug();
+  int CheckBcoRoundTrip();
   void RandomEvent(int);
 
  private:
@@ -53,6 +54,7 @@ class InttMon : public OnlMon
 
   TH1D* NumEvents = nullptr;
   TH1D* HitMap = nullptr;
+  TH1D* BcoDiffMap = nullptr;
   //...
 };
 

--- a/subsystems/intt/InttMonConstants.cc
+++ b/subsystems/intt/InttMonConstants.cc
@@ -1,5 +1,56 @@
 #include "InttMonConstants.h"
 
+Color_t INTT::GetFeeColor(int fee)
+{
+  switch(fee % 7)
+  {
+	case 0:
+	  return (fee / 7) ? kGray + 3 : kBlack;
+    case 1:
+      return kRed + 3 * (fee / 7);
+    case 2:
+      return kYellow + 3 * (fee / 7);
+    case 3:
+      return kGreen + 3 * (fee / 7);
+    case 4:
+      return kCyan + 3 * (fee / 7);
+    case 5:
+      return kBlue + 3 * (fee / 7);
+    case 6:
+      return kMagenta + 3 * (fee / 7);
+  }
+  return kBlack;
+}
+
+void INTT::GetBcoBin(int& b, struct BcoData_s const& bco_data)
+{
+  int s = 1;
+  b = 0;
+
+  b += bco_data.bco * s;
+  s *= BCO;
+
+  b += bco_data.fee * s;
+  s *= FELIX_CHANNEL;
+
+  b += (bco_data.pid - 3001) * s;
+
+  ++b;
+}
+
+void INTT::GetBcoIndexes(int b, struct BcoData_s& bco_data)
+{
+  --b;
+
+  bco_data.bco = b % BCO;
+  b /= BCO;
+
+  bco_data.fee = b % FELIX_CHANNEL;
+  b /= FELIX_CHANNEL;
+
+  bco_data.pid = b + 3001;
+}
+
 void INTT::GetFelixBinFromIndexes(int& b, int felix_channel, struct Indexes_s const& indexes)
 {
   int s = 1;

--- a/subsystems/intt/InttMonConstants.h
+++ b/subsystems/intt/InttMonConstants.h
@@ -2,6 +2,7 @@
 #define INTT_MON_CONSTANTS_H
 
 #include <iostream>
+#include <TROOT.h>
 
 namespace INTT
 {
@@ -18,6 +19,8 @@ namespace INTT
   constexpr int CHIP = 26;
   constexpr int CHANNEL = 128;
   constexpr int ADC = 8;
+
+  constexpr int BCO = 128;
 
   constexpr int LADDERS_()
   {
@@ -37,6 +40,7 @@ namespace INTT
   constexpr int CHIPS = CHIP * FELIX_CHANNELS;
   constexpr int CHANNELS = CHANNEL * CHIPS;
   constexpr int ADCS = CHANNELS * ADC;
+  constexpr int BCOS = FELIX * FELIX_CHANNEL * BCO;
 
   struct Indexes_s
   {
@@ -47,6 +51,17 @@ namespace INTT
     int chn = 0;
     int adc = 0;
   };
+
+  struct BcoData_s
+  {
+    int pid = 0;
+	int fee = 0;
+	int bco = 0; // bco difference
+  };
+
+  void GetBcoBin(int&, struct BcoData_s const&);
+  void GetBcoIndexes(int, struct BcoData_s&);
+  Color_t GetFeeColor(int);
 
   void GetFelixBinFromIndexes(int&, int, struct Indexes_s const&);
   void GetFelixIndexesFromBin(int, int&, struct Indexes_s&);
@@ -62,6 +77,7 @@ namespace INTT
 
   void GetLocalChipBinXYFromIndexes(int&, int&, struct Indexes_s const&);
   void GetIndexesFromLocalChipBinXY(int const&, int const&, struct Indexes_s&);
+
 }  // namespace INTT
 
 //      Ladder Structure                //

--- a/subsystems/intt/InttMonDraw.h
+++ b/subsystems/intt/InttMonDraw.h
@@ -54,6 +54,9 @@ class InttMonDraw : public OnlMonDraw
   typedef std::map<std::string, struct Option_s> Options_t;
   static Options_t OPTIONS;
 
+  //BCO histograms
+  static void DrawBcoDiff(std::string const&);
+
   //GlobalChip-Channel idiom
   static void GlobalChipLocalChannelHead(std::string const&);
   static void DrawGlobalChipMap(std::string const&);
@@ -78,7 +81,7 @@ class InttMonDraw : public OnlMonDraw
   static void PrepLocalChipHists_Hitmap(std::string const&, TH2D**, struct INTT::Indexes_s&);
 
  private:
-  //===	Constants for Drawing	===//
+  //===  Constants for Drawing  ===//
   static constexpr double NUM_SIG = 2.0;
 
   static constexpr int CNVS_WIDTH = 1280;
@@ -92,17 +95,19 @@ class InttMonDraw : public OnlMonDraw
   static constexpr double TOP_FRAC = 0.05;
   static constexpr double DISP_FRAC = 0.1;
   static constexpr double DISP_TEXT_SIZE = 0.20;
+  static constexpr double LEGEND_TEXT_SIZE = 0.10;
 
   static constexpr double KEY_FRAC = 0.0;
+  static constexpr double LEGEND_FRAC = 0.1;
   static constexpr double Y_LABEL_FRAC = 0.05;
   static constexpr double X_LABEL_FRAC = 0.15;
   static constexpr double Y_LABEL_TEXT_SIZE = 0.5;
   static constexpr double X_LABEL_TEXT_SIZE = 0.5;
-  //===	~Constants for Drawing	===//
+  //===  ~Constants for Drawing  ===//
 
-  //===	Drawing Methods		===//
+  //===  Drawing Methods   ===//
   static void DrawPad(TPad*, TPad*);
-  //===	~Drawing Methods	===//
+  //===  ~Drawing Methods  ===//
 };
 
 #endif


### PR DESCRIPTION
Some members of the INTT want to check the output is consistent with an analogous QA plot (it is, but I want to let them verify this tonight).

When that happens I will switch this from a draft state and it can be merged tomorrow morning (assuming it passes all checks).

The new option is called "bco_diff" and can be invoked with InttMonDraw::Draw("bco_diff")