### PR TITLE
Speedup html histos

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [![Build Status](https://web.sdcc.bnl.gov/jenkins-sphenix/buildStatus/icon?job=sPHENIX%2FsPHENIX_OnlMon_MasterBranch)](https://web.sdcc.bnl.gov/jenkins-sphenix/job/sPHENIX/job/sPHENIX_OnlMon_MasterBranch/)
 
+You need to use our online enviroment (online/Debian), not offline. Further 
+instructions are in our wiki
 
 To build it, create a build area and run
 


### PR DESCRIPTION
The CEMC has a ton of histos and our old way to read them from files was too slow (hours with root). The new implementation uses the histos read from file which stops root from starting a very slow cleanup process of its TObjects