### PR TITLE
Adding # of nonZS channels vs SAMPA hist, Adding ZS trigger QA hist, fixing bug in <= 5 Event display, calculating stuck channels in a more refined way

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -65,6 +65,7 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("Channels_in_Packet",servername);
     cl->registerHisto("Channels_Always",servername);
     cl->registerHisto("Num_non_ZS_channels_vs_SAMPA",servername);
+    cl->registerHisto("ZS_Trigger_ADC_vs_Sample",servername);
     cl->registerHisto("ADC_vs_SAMPLE",servername); 
     cl->registerHisto("ADC_vs_SAMPLE_large",servername);
     cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE",servername);

--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -64,6 +64,7 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("Stuck_Channels",servername);
     cl->registerHisto("Channels_in_Packet",servername);
     cl->registerHisto("Channels_Always",servername);
+    cl->registerHisto("Num_non_ZS_channels_vs_SAMPA",servername);
     cl->registerHisto("ADC_vs_SAMPLE",servername); 
     cl->registerHisto("ADC_vs_SAMPLE_large",servername);
     cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE",servername);

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -109,6 +109,7 @@ class TpcMon : public OnlMon
   TH1 *Channels_Always = nullptr;
 
   TH2 *Num_non_ZS_channels_vs_SAMPA = nullptr;
+  TH2 *ZS_Trigger_ADC_vs_Sample = nullptr;
 
   TH2 *MAXADC = nullptr;
 

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -108,6 +108,8 @@ class TpcMon : public OnlMon
   TH1 *Channels_in_Packet = nullptr;
   TH1 *Channels_Always = nullptr;
 
+  TH2 *Num_non_ZS_channels_vs_SAMPA = nullptr;
+
   TH2 *MAXADC = nullptr;
 
   TH1 *RAWADC_1D_R1= nullptr;

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -141,6 +141,7 @@ class TpcMon : public OnlMon
   int Max_Nine(int one, int two, int three, int four, int five, int six, int seven, int eight, int nine);
   bool side(int server_id);
   std::pair<float, float> calculateMedianAndStdDev(const std::vector<int>& values);
+  float calculateRawStdDev(const std::vector<int>& values);
 };
 
 #endif /* TPC_TPCMON_H */

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -330,6 +330,17 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     transparent[24]->Draw();
     TC[24]->SetEditable(false);
   }
+  else if (name == "TPCNonZSChannels")
+  {
+    TC[25] = new TCanvas(name.c_str(), "TPC non ZS Channels in SAMPAs acrosss whole Sector",-1, 0, xsize , ysize);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[25]->Divide(4,7);
+    transparent[25] = new TPad("transparent25", "this does not show", 0, 0, 1, 1);
+    transparent[25]->SetFillStyle(4000);
+    transparent[25]->Draw();
+    TC[25]->SetEditable(false);
+  }
      
   return 0;
 }
@@ -456,6 +467,11 @@ int TpcMonDraw::Draw(const std::string &what)
   if (what == "ALL" || what == "TPCCHANSINPACKETSS")
   {
     iret +=  DrawTPCChansinPacketSS(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCNONZSCHANNELS")
+  {
+    iret += DrawTPCNonZSChannels(what);
     idraw++;
   }
   if (what == "ALL" || what == "SERVERSTATS")
@@ -2720,6 +2736,82 @@ int TpcMonDraw::DrawTPCChansinPacketSS(const std::string & /* what */)
   time_t evttime = cl->EventTime("CURRENT");
   // fill run number and event time into string
   runnostream << ThisName << "_SS_Channels per Packet per RCDAQ Event Run " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  TransparentTPad->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+  MyTC->Update();
+  MyTC->Show();
+  MyTC->SetEditable(false);
+
+  return 0;
+}
+
+int TpcMonDraw::DrawTPCNonZSChannels(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH1 *tpcmon_nonZSchannels[24] = {nullptr};
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_nonZSchannels[i] = (TH1*) cl->getHisto(TPCMON_STR,"Num_non_ZS_channels_vs_SAMPA");
+  }
+
+  if (!gROOT->FindObject("TPCNonZSChannels"))
+  {
+    MakeCanvas("TPCNonZSChannels");
+  }
+  TCanvas *MyTC = TC[25];
+  TPad *TransparentTPad = transparent[25];
+  MyTC->SetEditable(true);
+  MyTC->Clear("D");
+
+  TLine *t2 = new TLine(); t2->SetLineStyle(2);
+  TText *tt1= new TText(); tt1->SetTextSize(0.05);
+
+  char title[50];
+
+  gStyle->SetOptStat(0);
+  gStyle->SetPalette(57); //kBird CVD friendly
+
+  for( int i=0; i<24; i++ ) 
+  {
+    if( tpcmon_nonZSchannels[i] )
+    {
+      MyTC->cd(i+5);
+      tpcmon_nonZSchannels[i]->DrawCopy("colz");
+      gPad->SetLogz(kTRUE);
+
+      MyTC->Update();
+
+      for(int j=0;j<25;j++)
+      {
+        t2->DrawLine((j+1)*8,-200.01,(j+1)*8,1024);
+      }
+      for(int k=0;k<26;k++)
+      {
+        sprintf(title,"%d",k);
+        tt1->DrawText(k*8+4,-100,title);
+      }
+      tt1->SetTextSize(0.06);
+    }
+  }
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_Non-ZS Channels per SAMPA Run " << cl->RunNumber()
               << ", Time: " << ctime(&evttime);
   runstring = runnostream.str();
   TransparentTPad->cd();

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -474,8 +474,7 @@ int TpcMonDraw::Draw(const std::string &what)
 int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
-  TCanvas *MyTC = TC[0];
-  TPad *TransparentTPad = transparent[0];
+
   TH2 *tpcmon_NSIDEADC[24] = {nullptr};
   TH2 *tpcmon_SSIDEADC[24] = {nullptr};
 
@@ -488,7 +487,6 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
     tpcmon_NSIDEADC[i] = (TH2*) cl->getHisto(TPCMON_STR,"NorthSideADC");
     tpcmon_SSIDEADC[i] = (TH2*) cl->getHisto(TPCMON_STR,"SouthSideADC");
   }
-
 
   //TH2 *tpcmon_NSIDEADC1 = (TH2*) cl->getHisto("TPCMON_0","NorthSideADC");
   //TH2 *tpcmon_SSIDEADC1 = (TH2*) cl->getHisto("TPCMON_0","SouthSideADC");
@@ -554,9 +552,14 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   SS10->SetFillColor(0);
   SS11->SetFillColor(0);
 
+  TCanvas *MyTC = TC[0];
+  TPad *TransparentTPad = transparent[0];
+
   MyTC->SetEditable(true);
   MyTC->Clear("D");
+
   MyTC->cd(1);
+
   gPad->SetTopMargin(0.15);
   gStyle->SetOptStat(0);
   dummy_his1->Draw("colpolzsame");
@@ -564,20 +567,21 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   float NS_max = 0;
   for( int i=0; i<12; i++ )
   {
-    if( tpcmon_NSIDEADC[i] ){
-    TC[3]->cd(1);
-    tpcmon_NSIDEADC[i] -> DrawCopy("colpolzsame");
-    if( tpcmon_NSIDEADC[i]->GetBinContent(tpcmon_NSIDEADC[i]->GetMaximumBin()) > NS_max)
+    if( tpcmon_NSIDEADC[i] )
     {
-      NS_max = tpcmon_NSIDEADC[i]->GetBinContent(tpcmon_NSIDEADC[i]->GetMaximumBin());
-      dummy_his1->SetMaximum( NS_max );
-    }
+      TC[3]->cd(1);
+      tpcmon_NSIDEADC[i] -> DrawCopy("colpolzsame");
+      if( tpcmon_NSIDEADC[i]->GetBinContent(tpcmon_NSIDEADC[i]->GetMaximumBin()) > NS_max)
+      {
+        NS_max = tpcmon_NSIDEADC[i]->GetBinContent(tpcmon_NSIDEADC[i]->GetMaximumBin());
+        dummy_his1->SetMaximum( NS_max );
+      }
     gStyle->SetPalette(57); //kBird CVD friendly
     }
-
   }
   MyTC->Update();
   MyTC->cd(1);
+
   SS00->Draw("same");
   SS01->Draw("same");
   SS02->Draw("same");
@@ -616,6 +620,7 @@ int TpcMonDraw::DrawTPCModules(const std::string & /* what */)
   MyTC->Update();
 
   MyTC->cd(2);
+
   NS18->Draw("same");
   NS17->Draw("same");
   NS16->Draw("same");

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -32,6 +32,7 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCCheckSum(const std::string &what = "ALL");
   int DrawTPCChansinPacketNS(const std::string &what = "ALL");
   int DrawTPCChansinPacketSS(const std::string &what = "ALL");
+  int DrawTPCNonZSChannels(const std::string &what = "ALL");
   int DrawTPCADCSample(const std::string &what = "ALL");
   int DrawTPCPedestSubADCSample(const std::string &what = "ALL");
   int DrawTPCPedestSubADCSample_R1(const std::string &what = "ALL");
@@ -53,8 +54,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawServerStats();
   time_t getTime();
   
-  TCanvas *TC[25] = {nullptr};
-  TPad *transparent[25] = {nullptr};
+  TCanvas *TC[26] = {nullptr};
+  TPad *transparent[26] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -33,6 +33,7 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCChansinPacketNS(const std::string &what = "ALL");
   int DrawTPCChansinPacketSS(const std::string &what = "ALL");
   int DrawTPCNonZSChannels(const std::string &what = "ALL");
+  int DrawTPCZSTriggerADCSample(const std::string &what = "ALL");
   int DrawTPCADCSample(const std::string &what = "ALL");
   int DrawTPCPedestSubADCSample(const std::string &what = "ALL");
   int DrawTPCPedestSubADCSample_R1(const std::string &what = "ALL");
@@ -54,8 +55,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawServerStats();
   time_t getTime();
   
-  TCanvas *TC[26] = {nullptr};
-  TPad *transparent[26] = {nullptr};
+  TCanvas *TC[27] = {nullptr};
+  TPad *transparent[27] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.cc
subystems/tpc/TpcMon.h
subystems/tpc/TpcMonDraw.cc
subystems/tpc/TpcMonDraw.h
macros/run_tpc_client.C

**Changes:**

Making it so hits from SS go into <= 5 Event display. Calculating the stuck channels from straight std_deviation only - not from standard deviation of median that excludes hits +/- 40 ADC from median. Also added TH2 which shows # of non-ZS samples in WaveForm vs SAMPA ID. Aslo added TH2 for hits above ZS threshold w/ ADC vs SAMPLE (assumes first non 65 K ADC sample is sample 0).

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

- ~~Number of channel packet per RCDAQ event: this checks data packaging in RCDAQ~~

- ~~Number of non-zerosuppressed sample per channel packet: this checks percentage of zero suppression in activated channels.~~
-
- For each channel, traversing through the time bins and look for a chunk of non-zero supressed ADC numbers.
- ~~Then plot ADC vs time-bin-in-waveform, with time=0 is the first non-zerosuppressed sample. This should show a blob of TPC data with presample-triggering sample-post sample shape. This can be done in a persistent scope plot like the ADC vs time plot now. This validates triggering~~
- Histogram first sample ADC of a waveform, which check for pedestal in ZS data
- Histogram first time bin ID of a waveform, which check for stability of zero suppression as 360 sample passes along. Also a channel failed zero suppression will have a peak at time-bin=0

    ~~FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS~~
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS
    ~~Persistent Scope Plot (ask Jin)~~
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
   ~~Stuck Channel Detection~~
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
