### PR TITLE
Adding in <= 5 Event XY hit display for Tom

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -32,6 +32,10 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("NorthSideADC_clusterXY_R2_LASER", servername);
     cl->registerHisto("NorthSideADC_clusterXY_R3_LASER", servername);
 
+    cl->registerHisto("NorthSideADC_clusterXY_R1_u5", servername);
+    cl->registerHisto("NorthSideADC_clusterXY_R2_u5", servername);
+    cl->registerHisto("NorthSideADC_clusterXY_R3_u5", servername);
+
     cl->registerHisto("NorthSideADC_clusterXY_R1_unw", servername);
     cl->registerHisto("NorthSideADC_clusterXY_R2_unw", servername);
     cl->registerHisto("NorthSideADC_clusterXY_R3_unw", servername);
@@ -45,6 +49,10 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("SouthSideADC_clusterXY_R1_LASER", servername);
     cl->registerHisto("SouthSideADC_clusterXY_R2_LASER", servername);
     cl->registerHisto("SouthSideADC_clusterXY_R3_LASER", servername);
+
+    cl->registerHisto("SouthSideADC_clusterXY_R1_u5", servername);
+    cl->registerHisto("SouthSideADC_clusterXY_R2_u5", servername);
+    cl->registerHisto("SouthSideADC_clusterXY_R3_u5", servername);
 
     cl->registerHisto("SouthSideADC_clusterXY_R1_unw", servername);
     cl->registerHisto("SouthSideADC_clusterXY_R2_unw", servername);

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -178,6 +178,40 @@ int TpcMon::Init()
 
   //____________________________________________________________________//
 
+  //TPC 5 event "cluster" XY heat maps WEIGHTED
+  //NorthSideADC_clusterXY_R1 = new TH2F("NorthSideADC_clusterXY_R1" , "ADC Peaks North Side", N_phi_binx_XY_R1, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  NorthSideADC_clusterXY_R1_u5 = new TH2F("NorthSideADC_clusterXY_R1_u5" , "(ADC-Pedestal) > 5#sigma North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R1_u5->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R1_u5->SetYTitle("Y [mm]");
+
+  //NorthSideADC_clusterXY_R2 = new TH2F("NorthSideADC_clusterXY_R2" , "ADC Peaks North Side", N_phi_binx_XY_R2, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  NorthSideADC_clusterXY_R2_u5 = new TH2F("NorthSideADC_clusterXY_R2_u5" , "(ADC-Pedestal) > 5#sigma North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R2_u5->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R2_u5->SetYTitle("Y [mm]");
+
+  //NorthSideADC_clusterXY_R3 = new TH2F("NorthSideADC_clusterXY_R3" , "ADC Peaks North Side", N_phi_binx_XY_R3, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  NorthSideADC_clusterXY_R3_u5 = new TH2F("NorthSideADC_clusterXY_R3_u5" , "(ADC-Pedestal) > 5#sigma North Side", 400, -800, 800, 400, -800, 800);
+  NorthSideADC_clusterXY_R3_u5->SetXTitle("X [mm]");
+  NorthSideADC_clusterXY_R3_u5->SetYTitle("Y [mm]");
+
+  //SouthSideADC_clusterXY_R1 = new TH2F("SouthSideADC_clusterXY_R1" , "ADC Peaks South Side", N_phi_binx_XY_R1, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  SouthSideADC_clusterXY_R1_u5 = new TH2F("SouthSideADC_clusterXY_R1_u5" , "(ADC-Pedestal) > 5#sigma South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R1_u5->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R1_u5->SetYTitle("Y [mm]");
+
+  //SouthSideADC_clusterXY_R2 = new TH2F("SouthSideADC_clusterXY_R2" , "ADC Peaks South Side", N_phi_binx_XY_R2, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);
+  SouthSideADC_clusterXY_R2_u5 = new TH2F("SouthSideADC_clusterXY_R2_u5" , "(ADC-Pedestal) > 5#sigma South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R2_u5->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R2_u5->SetYTitle("Y [mm]");
+
+  //SouthSideADC_clusterXY_R3 = new TH2F("SouthSideADC_clusterXY_R3" , "ADC Peaks South Side", N_phi_binx_XY_R3, -TMath::Pi(), TMath::Pi(), N_rBins_XY, r_bins);  
+  SouthSideADC_clusterXY_R3_u5 = new TH2F("SouthSideADC_clusterXY_R3_u5" , "(ADC-Pedestal) > 5#sigma South Side", 400, -800, 800, 400, -800, 800);
+  SouthSideADC_clusterXY_R3_u5->SetXTitle("X [mm]");
+  SouthSideADC_clusterXY_R3_u5->SetYTitle("Y [mm]");
+
+  //____________________________________________________________________//
+
+
   //TPC "cluster" ZY heat maps WEIGHTED
    NorthSideADC_clusterZY = new TH2F("NorthSideADC_clusterZY" , "(ADC-Pedestal) > 5#sigma North Side", 206, -1030, 1030, 400, -800, 800);
    SouthSideADC_clusterZY = new TH2F("SouthSideADC_clusterZY" , "(ADC-Pedestal) > 5#sigma South Side", 206, -1030, 1030, 400, -800, 800);
@@ -543,6 +577,14 @@ int TpcMon::Init()
   se->registerHisto(this, SouthSideADC_clusterXY_R2_LASER);
   se->registerHisto(this, SouthSideADC_clusterXY_R3_LASER);
 
+  se->registerHisto(this, NorthSideADC_clusterXY_R1_u5);
+  se->registerHisto(this, NorthSideADC_clusterXY_R2_u5);
+  se->registerHisto(this, NorthSideADC_clusterXY_R3_u5);
+
+  se->registerHisto(this, SouthSideADC_clusterXY_R1_u5);
+  se->registerHisto(this, SouthSideADC_clusterXY_R2_u5);
+  se->registerHisto(this, SouthSideADC_clusterXY_R3_u5);
+
   se->registerHisto(this, NorthSideADC_clusterZY);
   se->registerHisto(this, SouthSideADC_clusterZY);
 
@@ -611,7 +653,8 @@ int TpcMon::process_event(Event *evt/* evt */)
 
   NEvents_vs_EBDC->Fill(MonitorServerId());
   //std::cout<<"Event #"<< evtcnt <<std::endl;
-  
+
+  //  if( evtcnt >= 1200 ){ //evtcnt debug  
   for( int packet = firstpacket; packet < lastpacket; packet++) //packet 4001 or 4002 = Sec 00, packet 4231 or 4232 = Sec 23
   {
     Packet* p = evt->getPacket(packet);
@@ -853,6 +896,21 @@ int TpcMon::process_event(Event *evt/* evt */)
           else if(Module_ID(fee)==2){SouthSideADC_clusterXY_R3_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R3
         }
         //________________________________________________________________________________
+        //5 event displays
+        if( (serverid < 12 && (pedest_sub_wf_max) > std::max(5.0*noise,20.)) && layer != 0 )
+        {
+          if(Module_ID(fee)==0){NorthSideADC_clusterXY_R1_u5->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R1
+          else if(Module_ID(fee)==1){NorthSideADC_clusterXY_R2_u5->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R2
+          else if(Module_ID(fee)==2){NorthSideADC_clusterXY_R3_u5->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R3
+        }
+        if( (serverid < 12 && (pedest_sub_wf_max) > std::max(5.0*noise,20.)) && layer != 0 )
+        {
+          if(Module_ID(fee)==0){SouthSideADC_clusterXY_R1_u5->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R1
+          else if(Module_ID(fee)==1){SouthSideADC_clusterXY_R2_u5->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R2
+          else if(Module_ID(fee)==2){SouthSideADC_clusterXY_R3_u5->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R3
+        }
+        //________________________________________________________________________________
+
 
         is_channel_stuck = 0; //reset after looping through waveform samples
 
@@ -868,8 +926,23 @@ int TpcMon::process_event(Event *evt/* evt */)
     } // if packet exists
     //std::cout<<"MADE IT TO END OF PACKET LOOP, EVENT # "<<evtcnt<<std::endl;
   } //end of packet loop
-
+  //} //debug if evt >=1203
   evtcnt++;
+  if(evtcnt5 < 5) //increment 5 event counter for 5 events
+  { 
+    evtcnt5++;
+  }
+  else if(evtcnt5 >= 5) // reset to to 0 when get to event 5 (6th event starting from 0)
+  {
+    evtcnt5 = 0;
+    NorthSideADC_clusterXY_R1_u5->Reset();
+    NorthSideADC_clusterXY_R2_u5->Reset();
+    NorthSideADC_clusterXY_R3_u5->Reset();
+
+    SouthSideADC_clusterXY_R1_u5->Reset();
+    SouthSideADC_clusterXY_R2_u5->Reset();
+    SouthSideADC_clusterXY_R3_u5->Reset();    
+  }
 
   // get temporary pointers to histograms
   // one can do in principle directly se->getHisto("tpchist1")->Fill()

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -29,6 +29,7 @@ class TpcMon : public OnlMon
 
  protected:
   int evtcnt = 0;
+  int evtcnt5 = 0;
   int idummy = 0;
   int weird_counter = 0;
 
@@ -65,6 +66,14 @@ class TpcMon : public OnlMon
   TH2 *SouthSideADC_clusterXY_R1_LASER = nullptr;
   TH2 *SouthSideADC_clusterXY_R2_LASER = nullptr;
   TH2 *SouthSideADC_clusterXY_R3_LASER = nullptr;
+
+  TH2 *NorthSideADC_clusterXY_R1_u5 = nullptr;
+  TH2 *NorthSideADC_clusterXY_R2_u5 = nullptr;
+  TH2 *NorthSideADC_clusterXY_R3_u5 = nullptr;
+
+  TH2 *SouthSideADC_clusterXY_R1_u5 = nullptr;
+  TH2 *SouthSideADC_clusterXY_R2_u5 = nullptr;
+  TH2 *SouthSideADC_clusterXY_R3_u5 = nullptr;
 
   TH2 *NorthSideADC_clusterXY_R1_unw = nullptr;
   TH2 *NorthSideADC_clusterXY_R2_unw = nullptr;

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -346,7 +346,19 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     transparent[23]->SetFillStyle(4000);
     transparent[23]->Draw();
     TC[24]->SetEditable(false);
-  }      
+  }
+  else if (name == "TPCClusterXY_u5")
+  {
+    TC[25] = new TCanvas(name.c_str(), "(MAX ADC - pedestal)>  (20 ADC || 5sigma) for NS and SS, <= 5 EVENTS WEIGHTED", 1350, 700);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[25]->Divide(2,1);
+    // this one is used to plot the run number on the canvas
+    transparent[24] = new TPad("transparent24", "this does not show", 0, 0, 1, 1);
+    transparent[24]->SetFillStyle(4000);
+    transparent[24]->Draw();
+    TC[25]->SetEditable(false);
+  }          
   return 0;
 }
 
@@ -457,6 +469,11 @@ int TpcMonDraw::Draw(const std::string &what)
   if (what == "ALL" || what == "TPCLASERCLUSTERSXYWEIGTHED")
   {
     iret += DrawTPCXYlaserclusters(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCCLUSTERS5EXYUNWEIGTHED")
+  {
+    iret +=  DrawTPCXYclusters5event(what);
     idraw++;
   }
   if (what == "ALL" || what == "SERVERSTATS")
@@ -2306,6 +2323,174 @@ int TpcMonDraw::DrawTPCStuckChannels(const std::string & /* what */)
 
   return 0;
 }
+int TpcMonDraw::DrawTPCXYclusters5event(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH2 *tpcmon_NSTPC_5e_clusXY[24][3] = {nullptr};
+  TH2 *tpcmon_SSTPC_5e_clusXY[24][3] = {nullptr};
+
+  dummy_his1_u5_XY = new TH2F("dummy_his1_u5_XY", "(ADC-Pedestal) > (5#sigma||20ADC) North Side, <= 5 E , UNWEIGHTED", 400, -800, 800, 400, -800, 800); //dummy histos for titles
+  dummy_his2_u5_XY = new TH2F("dummy_his2_u5_XY", "(ADC-Pedestal) > (5#sigma||20ADC) South Side, <= 5 E , UNWEIGHTED", 400, -800, 800, 400, -800, 800);
+
+  dummy_his1_u5_XY->SetXTitle("X [mm]");
+  dummy_his1_u5_XY->SetYTitle("Y [mm]");
+  dummy_his1_u5_XY->GetYaxis()->SetTitleSize(0.02);
+
+  dummy_his2_u5_XY->SetXTitle("-X [mm]"); //SS x is flipped from global coordinates
+  dummy_his2_u5_XY->SetYTitle("Y [mm]");
+  dummy_his2_u5_XY->GetYaxis()->SetTitleSize(0.02);
+
+  //the lines are for the sector boundaries
+  Double_t sec_gap_inner = (2*M_PI - 0.5024*12.0)/12.0;
+
+  Double_t sec_gap_outer = (2*M_PI - 0.5097*12.0)/12.0;
+
+  Double_t sec_gap = (sec_gap_inner + sec_gap_outer)/2.0;
+
+  Double_t sec_phi = (0.5024 + 0.5097)/2.0;
+
+  TLine *lines[12];
+
+  for(int ln=0;ln<12;ln++)
+  {
+    lines[ln] = new TLine(311.05*cos((sec_phi+sec_gap)/2.0+ln*(sec_phi+sec_gap)),311.05*sin((sec_phi+sec_gap)/2.0+ln*(sec_phi+sec_gap)),759.11*cos((sec_phi+sec_gap)/2.0+ln*(sec_phi+sec_gap)),759.11*sin((sec_phi+sec_gap)/2.0+ln*(sec_phi+sec_gap)));
+  }
+
+  TEllipse *e1 = new TEllipse(0.0,0.0,311.05,311.05);
+  TEllipse *e2 = new TEllipse(0.0,0.0,(402.49+411.53)/2.0,(402.49+411.53)/2.0);
+  TEllipse *e3 = new TEllipse(0.0,0.0,(583.67+574.75)/2.0,(583.67+574.75)/2.0);
+  TEllipse *e4 = new TEllipse(0.0,0.0,759.11,759.11);
+  //__________________
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);                             
+    tpcmon_NSTPC_5e_clusXY[i][0] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R1_u5");
+    tpcmon_NSTPC_5e_clusXY[i][1] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R2_u5");
+    tpcmon_NSTPC_5e_clusXY[i][2] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC_clusterXY_R3_u5");
+
+    tpcmon_SSTPC_5e_clusXY[i][0] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R1_u5");
+    tpcmon_SSTPC_5e_clusXY[i][1] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R2_u5");
+    tpcmon_SSTPC_5e_clusXY[i][2] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC_clusterXY_R3_u5");
+  }
+
+  if (!gROOT->FindObject("TPCClusterXY_u5"))
+  {
+    MakeCanvas("TPCClusterXY_u5");
+  }  
+
+  TC[25]->SetEditable(true); 
+  TC[25]->Clear("D");
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_ADC-Pedestal>(5sigma||20ADC) UNWEIGHTED, <= 5E, Run" << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  transparent[24]->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+  TC[25]->cd(1);
+  gStyle->SetOptStat(kFALSE);
+  gPad->SetTopMargin(0.15);
+  //gPad->SetLogz(kTRUE);
+  dummy_his1_u5_XY->Draw("colzsame");
+
+  float NS_max = 0;
+  for( int i=0; i<12; i++ )
+  {
+    for( int j=0; j<3; j++ )
+    {
+      if( tpcmon_NSTPC_5e_clusXY[i][j] )
+      {
+        TC[25]->cd(1);
+        tpcmon_NSTPC_5e_clusXY[i][j] -> Draw("colzsame");
+        //gStyle->SetLogz(kTRUE);
+        if ( tpcmon_NSTPC_5e_clusXY[i][j]->GetBinContent(tpcmon_NSTPC_5e_clusXY[i][j]->GetMaximumBin()) > NS_max)
+        {
+          NS_max = tpcmon_NSTPC_5e_clusXY[i][j]->GetBinContent(tpcmon_NSTPC_5e_clusXY[i][j]->GetMaximumBin());
+          dummy_his1_u5_XY->SetMaximum( NS_max );
+        }
+        gStyle->SetPalette(57); //kBird CVD friendly
+      }
+
+    }
+  }
+  TC[25]->cd(1);
+  e1->SetFillStyle(0);
+  e2->SetFillStyle(0);
+  e3->SetFillStyle(0);
+  e4->SetFillStyle(0);
+
+  e1->Draw("same");
+  e2->Draw("same");
+  e3->Draw("same");
+  e4->Draw("same");
+  for(int ln2=0;ln2<12;ln2++)
+  {
+    lines[ln2]->Draw("same"); 
+  }
+  TC[25]->Update();
+
+  TC[25]->cd(2);
+  gStyle->SetOptStat(kFALSE);
+  gPad->SetTopMargin(0.15);
+  //gPad->SetLogz(kTRUE);
+  dummy_his2_u5_XY->Draw("colzsame");
+
+  float SS_max = 0;
+  for( int i=0; i<12; i++ )
+  {
+    for( int j=0; j<3; j++ )
+    {
+      if( tpcmon_SSTPC_5e_clusXY[i+12][j] )
+      {
+        //std::cout<<"South Side Custer XY i: "<< i+12 <<", j: "<<j<<std::endl;
+        TC[25]->cd(2);
+        tpcmon_SSTPC_5e_clusXY[i+12][j] -> Draw("colzsame");
+        //gStyle->SetLogz(kTRUE);
+        if ( tpcmon_SSTPC_5e_clusXY[i+12][j]->GetBinContent(tpcmon_SSTPC_5e_clusXY[i+12][j]->GetMaximumBin()) > SS_max)
+        {
+          SS_max = tpcmon_SSTPC_5e_clusXY[i+12][j]->GetBinContent(tpcmon_SSTPC_5e_clusXY[i+12][j]->GetMaximumBin());
+          dummy_his2_u5_XY->SetMaximum( SS_max );
+        }
+        gStyle->SetPalette(57); //kBird CVD friendly
+      }
+    }
+
+  }
+  TC[25]->cd(2);
+  e1->SetFillStyle(0);
+  e2->SetFillStyle(0);
+  e3->SetFillStyle(0);
+  e4->SetFillStyle(0);
+
+  e1->Draw("same");
+  e2->Draw("same");
+  e3->Draw("same");
+  e4->Draw("same");
+  for(int ln2=0;ln2<12;ln2++)
+  {
+    lines[ln2]->Draw("same"); 
+  }
+
+  TC[25]->Update();
+  TC[25]->Show();
+  TC[25]->SetEditable(false);
+
+  return 0;
+}
+
 
 
 int TpcMonDraw::SavePlot(const std::string &what, const std::string &type)

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -42,6 +42,7 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCPedestSubADC1D(const std::string &what = "ALL");
   int DrawTPCXYclusters(const std::string &what = "ALL");
   int DrawTPCXYlaserclusters(const std::string &what = "ALL");
+  int DrawTPCXYclusters5event(const std::string &what = "ALL");
   int DrawTPCXYclusters_unweighted(const std::string &what = "ALL");
   int DrawTPCZYclusters(const std::string &what = "ALL");
   int DrawTPCZYclusters_unweighted(const std::string &what = "ALL");
@@ -50,8 +51,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawServerStats();
   time_t getTime();
   
-  TCanvas *TC[25] = {nullptr};
-  TPad *transparent[24] = {nullptr};
+  TCanvas *TC[26] = {nullptr};
+  TPad *transparent[25] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module
@@ -64,6 +65,9 @@ class TpcMonDraw : public OnlMonDraw
 
   TH2 *dummy_his1_laser_XY = nullptr;
   TH2 *dummy_his2_laser_XY = nullptr;
+
+  TH2 *dummy_his1_u5_XY = nullptr;
+  TH2 *dummy_his2_u5_XY = nullptr;
 
   TH2 *dummy_his1_ZY = nullptr;
 


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.cc
subystems/tpc/TpcMon.h
subystems/tpc/TpcMonDraw.cc
subystems/tpc/TpcMonDraw.h
macros/run_tpc_client.C

**Changes:**

Adding a histogram which plots the XY hitmap except it clears it every 5 events. For Tom

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

- Number of channel packet per RCDAQ event: this checks data packaging in RCDAQ

- Number of non-zerosuppressed sample per channel packet: this checks percentage of zero suppression in activated channels.
-
- For each channel, traversing through the time bins and look for a chunk of non-zero supressed ADC numbers.
- Then plot ADC vs time-bin-in-waveform, with time=0 is the first non-zerosuppressed sample. This should show a blob of TPC data with presample-triggering sample-post sample shape. This can be done in a persistent scope plot like the ADC vs time plot now. This validates triggering
- Histogram first sample ADC of a waveform, which check for pedestal in ZS data
- Histogram first time bin ID of a waveform, which check for stability of zero suppression as 360 sample passes along. Also a channel failed zero suppression will have a peak at time-bin=0

    ~~FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS~~
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS
    ~~Persistent Scope Plot (ask Jin)~~
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
   ~~Stuck Channel Detection~~
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
