### PR TITLE
Fix macros

### DIFF
--- a/macros/run_cemc_client.C
+++ b/macros/run_cemc_client.C
@@ -7,6 +7,7 @@
 // cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonlcemcmon_client.so)
 const int nServers = 16;
+  //call with online > 1 if you want to just use the localhost
 void cemcDrawInit(const int online = 0)
 {
   OnlMonClient *cl = OnlMonClient::instance();
@@ -41,14 +42,7 @@ void cemcDrawInit(const int online = 0)
       cl->registerHisto("h1_packet_length",servername.c_str());
       cl->registerHisto("h1_packet_chans",servername.c_str());
       cl->registerHisto("h1_cemc_adc",servername.c_str());
-
-      for(int iphi=0; iphi<256; iphi++){
-	for(int ieta=0; ieta<96; ieta++){
-	  cl->registerHisto(Form("h2_waveform_phi%d_eta%d",iphi,ieta),servername.c_str());
-	}
-      }
     }
-  //cl->AddServerHost("localhost");  // check local host first
   CreateSubsysHostlist("cemc_hosts.list", online);
   //  get my histos from server, the second parameter = 1
   //  says I know they are all on the same node

--- a/macros/run_mvtx_client.C
+++ b/macros/run_mvtx_client.C
@@ -82,9 +82,6 @@ void mvtxDrawInit(const int online = 0)
       // cl->registerHisto(Form("MVTXMON/Occupancy/Layer%d/Layer%dChipStaveC", mLayer, mLayer), servername);
       cl->registerHisto(Form("MVTXMON_Occupancy_Layer%dOccupancy_LOG", mLayer), servername);
     }
-
-    cl->registerHisto("MVTXMON_Occupancy_TotalDeadChipPos", servername);
-    cl->registerHisto("MVTXMON_Occupancy_TotalAliveChipPos", servername);
   }
 
   // for local host, just call mvtxDrawInit(2)


### PR DESCRIPTION
remove histograms from the cemc and mvtx client macros which are not on the server and then trigger an extensive long search each time the shift crew is trying to look at them