### PR TITLE
fix xingshift 

### DIFF
--- a/macros/run_spin_server.C
+++ b/macros/run_spin_server.C
@@ -7,7 +7,7 @@
 // cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlspinmon_server.so)
  
-void run_spin_server(const std::string &name = "SPINMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/lustre01/sphnxpro/commissioning/GL1/beam/GL1_beam_gl1daq-00040854-0000.evt")
+void run_spin_server(const std::string &name = "SPINMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/lustre01/sphnxpro/commissioning/GL1/beam/GL1_beam_gl1daq-00041936-0000.evt")
 {
   OnlMon *m = new SpinMon(name);                     // create subsystem Monitor object
   m->SetMonitorServerId(serverid);

--- a/subsystems/spin/SpinMon.cc
+++ b/subsystems/spin/SpinMon.cc
@@ -456,7 +456,7 @@ int SpinMon::process_event(Event *e /* evt */)
 
     //========================//
 
-    if (!success && evtcnt > 4999 && evtcnt % 5000 == 0)
+    if (evtcnt > 4999 && evtcnt % 5000 == 0)
     {
       CalculateCrossingShift(xingshift, scalercounts, success);
 
@@ -513,7 +513,12 @@ int SpinMon::CalculateCrossingShift(int &xing, uint64_t counts[NTRIG][NBUNCHES],
       long long abort_sum = 0;
       for (int iabortbunch = NBUNCHES - 9; iabortbunch < NBUNCHES; iabortbunch++)
       {
-        abort_sum += counts[itrig][(iabortbunch + ishift) % NBUNCHES];
+	int shiftbunch = iabortbunch - ishift;
+	if (shiftbunch < 0)
+	{
+	  shiftbunch = 120 + shiftbunch;
+	}
+        abort_sum += counts[itrig][(shiftbunch) % NBUNCHES];
       }
       if (abort_sum < abort_sum_prev)
       {

--- a/subsystems/spin/SpinMon.h
+++ b/subsystems/spin/SpinMon.h
@@ -40,7 +40,7 @@ class SpinMon : public OnlMon
 
   bool success = 0;
   // default xingshift
-  int defaultxingshift = 5;
+  int defaultxingshift = 3;
   // for additional xingshift
   int xingshift = 0;
   int addxingshift = -999;

--- a/subsystems/spin/SpinMon.h
+++ b/subsystems/spin/SpinMon.h
@@ -40,7 +40,7 @@ class SpinMon : public OnlMon
 
   bool success = 0;
   // default xingshift
-  int defaultxingshift = 3;
+  int defaultxingshift = 0;
   // for additional xingshift
   int xingshift = 0;
   int addxingshift = -999;


### PR DESCRIPTION
This PR fixes the miscalculation of the crossing shift and sets the default crossing shift to 0.