### PR TITLE
Tpot calibration file

### DIFF
--- a/macros/run_tpot_client.C
+++ b/macros/run_tpot_client.C
@@ -14,6 +14,12 @@ void tpotDrawInit(const int online = 0)
 
   // create drawing object and register
   auto tpotmon = new TpotMonDraw("TPOT");
+
+  // prefer local calibration filename if exists
+  const std::string local_calibration_filename( "TPOT_Pedestal-000.root" );
+  if( std::ifstream( local_calibration_filename ).is_good() )
+  { tpotmon->set_calibration_file( local_calibration_filename ); }
+
   cl->registerDrawer(tpotmon);
 
   // get detector names

--- a/macros/run_tpot_client.C
+++ b/macros/run_tpot_client.C
@@ -3,6 +3,7 @@
 #include <onlmon/OnlMonClient.h>
 
 #include <array>
+#include <fstream>
 
 // cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonltpotmon_client.so)
@@ -17,7 +18,7 @@ void tpotDrawInit(const int online = 0)
 
   // prefer local calibration filename if exists
   const std::string local_calibration_filename( "TPOT_Pedestal-000.root" );
-  if( std::ifstream( local_calibration_filename ).is_good() )
+  if( std::ifstream( local_calibration_filename ).good() )
   { tpotmon->set_calibration_file( local_calibration_filename ); }
 
   cl->registerDrawer(tpotmon);

--- a/macros/run_tpot_server.C
+++ b/macros/run_tpot_server.C
@@ -10,12 +10,18 @@ R__LOAD_LIBRARY(libonltpotmon_server.so)
 void run_tpot_server(
   const std::string &name = "TPOTMON",
   unsigned int serverid = 0,
-  const std::string &prdffile = "/sphenix/lustre01/sphnxpro/commissioning/TPOT/junk/TPOT_ebdc39_junk-00041227-0000.evt"
+  // const std::string &prdffile = "/sphenix/lustre01/sphnxpro/commissioning/TPOT/junk/TPOT_ebdc39_junk-00041227-0000.evt"
+  const std::string &prdffile = "/sphenix/lustre01/sphnxpro/commissioning/TPOT/beam/TPOT_ebdc39_beam-00041374-0000.evt"
   )
 {
   // create subsystem Monitor object
   auto m = new TpotMon(name);
   m->SetMonitorServerId(serverid);
+
+  // prefer local calibration filename if exists
+  const std::string local_calibration_filename( "TPOT_Pedestal-000.root" );
+  if( std::ifstream( local_calibration_filename ).is_good() )
+  { m->set_calibration_file( local_calibration_filename ); }
 
   // get pointer to Server Framework
   auto se = OnlMonServer::instance();

--- a/macros/run_tpot_server.C
+++ b/macros/run_tpot_server.C
@@ -1,8 +1,9 @@
 #include "ServerFuncs.C"
 
 #include <onlmon/tpot/TpotMon.h>
-
 #include <onlmon/OnlMonServer.h>
+
+#include <fstream>
 
 // cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libonltpotmon_server.so)
@@ -20,7 +21,7 @@ void run_tpot_server(
 
   // prefer local calibration filename if exists
   const std::string local_calibration_filename( "TPOT_Pedestal-000.root" );
-  if( std::ifstream( local_calibration_filename ).is_good() )
+  if( std::ifstream( local_calibration_filename ).good() )
   { m->set_calibration_file( local_calibration_filename ); }
 
   // get pointer to Server Framework


### PR DESCRIPTION
This PR updates the run_tpot_server and Client so that if a local calibration file is found (in the running directory) it is used instead of the official one. 
There is proper debug information written in the log. 
This will make testing and debugging of online monitoring for TPOT much easier.