### PR TITLE
Cachehistomap

### DIFF
--- a/macros/run_Poms.C
+++ b/macros/run_Poms.C
@@ -32,9 +32,7 @@ void StartPoms()
   subsys->AddAction("cemcDraw(\"FIRST\")", "Towers");
   subsys->AddAction("cemcDraw(\"SECOND\")", "Packet Health [Expert]");
   subsys->AddAction("cemcDraw(\"THIRD\")", "Wave Forms");
-  subsys->AddAction("cemcDraw(\"FOURTH\")", "Wave vs Fast Fitting [Expert]");
   subsys->AddAction("cemcDraw(\"FIFTH\")", "Trigger [Expert]");
-  subsys->AddAction("cemcDraw(\"SIXTH\")", "All waveform summary [Expert]");
   subsys->AddAction("cemcDraw(\"SEVENTH\")", "Zero-suppression info");
   subsys->AddAction("cemcDraw(\"SERVERSTATS\")", "Server Stats");
   subsys->AddAction(new SubSystemActionSavePlot(subsys));
@@ -173,11 +171,11 @@ void StartPoms()
   subsys->AddAction(new SubSystemActionSavePlot(subsys));
   pmf->RegisterSubSystem(subsys);
 
-  subsys = new SubSystem("LOCALPOL", "localpol");
-  subsys->AddAction("localpolDraw(\"FIRST\")", "Asymmetries");
-  subsys->AddAction("localpolDraw(\"SECOND\")", "Polarisation direction");
-  subsys->AddAction(new SubSystemActionSavePlot(subsys));
-  pmf->RegisterSubSystem(subsys);
+  // subsys = new SubSystem("LOCALPOL", "localpol");
+  // subsys->AddAction("localpolDraw(\"FIRST\")", "Asymmetries");
+  // subsys->AddAction("localpolDraw(\"SECOND\")", "Polarisation direction");
+  // subsys->AddAction(new SubSystemActionSavePlot(subsys));
+  // pmf->RegisterSubSystem(subsys);
 
 
   pmf->Draw();

--- a/macros/run_Poms.C
+++ b/macros/run_Poms.C
@@ -8,12 +8,15 @@
 // See run_Poms.C.README
 
 #include <onlmon/Poms.h>
+#include <onlmon/OnlMonClient.h>
 
 // cppcheck-suppress unknownMacro
 R__LOAD_LIBRARY(libpoms.so)
 
 void StartPoms()
 {
+  OnlMonClient *cl = OnlMonClient::instance();
+  cl->ReadServerHistoMap();
   PomsMainFrame *pmf;
   pmf = PomsMainFrame::Instance();
 

--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -1014,10 +1014,13 @@ void OnlMonClient::Print(const char *what)
     std::map<const std::string, ClientHistoList *>::const_iterator hiter;
     for (hiter = Histo.begin(); hiter != Histo.end(); ++hiter)
     {
+      if (hiter->second)
+      {
       std::cout << hiter->first << " Address " << hiter->second->Histo()
                 << " on host " << hiter->second->ServerHost()
                 << " port " << hiter->second->ServerPort()
                 << ", subsystem " << hiter->second->SubSystem() << std::endl;
+      }
     }
     std::cout << std::endl;
     for (auto &subs : SubsysHisto)
@@ -1049,13 +1052,33 @@ void OnlMonClient::Print(const char *what)
     std::map<const std::string, ClientHistoList *>::const_iterator hiter;
     for (hiter = Histo.begin(); hiter != Histo.end(); ++hiter)
     {
-      if (hiter->second->ServerHost() == "UNKNOWN" ||
-          hiter->second->SubSystem() == "UNKNOWN")
+      if (hiter->second)
       {
-        std::cout << hiter->first << " Address " << hiter->second->Histo()
-                  << " on host " << hiter->second->ServerHost()
-                  << " port " << hiter->second->ServerPort()
-                  << ", subsystem " << hiter->second->SubSystem() << std::endl;
+	if (hiter->second->ServerHost() == "UNKNOWN" ||
+	    hiter->second->SubSystem() == "UNKNOWN")
+	{
+	  std::cout << hiter->first << " Address " << hiter->second->Histo()
+		    << " on host " << hiter->second->ServerHost()
+		    << " port " << hiter->second->ServerPort()
+		    << ", subsystem " << hiter->second->SubSystem() << std::endl;
+	}
+      }
+    }
+    std::cout << std::endl;
+    for (auto &subs : SubsysHisto)
+    {
+      auto subiter = MonitorHostPorts.find(subs.first);
+      for (auto &histos : subs.second)
+      {
+	if ( histos.second->ServerHost() == "UNKNOWN" ||
+	     histos.second->SubSystem() == "UNKNOWN")
+	{
+	  std::cout << histos.first << " @ " << subs.first
+		    << " Address " << histos.second->Histo()
+		    << " on host " << histos.second->ServerHost()
+		    << " port " << histos.second->ServerPort()
+		    << ", subsystem " << histos.second->SubSystem() << std::endl;
+	}
       }
     }
     std::cout << std::endl;
@@ -1816,23 +1839,22 @@ void OnlMonClient::ReadServerHistoMap(const std::string &cachefilename)
   int port;
   if (cachefile.good())
   {
-    std::cout << "opened file " << cachefilename << std::endl;
+    std::cout << "opened histogram map cache file " << cachefilename << std::endl;
     std::string line;
     while (std::getline(cachefile, line))
     {
-      std::cout << "read line " << line << std::endl;
       std::istringstream iss(line);
       iss >> hname;
       iss >> subsys;
       iss >> hostname;
       iss >> port;
-      std::cout << "hanem " << hname << ", port " << port << std::endl;
+      AddServerHost(hostname);
       PutHistoInMap(hname,subsys,hostname,port);
     }
     cachefile.close();
   }
   else
   {
-    std::cout << "failed to open file " << cachefilename << std::endl;
+    std::cout << "failed to open histogram map cache file " << cachefilename << std::endl;
   }
 }

--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -1067,7 +1067,6 @@ void OnlMonClient::Print(const char *what)
     std::cout << std::endl;
     for (auto &subs : SubsysHisto)
     {
-      auto subiter = MonitorHostPorts.find(subs.first);
       for (auto &histos : subs.second)
       {
 	if ( histos.second->ServerHost() == "UNKNOWN" ||

--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -1228,7 +1228,10 @@ void OnlMonClient::AddServerHost(const std::string &hostname)
 {
   if (find(MonitorHosts.begin(), MonitorHosts.end(), hostname) != MonitorHosts.end())
   {
-    std::cout << "Host " << hostname << " already in list" << std::endl;
+    if (Verbosity() > 2)
+    {
+      std::cout << "Host " << hostname << " already in list" << std::endl;
+    }
   }
   else
   {
@@ -1850,6 +1853,7 @@ void OnlMonClient::ReadServerHistoMap(const std::string &cachefilename)
       iss >> port;
       AddServerHost(hostname);
       PutHistoInMap(hname,subsys,hostname,port);
+      MonitorHostPorts.insert(std::make_pair(subsys, std::make_pair(hostname,port)));
     }
     cachefile.close();
   }

--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -1791,3 +1791,48 @@ OnlMonDraw *OnlMonClient::GetDrawer(const std::string &name)
   std::cout << "Cannot locate Drawer " << name << " in my list" << std::endl;
   return nullptr;
 }
+
+void OnlMonClient::SaveServerHistoMap(const std::string &cachefilename)
+{
+  std::ofstream cachefile(cachefilename);
+  std::cout << "saving histomap to " << cachefilename << std::endl;
+  for (auto &subs : SubsysHisto)
+  {
+    for (auto &histos : subs.second)
+    {
+      cachefile << histos.first << " " << histos.second->SubSystem() << " " << histos.second->ServerHost() << " " << histos.second->ServerPort() << std::endl;
+    }
+  }
+  cachefile.close();
+  return;
+}
+
+void OnlMonClient::ReadServerHistoMap(const std::string &cachefilename)
+{
+  std::ifstream cachefile(cachefilename);
+  std::string hname;
+  std::string subsys;
+  std::string hostname;
+  int port;
+  if (cachefile.good())
+  {
+    std::cout << "opened file " << cachefilename << std::endl;
+    std::string line;
+    while (std::getline(cachefile, line))
+    {
+      std::cout << "read line " << line << std::endl;
+      std::istringstream iss(line);
+      iss >> hname;
+      iss >> subsys;
+      iss >> hostname;
+      iss >> port;
+      std::cout << "hanem " << hname << ", port " << port << std::endl;
+      PutHistoInMap(hname,subsys,hostname,port);
+    }
+    cachefile.close();
+  }
+  else
+  {
+    std::cout << "failed to open file " << cachefilename << std::endl;
+  }
+}

--- a/onlmonclient/OnlMonClient.h
+++ b/onlmonclient/OnlMonClient.h
@@ -88,6 +88,8 @@ class OnlMonClient : public OnlMonBase
   std::map<std::string, std::tuple<bool, int, int, time_t>>::const_iterator GetServerMap(const std::string subsys) { return m_ServerStatsMap.find(subsys); }
   std::map<std::string, std::tuple<bool, int, int, time_t>>::const_iterator GetServerMapEnd() { return m_ServerStatsMap.end(); }
   OnlMonDraw *GetDrawer(const std::string &name);
+  void SaveServerHistoMap(const std::string &cachefile = "HistoMap.save");
+  void ReadServerHistoMap(const std::string &cachefile = "HistoMap.save");
 
  private:
   OnlMonClient(const std::string &name = "ONLMONCLIENT");


### PR DESCRIPTION
This PR allows saving the histogram map to a file and restoring it from file which speeds up the startup since Poms doesn't have to search for histograms anymore. If new histos are added or servers are moved, it will again search for them - at which point a new snapshot can be created