### PR TITLE
Fix zdc html

### DIFF
--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -520,6 +520,7 @@ int OnlMonClient::DoSomething(const std::string &who, const std::string &what, c
           std::cout << __PRETTY_FUNCTION__ << " creating html output for "
                     << iter->second->Name() << std::endl;
         }
+	iter->second->isHtml(true);
         if (iter->second->MakeHtml(what))
         {
           std::cout << "subsystem " << iter->second->Name()
@@ -561,6 +562,7 @@ int OnlMonClient::DoSomething(const std::string &who, const std::string &what, c
                     << iter->second->Name() << std::endl;
         }
         gROOT->Reset();
+	iter->second->isHtml(true);
         int iret = iter->second->MakeHtml(what);
         if (iret)
         {

--- a/subsystems/hcal/HcalMonDraw.cc
+++ b/subsystems/hcal/HcalMonDraw.cc
@@ -1320,7 +1320,6 @@ int HcalMonDraw::SavePlot(const std::string& what, const std::string& type)
 
 int HcalMonDraw::MakeHtml(const std::string& what)
 {
-  isHtml(true);
   int iret = Draw(what);
   if (iret)  // on error no html output please
   {


### PR DESCRIPTION
This PR fixes the missing wave for the zdc in the html output. More generalized html output in the future, isHtml flag now set in the OnlMonClient, not in the subsystem anymore