### PR TITLE
Adding FEE/Region lines to Stuck_Channels & CheckSumError Hists

### DIFF
--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -759,8 +759,8 @@ int TpcMon::process_event(Event *evt/* evt */)
         int checksumError = p->iValue(wf, "CHECKSUMERROR");
         int channel = p->iValue(wf, "CHANNEL");
 
-        Check_Sums->Fill(fee*8 + sampaAddress); 
-        if( checksumError == 1){Check_Sum_Error->Fill(fee*8 + sampaAddress);}
+        Check_Sums->Fill(FEE_transform[fee]*8 + sampaAddress); 
+        if( checksumError == 1){Check_Sum_Error->Fill(FEE_transform[fee]*8 + sampaAddress);}
 
         if( checksumError == 0){Channels_in_Packet->Fill(channel + (256*FEE_transform[fee]));}
 
@@ -865,8 +865,8 @@ int TpcMon::process_event(Event *evt/* evt */)
         if(rawnoise==0. && median_and_stdev_vec.size() > 1 )
         {
           //for( int si=0;si < nr_Samples; si++ ){ std::cout<<"SAMPLE: "<<si<<", ADC: "<< p->iValue(wf,si) << std::endl; } 
-	  stuck_channel_count[channel][fee]++;  // if the RMS is 0, this channel must be stuck
-          if(stuck_channel_count[channel][fee] == 1){ Stuck_Channels->Fill(fee); } // only count # of unique channels in FEE that get stuck at least once
+	  stuck_channel_count[channel][FEE_transform[fee]]++;  // if the RMS is 0, this channel must be stuck
+          if(stuck_channel_count[channel][FEE_transform[fee]] == 1){ Stuck_Channels->Fill(FEE_transform[fee]); } // only count # of unique channels in FEE that get stuck at least once
         } 
 
         int wf_max = 0;

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -776,6 +776,17 @@ int TpcMonDraw::DrawTPCCheckSum(const std::string & /* what */)
   MyTC->Clear("D");
   MyTC->cd(1);
 
+  TLine *t1 = new TLine(); t1->SetLineWidth(2);
+  TLine *t2 = new TLine(); t2->SetLineStyle(2);
+  TText *tt1= new TText(); tt1->SetTextSize(0.05);
+
+  int FEEid[26]={2,4,3,13,17,16, // R1
+                 11,12,19,18,0,1,15,14, // R2
+                 20,22,21,23,25,24,10,9,8,6,7,5 // R3
+                };
+
+  char title[50];
+
   for( int i=0; i<24; i++ )
   {
     if( tpcmon_checksumerror[i] && tpcmon_checksums[i] )
@@ -783,8 +794,29 @@ int TpcMonDraw::DrawTPCCheckSum(const std::string & /* what */)
       MyTC->cd(i+5);
 
       tpcmon_checksumerror[i]->Divide(tpcmon_checksums[i]);
-      tpcmon_checksumerror[i]->GetYaxis()->SetRangeUser(0.0001,1.2);
+      tpcmon_checksumerror[i]->GetYaxis()->SetRangeUser(0.0001,1.5);
       tpcmon_checksumerror[i]->DrawCopy("HIST");
+    
+      MyTC->Update();
+
+      for(int j=0;j<25;j++)
+      {
+        t2->DrawLine((j+1)*8,-0.01,(j+1)*8,1.5);
+      }
+      for(int k=0;k<26;k++)
+      {
+        sprintf(title,"%d",FEEid[k]);
+        tt1->DrawText(k*8+4,1.2,title);
+      }
+      tt1->SetTextSize(0.06);
+      tt1->DrawText(25,1.4,"R1");
+      tt1->DrawText(77,1.4,"R2");
+      tt1->DrawText(163,1.4,"R3");
+      tt1->SetTextSize(0.05); 
+
+      t1->DrawLine(48.5,-0.01,48.5,1.5);
+      t1->DrawLine(112.5,-0.01,112.5,1.5);
+
     }
   }
 
@@ -2361,16 +2393,50 @@ int TpcMonDraw::DrawTPCStuckChannels(const std::string & /* what */)
   MyTC->Clear("D");
   MyTC->cd(1);
 
+  TLine *t1 = new TLine(); t1->SetLineWidth(2);
+  TLine *t11 = new TLine(); t11->SetLineWidth(2);
+  TLine *t2 = new TLine(); t2->SetLineStyle(2);
+  TText *tt1= new TText(); tt1->SetTextSize(0.05);
+
+  int FEEid[26]={2,4,3,13,17,16, // R1
+                 11,12,19,18,0,1,15,14, // R2
+                 20,22,21,23,25,24,10,9,8,6,7,5 // R3
+                };
+
+  char title[50];
+
   for( int i=0; i<24; i++ )
   {
     if( tpcmon_stuckchannels[i] )
     {
       MyTC->cd(i+5);
 
-      tpcmon_stuckchannels[i]->GetYaxis()->SetRangeUser(0.01,300);
+      tpcmon_stuckchannels[i]->GetYaxis()->SetRangeUser(0.01,10000);
       tpcmon_stuckchannels[i]->DrawCopy("HIST");
 
       gPad->SetLogy(kTRUE);
+
+      MyTC->Update();
+
+      for(int j=0;j<25;j++)
+      {
+        t2->DrawLine((j+0.5),0.01,(j+0.5),1500);
+      }
+      for(int k=0;k<26;k++)
+      {
+        sprintf(title,"%d",FEEid[k]);
+        tt1->DrawText(k,400,title);
+      }
+      tt1->SetTextSize(0.06);
+      tt1->DrawText(3.1,2000,"R1");
+      tt1->DrawText(9.6,2000,"R2");
+      tt1->DrawText(20.4,2000,"R3");
+      tt1->SetTextSize(0.05); 
+
+      t1->DrawLine(5.5,0.01,5.5,5000);
+      t1->DrawLine(13.5,0.01,13.5,5000);
+
+      t11->DrawLine(-0.5,256,25.5,256);
     }
   }
 


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.cc
subystems/tpc/TpcMonDraw.cc

**Changes:**

Adding divider lines for the Stuck Channels and Checksum error hists. Also arranging FEE in the order they are physically.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

- ~~Number of channel packet per RCDAQ event: this checks data packaging in RCDAQ~~

- ~~Number of non-zerosuppressed sample per channel packet: this checks percentage of zero suppression in activated channels.~~
-
- For each channel, traversing through the time bins and look for a chunk of non-zero supressed ADC numbers.
- ~~Then plot ADC vs time-bin-in-waveform, with time=0 is the first non-zerosuppressed sample. This should show a blob of TPC data with presample-triggering sample-post sample shape. This can be done in a persistent scope plot like the ADC vs time plot now. This validates triggering~~
- Histogram first sample ADC of a waveform, which check for pedestal in ZS data
- Histogram first time bin ID of a waveform, which check for stability of zero suppression as 360 sample passes along. Also a channel failed zero suppression will have a peak at time-bin=0

    ~~FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS~~
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS
    ~~Persistent Scope Plot (ask Jin)~~
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
   ~~Stuck Channel Detection~~
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
