### PR TITLE
(INTT) New feature, implementation improvement

### DIFF
--- a/subsystems/intt/InttMonDraw.cc
+++ b/subsystems/intt/InttMonDraw.cc
@@ -36,7 +36,7 @@ int InttMonDraw::Draw(const std::string& what)
   }
   ++icnvs;
 
-  if (what == "ALL" || what == "bco_diff")
+  if (what == "ALL" || what == "bco_diff") // Expert
   {
     iret += DrawFelixBcoFphxBco(icnvs);
     ++idraw;
@@ -50,7 +50,8 @@ int InttMonDraw::Draw(const std::string& what)
   }
   ++icnvs;
 
-  if(what == "ALL" || what == "hitrates") {
+  if(what == "ALL" || what == "hitrates") // Expert
+  {
 	  iret += DrawHitRates(icnvs);
 	  ++idraw;
   }

--- a/subsystems/intt/InttMonDraw.cc
+++ b/subsystems/intt/InttMonDraw.cc
@@ -46,6 +46,12 @@ int InttMonDraw::Draw(const std::string& what)
   }
   ++icnvs;
 
+  if(what == "ALL" || what == "hitrates") {
+	  iret += DrawHitRates(icnvs);
+	  ++idraw;
+  }
+  ++icnvs;
+
   if(!idraw) {
     std::cerr << __PRETTY_FUNCTION__ << ":" << __LINE__ << "\n"
               << "\tUnimplemented drawing option \"" << what << "\"" << std::endl;

--- a/subsystems/intt/InttMonDraw.h
+++ b/subsystems/intt/InttMonDraw.h
@@ -53,14 +53,15 @@ class InttMonDraw : public OnlMonDraw
     double cnvs_width, cnvs_height;
     double disp_frac, lgnd_frac;
     double disp_text_size;
+    double warn_text_size, min_events;
     double lgnd_box_width, lgnd_box_height, lgnd_text_size;
     std::string name;
   } static const m_FelixBcoFphxBco;
   int DrawFelixBcoFphxBco(int);
-  int DrawFelixBcoFphxBco_DispPad();
-  int DrawFelixBcoFphxBco_LgndPad();
-  int DrawFelixBcoFphxBco_SubPads();
-  int DrawFelixBcoFphxBco_SubPad(int);
+  int DrawFelixBcoFphxBco_DispPad(int);
+  int DrawFelixBcoFphxBco_LgndPad(int);
+  int DrawFelixBcoFphxBco_SubPads(int);
+  int DrawFelixBcoFphxBco_SubPad(TPad*, int);
 
   // InttMonDraw_o_HitMap.cc
   struct HitMap_s
@@ -68,28 +69,31 @@ class InttMonDraw : public OnlMonDraw
     double cnvs_width, cnvs_height;
     double disp_frac, lgnd_frac;
     double disp_text_size;
+    double warn_text_size, min_events;
     double lgnd_box_width, lgnd_box_height, lgnd_text_size;
     double lower, upper;
     std::string name;
   } static const m_HitMap;
   int DrawHitMap(int);
-  int DrawHitMap_DispPad();
-  int DrawHitMap_LgndPad();
-  int DrawHitMap_SubPads();
-  int DrawHitMap_SubPad(int);
+  int DrawHitMap_DispPad(int);
+  int DrawHitMap_LgndPad(int);
+  int DrawHitMap_SubPads(int);
+  int DrawHitMap_SubPad(TPad*, int);
 
   // InttMonDraw_o_HitRates.cc
   struct HitRates_s
   {
 	double cnvs_width, cnvs_height;
-	double disp_frac, lgnd_frac;
+	double disp_frac;
 	double disp_text_size;
+    double warn_text_size, min_events;
+    double lower, upper;
 	std::string name;
   } static const m_HitRates;
   int DrawHitRates(int);
-  int DrawHitRates_DispPad();
-  int DrawHitRates_SubPads();
-  int DrawHitRates_SubPad(int);
+  int DrawHitRates_DispPad(int);
+  int DrawHitRates_SubPads(int);
+  int DrawHitRates_SubPad(TPad*, int);
 
   // InttMonDraw_o_Peaks.cc
   struct Peaks_s
@@ -97,14 +101,15 @@ class InttMonDraw : public OnlMonDraw
     double cnvs_width, cnvs_height;
     double disp_frac;
     double disp_text_size;
+    double warn_text_size, min_events;
     double frac;
     double max_width;
     std::string name;
   } static const m_Peaks;
   int DrawPeaks(int);
-  int DrawPeaks_DispPad();
-  int DrawPeaks_SubPads();
-  int DrawPeaks_SubPad(int);
+  int DrawPeaks_DispPad(int);
+  int DrawPeaks_SubPads(int);
+  int DrawPeaks_SubPad(TPad*, int);
   int DrawPeaks_GetFeePeakAndWidth(int, double*, double*, double*);
   // ...
 

--- a/subsystems/intt/InttMonDraw.h
+++ b/subsystems/intt/InttMonDraw.h
@@ -78,6 +78,19 @@ class InttMonDraw : public OnlMonDraw
   int DrawHitMap_SubPads();
   int DrawHitMap_SubPad(int);
 
+  // InttMonDraw_o_HitRates.cc
+  struct HitRates_s
+  {
+	double cnvs_width, cnvs_height;
+	double disp_frac, lgnd_frac;
+	double disp_text_size;
+	std::string name;
+  } static const m_HitRates;
+  int DrawHitRates(int);
+  int DrawHitRates_DispPad();
+  int DrawHitRates_SubPads();
+  int DrawHitRates_SubPad(int);
+
   // InttMonDraw_o_Peaks.cc
   struct Peaks_s
   {
@@ -101,7 +114,7 @@ class InttMonDraw : public OnlMonDraw
   Color_t static GetFeeColor(int const&);
 
   // Member Variables
-  TCanvas* TC[4] = {nullptr};
+  TCanvas* TC[999] = {nullptr}; // Make it large--code compiles if I forget to change it, but isn't safe
   TPad* transparent[1] = {nullptr};
 };
 

--- a/subsystems/intt/InttMonDraw_o_FelixBcoFphxBco.cc
+++ b/subsystems/intt/InttMonDraw_o_FelixBcoFphxBco.cc
@@ -2,42 +2,40 @@
 #include "InttMonDraw.h"
 
 InttMonDraw::FelixBcoFphxBco_s const
-    InttMonDraw::m_FelixBcoFphxBco{
-        .cnvs_width = 1280, .cnvs_height = 720, .disp_frac = 0.1, .lgnd_frac = 0.15, .disp_text_size = 0.25, .lgnd_box_width = 0.16, .lgnd_box_height = 0.01, .lgnd_text_size = 0.08, .name = "INTT_FelixBco_FphxBco_Diff"};
+InttMonDraw::m_FelixBcoFphxBco{
+        .cnvs_width = 1280, .cnvs_height = 720, //
+		.disp_frac = 0.1, .lgnd_frac = 0.15, //
+		.disp_text_size = 0.25, //
+		.warn_text_size = 0.2, .min_events = 50000, //
+		.lgnd_box_width = 0.16, .lgnd_box_height = 0.01, .lgnd_text_size = 0.08, //
+		.name = "INTT_FelixBco_FphxBco_Diff"
+};
 
 int InttMonDraw::DrawFelixBcoFphxBco(
     int icnvs)
 {
   std::string name;
 
-  // use gROOT to find TStyle
-  name = Form("%s_style", m_FelixBcoFphxBco.name.c_str());
-  TStyle* style = dynamic_cast<TStyle*>(gROOT->FindObject(name.c_str()));
-  if (!style)
-  {
-    style = new TStyle(name.c_str(), name.c_str());
-    style->SetOptStat(0);
-    //...
-  }
+  TStyle* style = new TStyle(name.c_str(), name.c_str());
+  style->SetOptStat(0);
+  //...
+
   style->cd();
-  gROOT->SetStyle(name.c_str());
-  gROOT->ForceStyle();
+  // gROOT->SetStyle(name.c_str());
+  // gROOT->ForceStyle();
 
   name = Form("%s", m_FelixBcoFphxBco.name.c_str());
-  if (!dynamic_cast<TCanvas*>(gROOT->FindObject(name.c_str())))
-  {  // Only allocate if gROOT doesn't find it
-    delete TC[icnvs];
-    TC[icnvs] = new TCanvas(
-        name.c_str(), name.c_str(),
-        0, 0,
-        m_FelixBcoFphxBco.cnvs_width, m_FelixBcoFphxBco.cnvs_height);
-  }
+  TC[icnvs] = new TCanvas(
+    name.c_str(), name.c_str(),
+    0, 0,
+    m_FelixBcoFphxBco.cnvs_width, m_FelixBcoFphxBco.cnvs_height
+  );
   gSystem->ProcessEvents();  // ...ROOT garbage collection?
 
   int iret = 0;
-  iret += DrawFelixBcoFphxBco_DispPad();
-  iret += DrawFelixBcoFphxBco_LgndPad();
-  iret += DrawFelixBcoFphxBco_SubPads();
+  iret += DrawFelixBcoFphxBco_DispPad(icnvs);
+  iret += DrawFelixBcoFphxBco_LgndPad(icnvs);
+  iret += DrawFelixBcoFphxBco_SubPads(icnvs);
 
   TC[icnvs]->Update();
   TC[icnvs]->Show();
@@ -46,44 +44,18 @@ int InttMonDraw::DrawFelixBcoFphxBco(
   return iret;
 }
 
-int InttMonDraw::DrawFelixBcoFphxBco_DispPad()
-{
+int InttMonDraw::DrawFelixBcoFphxBco_DispPad (
+	int icnvs
+) {
   std::string name;
 
-  // use gROOT to find parent TPad (TCanvas)
-  name = Form("%s", m_FelixBcoFphxBco.name.c_str());
-  TCanvas* cnvs = dynamic_cast<TCanvas*>(gROOT->FindObject(name.c_str()));
-  if (!cnvs)
-  {  // If we fail to find it, give up
-    std::cerr << __PRETTY_FUNCTION__ << ":" << __LINE__ << "\n"
-              << "\tCouldn't get parent pad \"" << name << "\"" << std::endl;
-    return 1;
-  }
-
-  // find or make this this pad
   name = Form("%s_disp_pad", m_FelixBcoFphxBco.name.c_str());
-  TPad* disp_pad = dynamic_cast<TPad*>(gROOT->FindObject(name.c_str()));
-  if (!disp_pad)
-  {  // Make if it does not exist
-    disp_pad = new TPad(
-        name.c_str(), name.c_str(),
-        0.0, 1.0 - m_FelixBcoFphxBco.disp_frac,  // Southwest x, y
-        1.0, 1.0                                 // Northeast x, y
-    );
-    DrawPad(cnvs, disp_pad);
-  }
-  CdPad(disp_pad);
-
-  name = Form("%s_disp_text", m_FelixBcoFphxBco.name.c_str());
-  TText* disp_text = dynamic_cast<TText*>(gROOT->FindObject(name.c_str()));
-  if (!disp_text)
-  {
-    disp_text = new TText(0.5, 0.5, name.c_str());
-    disp_text->SetName(name.c_str());
-    disp_text->SetTextAlign(22);
-    disp_text->SetTextSize(m_FelixBcoFphxBco.disp_text_size);
-    disp_text->Draw();
-  }
+  TPad* disp_pad = new TPad (
+    name.c_str(), name.c_str(),
+    0.0, 1.0 - m_FelixBcoFphxBco.disp_frac,  // Southwest x, y
+    1.0, 1.0                                 // Northeast x, y
+  );
+  DrawPad(TC[icnvs], disp_pad); // Floor of division will be the right icnvs
 
   name = "InttEvtHist";
   OnlMonClient* cl = OnlMonClient::instance();
@@ -102,59 +74,52 @@ int InttMonDraw::DrawFelixBcoFphxBco_DispPad()
       cl->RunNumber(),
       (int) evt_hist->GetBinContent(1),
       ts->tm_mon + 1, ts->tm_mday, ts->tm_year + 1900);
-  disp_text->SetTitle(name.c_str());
+  TText* disp_text = new TText(0.5, 0.5, name.c_str());
+  disp_text->SetTextAlign(22);
+  disp_text->SetTextSize(m_FelixBcoFphxBco.disp_text_size);
+  disp_text->Draw();
 
-  name = Form("%s_title_text", m_FelixBcoFphxBco.name.c_str());
-  TText* title_text = dynamic_cast<TText*>(gROOT->FindObject(name.c_str()));
-  if (title_text) return 0;  // Early return since the title text is unchanging, and this means we've drawn it
-
-  title_text = new TText(0.5, 0.75, name.c_str());
-  title_text->SetName(name.c_str());
+  name = Form("%s", m_FelixBcoFphxBco.name.c_str());
+  TText* title_text = new TText(0.5, 0.75, name.c_str());
   title_text->SetTextAlign(22);
   title_text->SetTextSize(m_FelixBcoFphxBco.disp_text_size);
   title_text->Draw();
 
-  name = Form("%s", m_FelixBcoFphxBco.name.c_str());
-  title_text->SetTitle(name.c_str());
+  name = "  "; // Nothing if we have enough events
+  if (evt_hist->GetBinContent(1) < m_FelixBcoFphxBco.min_events) {
+  	name = Form("Not enough events (min %0.E) to be statistically significant yet", m_FelixBcoFphxBco.min_events);
+  }
+  TText* warn_text = new TText(0.5, 0.25, name.c_str());
+  warn_text->SetName(name.c_str());
+  warn_text->SetTextAlign(22);
+  warn_text->SetTextSize(m_FelixBcoFphxBco.warn_text_size);
+  warn_text->SetTextColor(kRed);
+  warn_text->Draw();
 
   return 0;
 }
 
-int InttMonDraw::DrawFelixBcoFphxBco_LgndPad()
-{
+int InttMonDraw::DrawFelixBcoFphxBco_LgndPad(
+	int icnvs
+) {
   std::string name;
 
-  // use gROOT to find parent TPad (TCanvas)
-  name = Form("%s", m_FelixBcoFphxBco.name.c_str());
-  TCanvas* cnvs = dynamic_cast<TCanvas*>(gROOT->FindObject(name.c_str()));
-  if (!cnvs)
-  {  // If we fail to find it, give up
-    std::cerr << __PRETTY_FUNCTION__ << ":" << __LINE__ << "\n"
-              << "\tCouldn't get parent pad \"" << name << "\"" << std::endl;
-    return 1;
-  }
-
-  // find or make this this pad
-  name = Form("%s_lgnd_pad", m_FelixBcoFphxBco.name.c_str());
-  TPad* lgnd_pad = dynamic_cast<TPad*>(gROOT->FindObject(name.c_str()));
-  if (lgnd_pad) return 0;
-  // Everything that follows doesn't change,
-  // early return if we've drawn it
-
-  lgnd_pad = new TPad(
+  TPad* lgnd_pad = new TPad (
       name.c_str(), name.c_str(),
       1.0 - m_FelixBcoFphxBco.lgnd_frac, 0.0,  // Southwest x, y
       1.0, 1.0 - m_FelixBcoFphxBco.disp_frac   // Northeast x, y
   );
-  DrawPad(cnvs, lgnd_pad);
+  DrawPad(TC[icnvs], lgnd_pad);
 
   double x0, y0, x[4], y[4];
+  double w[4] = {-1, +1, +1, -1};
+  double h[4] = {-1, -1, +1, +1};
   for (int fee = 0; fee < 14; ++fee)
   {
     x0 = 0.5 - m_FelixBcoFphxBco.lgnd_box_width;
     y0 = (2.0 * fee + 1.0) / (2.0 * 14);
 
-    TText* lgnd_text = new TText(
+    TText* lgnd_text = new TText (
         x0 + 1.5 * m_FelixBcoFphxBco.lgnd_box_width,
         y0,
         Form("FCh %2d", fee));
@@ -163,19 +128,13 @@ int InttMonDraw::DrawFelixBcoFphxBco_LgndPad()
     lgnd_text->SetTextColor(kBlack);
     lgnd_text->Draw();
 
-    x[0] = -1;
-    x[1] = +1;
-    x[2] = +1;
-    x[3] = -1;
-    y[0] = -1;
-    y[1] = -1;
-    y[2] = +1;
-    y[3] = +1;
     for (int i = 0; i < 4; ++i)
     {
+      x[i] = w[i];
       x[i] *= 0.5 * m_FelixBcoFphxBco.lgnd_box_width;
       x[i] += x0;
 
+      y[i] = h[i];
       y[i] *= 0.5 * m_FelixBcoFphxBco.lgnd_box_height;
       y[i] += y0;
     }
@@ -190,61 +149,42 @@ int InttMonDraw::DrawFelixBcoFphxBco_LgndPad()
   return 0;
 }
 
-int InttMonDraw::DrawFelixBcoFphxBco_SubPads()
-{
+int InttMonDraw::DrawFelixBcoFphxBco_SubPads(
+	int icnvs
+) {
   std::string name;
 
-  // use gROOT to find parent TPad (TCanvas)
-  name = Form("%s", m_FelixBcoFphxBco.name.c_str());
-  TCanvas* cnvs = dynamic_cast<TCanvas*>(gROOT->FindObject(name.c_str()));
-  if (!cnvs)
-  {  // If we fail to find it, give up
-    std::cerr << __PRETTY_FUNCTION__ << ":" << __LINE__ << "\n"
-              << "\tCouldn't get parent pad \"" << name << "\"" << std::endl;
-    return 1;
-  }
-
-  double x_min = 0.0;
-  double x_max = 1.0 - m_FelixBcoFphxBco.lgnd_frac;
-  double y_min = 0.0;
-  double y_max = 1.0 - m_FelixBcoFphxBco.disp_frac;
+  int iret = 0;
+  double x_min = 0.0, x_max = 1.0 - m_FelixBcoFphxBco.lgnd_frac;
+  double y_min = 0.0, y_max = 1.0 - m_FelixBcoFphxBco.disp_frac;
   for (int i = 0; i < 8; ++i)
   {
     name = Form("%s_hist_pad_%d", m_FelixBcoFphxBco.name.c_str(), i);
-    TPad* hist_pad = dynamic_cast<TPad*>(gROOT->FindObject(name.c_str()));
-    if (hist_pad) continue;
-
-    hist_pad = new TPad(
+    TPad* hist_pad = new TPad(
         name.c_str(), name.c_str(),
         x_min + (x_max - x_min) * (i % 4 + 0) / 4.0, y_min + (y_max - y_min) * (i / 4 + 0) / 2.0,  // Southwest x, y
         x_min + (x_max - x_min) * (i % 4 + 1) / 4.0, y_min + (y_max - y_min) * (i / 4 + 1) / 2.0   // Southwest x, y
     );
     hist_pad->SetBottomMargin(0.15);
     hist_pad->SetLeftMargin(0.15);
-    DrawPad(cnvs, hist_pad);
-  }
+    DrawPad(TC[icnvs], hist_pad);
 
-  int iret = 0;
-  for (int i = 0; i < 8; ++i)
-  {
-    iret += DrawFelixBcoFphxBco_SubPad(i);
+    iret += DrawFelixBcoFphxBco_SubPad(hist_pad, i);
   }
 
   return iret;
 }
 
 int InttMonDraw::DrawFelixBcoFphxBco_SubPad(
+	TPad* prnt_pad,
     int i)
 {
   std::string name;
 
-  // use gROOT to find parent TPad
-  name = Form("%s_hist_pad_%d", m_FelixBcoFphxBco.name.c_str(), i);
-  TPad* prnt_pad = dynamic_cast<TPad*>(gROOT->FindObject(name.c_str()));
   if (!prnt_pad)
   {  // If we fail to find it, give up
     std::cerr << __PRETTY_FUNCTION__ << ":" << __LINE__ << "\n"
-              << "\tCouldn't get parent pad \"" << name << "\"" << std::endl;
+              << "\tnull TPad*" << std::endl;
     return 1;
   }
   CdPad(prnt_pad);

--- a/subsystems/intt/InttMonDraw_o_HitRates.cc
+++ b/subsystems/intt/InttMonDraw_o_HitRates.cc
@@ -1,0 +1,197 @@
+#include "InttMon.h"
+#include "InttMonDraw.h"
+
+InttMonDraw::HitRates_s const
+InttMonDraw::m_HitRates {
+	.cnvs_width = 1280, .cnvs_height = 720, //
+	.disp_frac = 0.1, //
+	.disp_text_size = 0.25, //
+	.warn_text_size = 0.2, .min_events = 50000, //
+	.lower = 0.0, .upper = 0.02, //
+	.name = "INTT_HitRates"
+};
+
+int
+InttMonDraw::DrawHitRates (
+	int icnvs
+) {
+	std::string name;
+
+	// use gROOT to find TStyle
+	name = Form("%s_style", m_HitRates.name.c_str());
+	TStyle* style = new TStyle(name.c_str(), name.c_str());
+	style->SetOptStat(0);
+	//...
+
+	style->cd();
+	// gROOT->SetStyle(name.c_str());
+	// gROOT->ForceStyle();
+
+	name = Form("%s", m_HitRates.name.c_str());
+	TC[icnvs] = new TCanvas (
+		name.c_str(), name.c_str(),
+		0, 0,
+		m_HitRates.cnvs_width, m_HitRates.cnvs_height
+	);
+	gSystem->ProcessEvents(); // ...ROOT garbage collection?
+
+	int iret = 0;
+	iret += DrawHitRates_DispPad(icnvs);
+	iret += DrawHitRates_SubPads(icnvs);
+
+	TC[icnvs]->Update();
+	TC[icnvs]->Show();
+	TC[icnvs]->SetEditable(false);
+
+	return iret;
+}
+
+int
+InttMonDraw::DrawHitRates_DispPad (
+	int icnvs
+) {
+  std::string name;
+
+  name = Form("%s_disp_pad", m_HitRates.name.c_str());
+  TPad* disp_pad = new TPad (
+    name.c_str(), name.c_str(),
+    0.0, 1.0 - m_HitRates.disp_frac,  // Southwest x, y
+    1.0, 1.0                                 // Northeast x, y
+  );
+  DrawPad(TC[icnvs], disp_pad); // Floor of division will be the right icnvs
+
+  name = "InttEvtHist";
+  OnlMonClient* cl = OnlMonClient::instance();
+  TH1D* evt_hist = (TH1D*) cl->getHisto(Form("INTTMON_%d", 0), name);
+  if (!evt_hist)
+  {
+    std::cerr << __PRETTY_FUNCTION__ << ":" << __LINE__ << "\n"
+              << "\tCould not get \"" << name << "\" from " << Form("INTTMON_%d", 0) << std::endl;
+    return 1;
+  }
+
+  std::time_t t = cl->EventTime("CURRENT");  // BOR, CURRENT, or EOR
+  struct tm* ts = std::localtime(&t);
+  name = Form(
+      "Run: %08d, Events: %d, Date: %02d/%02d/%4d",
+      cl->RunNumber(),
+      (int) evt_hist->GetBinContent(1),
+      ts->tm_mon + 1, ts->tm_mday, ts->tm_year + 1900);
+  TText* disp_text = new TText(0.5, 0.5, name.c_str());
+  disp_text->SetTextAlign(22);
+  disp_text->SetTextSize(m_HitRates.disp_text_size);
+  disp_text->Draw();
+
+  name = Form("%s", m_HitRates.name.c_str());
+  TText* title_text = new TText(0.5, 0.75, name.c_str());
+  title_text->SetTextAlign(22);
+  title_text->SetTextSize(m_HitRates.disp_text_size);
+  title_text->Draw();
+
+  name = "  "; // Nothing if we have enough events
+  if (evt_hist->GetBinContent(1) < m_HitRates.min_events) {
+  	name = Form("Not enough events (min %0.E) to be statistically significant yet", m_HitRates.min_events);
+  }
+  TText* warn_text = new TText(0.5, 0.25, name.c_str());
+  warn_text->SetName(name.c_str());
+  warn_text->SetTextAlign(22);
+  warn_text->SetTextSize(m_HitRates.warn_text_size);
+  warn_text->SetTextColor(kRed);
+  warn_text->Draw();
+
+  return 0;
+
+}
+
+int
+InttMonDraw::DrawHitRates_SubPads (
+	int icnvs
+) {
+  std::string name;
+
+  int iret = 0;
+  double x_min = 0.0, x_max = 1.0;
+  double y_min = 0.0, y_max = 1.0 - m_HitRates.disp_frac;
+  for (int i = 0; i < 8; ++i)
+  {
+    name = Form("%s_hist_pad_%d", m_HitRates.name.c_str(), i);
+    TPad* hist_pad = new TPad(
+        name.c_str(), name.c_str(),
+        x_min + (x_max - x_min) * (i % 4 + 0) / 4.0, y_min + (y_max - y_min) * (i / 4 + 0) / 2.0,  // Southwest x, y
+        x_min + (x_max - x_min) * (i % 4 + 1) / 4.0, y_min + (y_max - y_min) * (i / 4 + 1) / 2.0   // Southwest x, y
+    );
+    hist_pad->SetBottomMargin(0.15);
+    hist_pad->SetLeftMargin(0.15);
+    DrawPad(TC[icnvs], hist_pad);
+
+    iret += DrawHitRates_SubPad(hist_pad, i);
+  }
+
+  return iret;
+}
+
+int
+InttMonDraw::DrawHitRates_SubPad (
+	TPad* prnt_pad,
+	int i 
+) {
+	std::string name;
+
+	if(!prnt_pad) {
+		std::cerr << __PRETTY_FUNCTION__ << ":" << __LINE__ << "\n"
+		          << "\tnull TPad*" << std::endl;
+		return 1;
+	}
+	CdPad(prnt_pad);
+
+	// For now, just the histogram
+	// Other niceties (manual axis labels/ticks, maybe gridlines)
+	//   in the future (broken up into other methods)
+
+	OnlMonClient* cl = OnlMonClient::instance();
+
+	name = "InttEvtHist";
+	TH1D* evt_hist = (TH1D*) cl->getHisto(Form("INTTMON_%d", 0), name);
+	if (!evt_hist) {
+		std::cerr << __PRETTY_FUNCTION__ << ":" << __LINE__ << "\n"
+		          << "\tCould not get \"" << name << "\" from " << Form("INTTMON_%d", 0) << std::endl;
+		return 1;
+	}
+
+	name = "InttHitHist";
+	TH1D* bco_hist = (TH1D*) cl->getHisto(Form("INTTMON_%d", i), name);
+	if (!bco_hist) {
+		std::cerr << __PRETTY_FUNCTION__ << ":" << __LINE__ << "\n"
+		          << "\tCould not get \"" << name << "\" from " << Form("INTTMON_%d", i) << std::endl;
+		return 1;
+	}
+
+	name = Form("%s_hist_%01d", m_HitRates.name.c_str(), i);
+	TH1D* hist = new TH1D (
+		name.c_str(), name.c_str(),
+		112, m_HitRates.lower, m_HitRates.upper
+	);
+	hist->GetXaxis()->SetNdivisions(8, true);
+
+	// Fill
+	double bin;
+	struct InttMon::HitData_s hit_data;
+	for(hit_data.fee = 0; hit_data.fee < 14; ++hit_data.fee) {
+		for(hit_data.chp = 0; hit_data.chp < 26; ++hit_data.chp) {
+			bin = InttMon::HitBin(hit_data);         // Which bin has the data we want
+			bin = bco_hist->GetBinContent((int)bin); // Reuse the index as the value in that bin
+			bin /= evt_hist->GetBinContent(1);       // Normalize by number of events
+
+			// Manually catch overflows and put them in the last displayed bin
+			if(m_HitRates.upper <= bin) {
+				bin = m_HitRates.upper - hist->GetXaxis()->GetBinWidth(1);
+			}
+
+			hist->Fill(bin);
+		}
+		hist->SetTitle(Form("intt%01d;Hits/Event (overflow is shown in last bin);Entries (One Hitrate per Chip)", i));
+	}
+	hist->Draw();
+
+	return 0;
+}

--- a/subsystems/intt/Makefile.am
+++ b/subsystems/intt/Makefile.am
@@ -41,6 +41,7 @@ libonlinttmon_client_la_SOURCES = \
   InttMon_o_Binning.cc \
   InttMonDraw_o_FelixBcoFphxBco.cc \
   InttMonDraw_o_HitMap.cc \
+  InttMonDraw_o_HitRates.cc \
   InttMonDraw_o_Peaks.cc \
   InttMonDraw.cc
 


### PR DESCRIPTION
Added a new feature ("hitrates") to set of options
Removed gROOT->FindObject calls
- It has some pros but I just don't like doing it
- Canvases completely redrawn each Draw('what") call, slower if they were drawn before but fewer things can go wrong

Allocate everything, delete nothing
- It might leak more now, but there's not chance it crashes on a double free()
- No issues with this (yet) but I don't trust what ROOT does/doesn't delete

Let me know when/where/how to edit run_Poms.C--available methods are easy to see in the usual block of code in InttMonDraw.cc in the implementation of InttMonDraw::Draw. I'm including comments for which methods are intended for experts