### PR TITLE
Adding Channel Fraction per Packet per RCDAQ Event

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -62,6 +62,8 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("Check_Sum_Error",servername);
     cl->registerHisto("Check_Sums",servername);
     cl->registerHisto("Stuck_Channels",servername);
+    cl->registerHisto("Channels_in_Packet",servername);
+    cl->registerHisto("Channels_Always",servername);
     cl->registerHisto("ADC_vs_SAMPLE",servername); 
     cl->registerHisto("ADC_vs_SAMPLE_large",servername);
     cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE",servername);

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -368,6 +368,34 @@ int TpcMon::Init()
   Check_Sum_Error -> GetYaxis() -> SetTitleSize(0.05);
   Check_Sum_Error -> GetYaxis() -> SetTitleOffset(1.0); 
 
+  // # of times channels are in packet per RCDAQ event
+  char chans_in_packet_title_str[100];
+  sprintf(chans_in_packet_title_str,"Channel counts vs Channel in packets in  RCDAQ Events: SECTOR %i",MonitorServerId());  
+  Channels_in_Packet = new TH1F("Channels_in_Packet" , chans_in_packet_title_str, 6656, -0.5, 6655.5);
+  Channels_in_Packet->SetXTitle("(FEE # * 256) + chan. #");
+  Channels_in_Packet->SetYTitle("Counts / Packet in RCDAQ Event");
+  Channels_in_Packet->SetStats(0);
+
+  Channels_in_Packet -> GetXaxis() -> SetLabelSize(0.05);
+  Channels_in_Packet -> GetXaxis() -> SetTitleSize(0.05);
+  Channels_in_Packet -> GetYaxis() -> SetLabelSize(0.05);
+  Channels_in_Packet -> GetYaxis() -> SetTitleSize(0.05);
+  Channels_in_Packet -> GetYaxis() -> SetTitleOffset(1.0);
+
+  // # of times channels are in packet per RCDAQ event
+  char chans_always_title_str[100];
+  sprintf(chans_always_title_str,"Channel counts vs all channels (filled once per event w/ packets): SECTOR %i",MonitorServerId());  
+  Channels_Always = new TH1F("Channels_Always" , chans_always_title_str, 6656, -0.5, 6655.5);
+  Channels_Always->SetXTitle("(FEE # * 256) + chan. #");
+  Channels_Always->SetYTitle("Counts");
+  Channels_Always->SetStats(0);
+
+  Channels_Always -> GetXaxis() -> SetLabelSize(0.05);
+  Channels_Always -> GetXaxis() -> SetTitleSize(0.05);
+  Channels_Always -> GetYaxis() -> SetLabelSize(0.05);
+  Channels_Always -> GetYaxis() -> SetTitleSize(0.05);
+  Channels_Always -> GetYaxis() -> SetTitleOffset(1.0);
+
   // Max ADC per waveform dist for each module (R1, R2, R3)
   char MAXADC_str[100];
   char YLabel_str[5];
@@ -536,6 +564,9 @@ int TpcMon::Init()
   se->registerHisto(this, Check_Sum_Error);
   se->registerHisto(this, Check_Sums);
   se->registerHisto(this, Stuck_Channels);
+  se->registerHisto(this, Channels_in_Packet);
+  se->registerHisto(this, Channels_Always);
+  se->registerHisto(this, Channels_Always);
   se->registerHisto(this, ADC_vs_SAMPLE);
   se->registerHisto(this, PEDEST_SUB_ADC_vs_SAMPLE);
   se->registerHisto(this, PEDEST_SUB_ADC_vs_SAMPLE_R1);
@@ -672,6 +703,8 @@ int TpcMon::process_event(Event *evt/* evt */)
 
       bool is_channel_stuck = 0;
 
+      for(int ci = 0; ci < 6656; ci++){ Channels_Always->Fill(ci);}
+
       for( int wf = 0; wf < nr_of_waveforms; wf++)
       {
 	//std::cout<<"START OF WF LOOP, "<<"current wf = "<<wf<<", total wf = "<<nr_of_waveforms<<" EVENT "<<evtcnt<<std::endl;
@@ -697,6 +730,8 @@ int TpcMon::process_event(Event *evt/* evt */)
 
         Check_Sums->Fill(fee*8 + sampaAddress); 
         if( checksumError == 1){Check_Sum_Error->Fill(fee*8 + sampaAddress);}
+
+        if( checksumError == 0){Channels_in_Packet->Fill(channel + (256*FEE_transform[fee]));}
 
         int nr_Samples = p->iValue(wf, "SAMPLES");
         sample_size_hist->Fill(nr_Samples);

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -37,6 +37,8 @@ class TpcMon : public OnlMon
   const int N_thBins = 12; //(12 theta bins of uniform angle (360/12 = 30 degrees = TMath::Pi()/6 ~= 0.523 rad)
   const double rBin_edges[N_rBins+1] = {0.0, 0.256, 0.504, 0.752, 1.00}; //variable edges for radial dims
 
+  const int FEE_transform[26] = {10, 11, 0, 2, 1, 25, 23, 24, 22, 21, 20, 6, 7, 3, 13, 12, 5, 4, 9, 8, 14, 16, 15, 17, 19, 18};
+
   //for X-Y channel plot
   static const int N_rBins_XY = 66; //From Evgeny code - global to all modules
   const double r_bins[N_rBins_XY + 1] = {217.83,
@@ -103,6 +105,8 @@ class TpcMon : public OnlMon
   TH1 *Check_Sum_Error = nullptr;
   TH1 *Check_Sums = nullptr;
   TH1 *Stuck_Channels = nullptr;
+  TH1 *Channels_in_Packet = nullptr;
+  TH1 *Channels_Always = nullptr;
 
   TH2 *MAXADC = nullptr;
 

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -30,6 +30,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCSampleSize(const std::string &what = "ALL");
   int DrawTPCStuckChannels(const std::string &what = "ALL");
   int DrawTPCCheckSum(const std::string &what = "ALL");
+  int DrawTPCChansinPacketNS(const std::string &what = "ALL");
+  int DrawTPCChansinPacketSS(const std::string &what = "ALL");
   int DrawTPCADCSample(const std::string &what = "ALL");
   int DrawTPCPedestSubADCSample(const std::string &what = "ALL");
   int DrawTPCPedestSubADCSample_R1(const std::string &what = "ALL");
@@ -51,8 +53,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawServerStats();
   time_t getTime();
   
-  TCanvas *TC[26] = {nullptr};
-  TPad *transparent[25] = {nullptr};
+  TCanvas *TC[28] = {nullptr};
+  TPad *transparent[27] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.cc
subystems/tpc/TpcMon.h
subystems/tpc/TpcMonDraw.cc
subystems/tpc/TpcMonDraw.h
macros/run_tpc_client.C

**Changes:**

Adding a NS and SS Channel Fraction per Packet per RCDAQ Event. From tests, ideal # is 0.25 in non-ZS.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

- ~~Number of channel packet per RCDAQ event: this checks data packaging in RCDAQ~~

- Number of non-zerosuppressed sample per channel packet: this checks percentage of zero suppression in activated channels.
-
- For each channel, traversing through the time bins and look for a chunk of non-zero supressed ADC numbers.
- Then plot ADC vs time-bin-in-waveform, with time=0 is the first non-zerosuppressed sample. This should show a blob of TPC data with presample-triggering sample-post sample shape. This can be done in a persistent scope plot like the ADC vs time plot now. This validates triggering
- Histogram first sample ADC of a waveform, which check for pedestal in ZS data
- Histogram first time bin ID of a waveform, which check for stability of zero suppression as 360 sample passes along. Also a channel failed zero suppression will have a peak at time-bin=0

    ~~FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS~~
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS
    ~~Persistent Scope Plot (ask Jin)~~
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
   ~~Stuck Channel Detection~~
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
