### PR TITLE
Fast tfile close

### DIFF
--- a/macros/run_Poms.C
+++ b/macros/run_Poms.C
@@ -131,6 +131,7 @@ void StartPoms()
   subsys->AddAction("tpcDraw(\"TPCPEDESTSUBADCVSSAMPLE_R1\")", "TPC Pedest Sub. ADC vs Sample R1 ONLY");
   subsys->AddAction("tpcDraw(\"TPCPEDESTSUBADCVSSAMPLE_R2\")", "TPC Pedest Sub. ADC vs Sample R2 ONLY");
   subsys->AddAction("tpcDraw(\"TPCPEDESTSUBADCVSSAMPLE_R3\")", "TPC Pedest Sub. ADC vs Sample R3 ONLY");
+  subsys->AddAction("tpcDraw(\"TPCSTUCKCHANNELS\")", "TPC Stuck Channels in FEE");
   subsys->AddAction("tpcDraw(\"SERVERSTATS\")", "Server Stats");
   subsys->AddAction(new SubSystemActionSavePlot(subsys));
   pmf->RegisterSubSystem(subsys);

--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -1359,7 +1359,8 @@ int OnlMonClient::ReadHistogramsFromFile(const std::string &filename, OnlMonDraw
 {
   std::string subsys = ExtractSubsystem(filename, drawer);
   TDirectory *save = gDirectory;  // save current dir (which will be overwritten by the following fileopen)
-  TFile *histofile = new TFile(filename.c_str(), "READ");
+  std::cout << "Reading histos from " << filename << std::endl;
+  TFile *histofile = TFile::Open(filename.c_str(), "READ");
   if (!histofile)
   {
     std::cout << "Can't open " << filename << std::endl;
@@ -1389,8 +1390,10 @@ int OnlMonClient::ReadHistogramsFromFile(const std::string &filename, OnlMonDraw
       }
     }
   }
-  delete histofile;
   delete titer;
+// this is a fast way to close a file, if you call TFile->Close() it deletes all
+// histograms which can take a really long time (hours)
+  gROOT->GetListOfFiles()->Remove( histofile );
   return 0;
 }
 


### PR DESCRIPTION
Using TFile::Close() deletes all histograms which is a really lengthy process, with the huge number of CEMC histos, this was taking hours now. Using 
gROOT->GetListOfFiles()->Remove( histofile );
instead of
histofile->Close()
gets this back to reasonable times