### PR TITLE
Adding in plot for first nonZS ADC vs first nonZS sample

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -65,6 +65,7 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("Channels_in_Packet",servername);
     cl->registerHisto("Channels_Always",servername);
     cl->registerHisto("Num_non_ZS_channels_vs_SAMPA",servername);
+    cl->registerHisto("First_ADC_vs_First_Time_Bin",servername);
     cl->registerHisto("ZS_Trigger_ADC_vs_Sample",servername);
     cl->registerHisto("ADC_vs_SAMPLE",servername); 
     cl->registerHisto("ADC_vs_SAMPLE_large",servername);

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -110,6 +110,7 @@ class TpcMon : public OnlMon
 
   TH2 *Num_non_ZS_channels_vs_SAMPA = nullptr;
   TH2 *ZS_Trigger_ADC_vs_Sample = nullptr;
+  TH2 *First_ADC_vs_First_Time_Bin = nullptr;
 
   TH2 *MAXADC = nullptr;
 

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -352,6 +352,17 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     transparent[26]->Draw();
     TC[26]->SetEditable(false);
   }
+  else if (name == "TPCFirstADCvsFirstSample")
+  {
+    TC[27] = new TCanvas(name.c_str(), "",-1, 0, xsize , ysize);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[27]->Divide(4,7);
+    transparent[27] = new TPad("transparent27", "this does not show", 0, 0, 1, 1);
+    transparent[27]->SetFillStyle(4000);
+    transparent[27]->Draw();
+    TC[27]->SetEditable(false);
+  }
      
   return 0;
 }
@@ -488,6 +499,11 @@ int TpcMonDraw::Draw(const std::string &what)
   if (what == "ALL" || what == "TPCZSTRIGGERADCVSSAMPLE")
   {
     iret += DrawTPCZSTriggerADCSample(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCFIRSTNONZSADCVSFIRSTNONZSSAMPLE")
+  {
+    iret +=  DrawTPCFirstnonZSADCFirstnonZSSample(what);
     idraw++;
   }
   if (what == "ALL" || what == "SERVERSTATS")
@@ -2980,6 +2996,68 @@ int TpcMonDraw::DrawTPCZSTriggerADCSample(const std::string & /* what */)
 
   return 0;
 }
+
+int TpcMonDraw::DrawTPCFirstnonZSADCFirstnonZSSample(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH1 *tpcmon_FirstNZSADCvsFirstNZSSample[24] = {nullptr};
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_FirstNZSADCvsFirstNZSSample[i] = (TH1*) cl->getHisto(TPCMON_STR,"First_ADC_vs_First_Time_Bin");
+  }
+
+  if (!gROOT->FindObject("TPCFirstADCvsFirstSample"))
+  {
+    MakeCanvas("TPCFirstADCvsFirstSample");
+  }
+
+  TCanvas *MyTC = TC[27];
+  TPad *TransparentTPad = transparent[27];
+  MyTC->SetEditable(true);
+  MyTC->Clear("D");
+
+  gStyle->SetOptStat(0);
+  gStyle->SetPalette(57); //kBird CVD friendly
+
+  for( int i=0; i<24; i++ ) 
+  {
+    if( tpcmon_FirstNZSADCvsFirstNZSSample[i] )
+    {
+      MyTC->cd(i+5);
+      tpcmon_FirstNZSADCvsFirstNZSSample[i]->RebinX(5);
+      tpcmon_FirstNZSADCvsFirstNZSSample[i]->DrawCopy("colz");
+      gPad->SetLogz(kTRUE);
+      gPad->SetLogy(kTRUE);
+    }
+  }
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_1st non-ZS ADC vs 1st non-ZS Sample Run " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  TransparentTPad->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+  MyTC->Update();
+  MyTC->Show();
+  MyTC->SetEditable(false);
+
+  return 0;
+}
+
 
 int TpcMonDraw::SavePlot(const std::string &what, const std::string &type)
 {

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -34,6 +34,7 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCChansinPacketSS(const std::string &what = "ALL");
   int DrawTPCNonZSChannels(const std::string &what = "ALL");
   int DrawTPCZSTriggerADCSample(const std::string &what = "ALL");
+  int DrawTPCFirstnonZSADCFirstnonZSSample(const std::string &what = "ALL");
   int DrawTPCADCSample(const std::string &what = "ALL");
   int DrawTPCPedestSubADCSample(const std::string &what = "ALL");
   int DrawTPCPedestSubADCSample_R1(const std::string &what = "ALL");
@@ -55,8 +56,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawServerStats();
   time_t getTime();
   
-  TCanvas *TC[27] = {nullptr};
-  TPad *transparent[27] = {nullptr};
+  TCanvas *TC[28] = {nullptr};
+  TPad *transparent[28] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.cc
subystems/tpc/TpcMon.h
subystems/tpc/TpcMonDraw.cc
subystems/tpc/TpcMonDraw.h
macros/run_tpc_client.C

**Changes:**

Adding a 2D histogram that plots 1st nonZS ADC vs 1st nonZS sample.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

- ~~Number of channel packet per RCDAQ event: this checks data packaging in RCDAQ~~

- ~~Number of non-zerosuppressed sample per channel packet: this checks percentage of zero suppression in activated channels.~~
-
- For each channel, traversing through the time bins and look for a chunk of non-zero supressed ADC numbers.
- ~~Then plot ADC vs time-bin-in-waveform, with time=0 is the first non-zerosuppressed sample. This should show a blob of TPC data with presample-triggering sample-post sample shape. This can be done in a persistent scope plot like the ADC vs time plot now. This validates triggering~~
- ~~Histogram first sample ADC of a waveform, which check for pedestal in ZS data~~
- ~~Histogram first time bin ID of a waveform, which check for stability of zero suppression as 360 sample passes along. Also a channel failed zero suppression will have a peak at time-bin=0~~

    ~~FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS~~
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS
    ~~Persistent Scope Plot (ask Jin)~~
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
   ~~Stuck Channel Detection~~
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
