### PR TITLE
Tpot plots improvements 4

### DIFF
--- a/subsystems/tpot/TpotMon.cc
+++ b/subsystems/tpot/TpotMon.cc
@@ -112,6 +112,7 @@ int TpotMon::Init()
   m_counters->GetXaxis()->SetBinLabel(TpotMonDefs::kEventCounter, "events" );
   m_counters->GetXaxis()->SetBinLabel(TpotMonDefs::kValidEventCounter, "valid events" );
   m_counters->GetXaxis()->SetBinLabel(TpotMonDefs::kFullEventCounter, "full events" );
+  m_counters->GetXaxis()->SetBinLabel(TpotMonDefs::kTriggerCounter, "triggers" );
   se->registerHisto(this, m_counters);
 
   // global occupancy
@@ -255,6 +256,10 @@ int TpotMon::process_event(Event* event)
       { std::cout << "TpotMon::process_event - packet " << packet_id << " not found" << std::endl; }
       continue;
     }
+
+    // get number of lvl1 tagger
+
+
 
     // get number of datasets (also call waveforms)
     const auto n_waveforms = packet->iValue(0, "NR_WF" );

--- a/subsystems/tpot/TpotMon.cc
+++ b/subsystems/tpot/TpotMon.cc
@@ -31,6 +31,10 @@ namespace
     FILLMESSAGE = 2
   };
 
+  //! number of active packets used by TPOT.
+  /** This is used to properly normalize the number of trigger received */
+  static constexpr int m_npackets_active = 2;
+
   // get first member of pairs into a list
   std::vector<double> get_x( const MicromegasGeometry::point_list_t& point_list )
   {
@@ -109,9 +113,8 @@ int TpotMon::Init()
   // counters
   /* arbitrary counters. First bin is number of events */
   m_counters = new TH1F( "m_counters", "counters", 10, 0, 10 );
-  m_counters->GetXaxis()->SetBinLabel(TpotMonDefs::kEventCounter, "events" );
-  m_counters->GetXaxis()->SetBinLabel(TpotMonDefs::kValidEventCounter, "valid events" );
-  m_counters->GetXaxis()->SetBinLabel(TpotMonDefs::kFullEventCounter, "full events" );
+  m_counters->GetXaxis()->SetBinLabel(TpotMonDefs::kEventCounter, "RCDAQ frame" );
+  m_counters->GetXaxis()->SetBinLabel(TpotMonDefs::kValidEventCounter, "valid RCDAQ frames" );
   m_counters->GetXaxis()->SetBinLabel(TpotMonDefs::kTriggerCounter, "triggers" );
   se->registerHisto(this, m_counters);
 
@@ -197,7 +200,7 @@ int TpotMon::Init()
     se->registerHisto(this, detector_histograms.m_hit_multiplicity);
 
     // hit per channel
-    detector_histograms.m_hit_vs_channel = new TH1I(
+    detector_histograms.m_hit_vs_channel = new TH1F(
       Form( "m_hit_vs_channel_%s", detector_name.c_str() ),
       Form( "hit profile (%s);strip", detector_name.c_str() ),
       MicromegasDefs::m_nchannels_fee, 0, MicromegasDefs::m_nchannels_fee );
@@ -245,7 +248,6 @@ int TpotMon::process_event(Event* event)
   std::map<int, int> multiplicity;
 
   // read the data
-  double fullevent_weight = 0;
   for( const auto& packet_id:MicromegasDefs::m_packet_ids )
   {
     std::unique_ptr<Packet> packet(event->getPacket(packet_id));
@@ -258,19 +260,20 @@ int TpotMon::process_event(Event* event)
     }
 
     // get number of lvl1 tagger
+    const int n_tagger = packet->lValue(0, "N_TAGGER");
+    int n_lvl1_tagger = 0;
+    for (int t = 0; t < n_tagger; t++)
+    {
+      const bool is_lvl1_tagger( static_cast<uint8_t>(packet->lValue(t, "IS_LEVEL1_TRIGGER" )));
+      if( is_lvl1_tagger ) ++n_lvl1_tagger;
+    }
 
-
+    // increment counter
+    increment( m_counters, TpotMonDefs::kTriggerCounter, double(n_lvl1_tagger)/m_npackets_active );
+    m_triggercnt += double(n_lvl1_tagger)/m_npackets_active;
 
     // get number of datasets (also call waveforms)
     const auto n_waveforms = packet->iValue(0, "NR_WF" );
-
-    // add contribution to full event
-    /*
-     * we assume a full event must have m_nchannels_total waveforms
-     * this does not work with zero suppression ON. We do not know how many waveforms to expect for a full event.
-     * it might be more relevant to load taggers and increment.
-     */
-    fullevent_weight += double(n_waveforms)/MicromegasDefs::m_nchannels_total;
 
     if( Verbosity() )
     { std::cout << "TpotMon::process_event - n_waveforms: " << n_waveforms << std::endl; }
@@ -369,10 +372,6 @@ int TpotMon::process_event(Event* event)
     }
   }
 
-  // increment full event counter and counters histogram
-  m_fullevtcnt += fullevent_weight;
-  increment( m_counters, TpotMonDefs::kFullEventCounter, fullevent_weight );
-
   // fill hit multiplicities
   for( auto&& [fee_id, detector_histograms]:m_detector_histograms )
   { detector_histograms.m_hit_multiplicity->Fill( multiplicity[fee_id] ); }
@@ -384,10 +383,10 @@ int TpotMon::process_event(Event* event)
     { destination->SetBinContent( bin+1, source->GetBinContent( bin+1 )*scale ); }
   };
 
-  copy_content( m_detector_multiplicity_z, m_detector_occupancy_z, 100./(m_fullevtcnt*MicromegasDefs::m_nchannels_fee) );
-  copy_content( m_detector_multiplicity_phi, m_detector_occupancy_phi, 100./(m_fullevtcnt*MicromegasDefs::m_nchannels_fee) );
-  copy_content( m_resist_multiplicity_z, m_resist_occupancy_z, 400./(m_fullevtcnt*MicromegasDefs::m_nchannels_fee) );
-  copy_content( m_resist_multiplicity_phi, m_resist_occupancy_phi, 400./(m_fullevtcnt*MicromegasDefs::m_nchannels_fee) );
+  copy_content( m_detector_multiplicity_z, m_detector_occupancy_z, 100./(m_triggercnt*MicromegasDefs::m_nchannels_fee) );
+  copy_content( m_detector_multiplicity_phi, m_detector_occupancy_phi, 100./(m_triggercnt*MicromegasDefs::m_nchannels_fee) );
+  copy_content( m_resist_multiplicity_z, m_resist_occupancy_z, 400./(m_triggercnt*MicromegasDefs::m_nchannels_fee) );
+  copy_content( m_resist_multiplicity_phi, m_resist_occupancy_phi, 400./(m_triggercnt*MicromegasDefs::m_nchannels_fee) );
 
   return 0;
 }
@@ -397,7 +396,7 @@ int TpotMon::Reset()
 {
   // reset our internal counters
   m_evtcnt = 0;
-  m_fullevtcnt = 0;
+  m_triggercnt = 0;
 
   // reset all histograms
   for( TH1* h:{

--- a/subsystems/tpot/TpotMon.h
+++ b/subsystems/tpot/TpotMon.h
@@ -63,10 +63,10 @@ class TpotMon : public OnlMon
 
   //! keep track of number of 'full' triggers
   /*
-   * it is estimated by summing the number of recorded waveforms/max_waveform/trigger
-   * this will break when zero suppression is implemented
+   * it is estimated by counting the number of lvl1 taggers received for each packet
+   * and dividing by the number of active packets (2)
    */
-  double m_fullevtcnt = 0;
+  double m_triggercnt = 0;
 
   //! mapping
   MicromegasMapping m_mapping;

--- a/subsystems/tpot/TpotMonDefs.h
+++ b/subsystems/tpot/TpotMonDefs.h
@@ -7,11 +7,12 @@
 namespace TpotMonDefs
 {
   //! bin enumeration for counters histogram
-  enum 
+  enum
   {
     kEventCounter = 1,
     kValidEventCounter = 2,
-    kFullEventCounter = 3
+    kFullEventCounter = 3,
+    kTriggerCounter = 4
   };
 }
 #endif

--- a/subsystems/tpot/TpotMonDefs.h
+++ b/subsystems/tpot/TpotMonDefs.h
@@ -11,8 +11,7 @@ namespace TpotMonDefs
   {
     kEventCounter = 1,
     kValidEventCounter = 2,
-    kFullEventCounter = 3,
-    kTriggerCounter = 4
+    kTriggerCounter = 3
   };
 }
 #endif

--- a/subsystems/tpot/TpotMonDraw.cc
+++ b/subsystems/tpot/TpotMonDraw.cc
@@ -767,8 +767,6 @@ int TpotMonDraw::draw_counters()
 
   // get histograms
   auto m_counters =  get_histogram( "m_counters");
-  m_counters->SetMinimum(0);
-
   std::unique_ptr<TH1> m_counters_ref( normalize( get_ref_histogram( "m_counters" ), get_ref_scale_factor() ) );
 
   auto cv = get_canvas("TPOT_counters");
@@ -783,6 +781,8 @@ int TpotMonDraw::draw_counters()
 
   if( m_counters )
   {
+    m_counters->SetMinimum(0);
+
     cv->cd(1);
     gPad->SetLeftMargin( 0.07 );
     gPad->SetRightMargin( 0.15 );

--- a/subsystems/tpot/TpotMonDraw.cc
+++ b/subsystems/tpot/TpotMonDraw.cc
@@ -453,7 +453,7 @@ TCanvas* TpotMonDraw::create_canvas(const std::string &name)
     auto cv = new TCanvas(name.c_str(), "TpotMon hit vs channel", -1, 0, xsize / 2, ysize);
     gSystem->ProcessEvents();
     divide_canvas(cv, 4, 4);
-    hide_margins(cv);
+    hide_margins(cv,0.2);
     create_transparent_pad(name);
     cv->SetEditable(false);
     m_canvas.push_back( cv );
@@ -475,11 +475,18 @@ int TpotMonDraw::Draw(const std::string &what)
   {
     // get counters
     const auto m_counters = get_histogram( "m_counters");
+    if( m_counters )
+    {
+      m_triggercnt =  m_counters->GetBinContent( TpotMonDefs::kTriggerCounter );
+    } else {
+      m_triggercnt = 0;
+    }
+
     if( m_counters && Verbosity() )
     {
       const int events = m_counters->GetBinContent( TpotMonDefs::kEventCounter );
       const int valid_events = m_counters->GetBinContent( TpotMonDefs::kValidEventCounter );
-      std::cout << "TpotMonDraw::Draw - events: " << events << " valid events: " << valid_events << std::endl;
+      std::cout << "TpotMonDraw::Draw - RCDAQ frames: " << events << " valid RCDAQ frames: " << valid_events << std::endl;
     }
   }
 
@@ -638,7 +645,7 @@ int TpotMonDraw::Draw(const std::string &what)
 
   if (what == "ALL" || what == "TPOT_hit_vs_channel")
   {
-    iret += draw_array("TPOT_hit_vs_channel", get_histograms( "m_hit_vs_channel" ), get_ref_histograms_scaled( "m_hit_vs_channel" ), DrawOptions::Logy|DrawOptions::MatchRange);
+    iret += draw_array("TPOT_hit_vs_channel", get_histograms( "m_hit_vs_channel" ), get_ref_histograms_scaled( "m_hit_vs_channel" ), DrawOptions::Logy|DrawOptions::MatchRange|DrawOptions::Normalize);
     auto cv = get_canvas("TPOT_hit_vs_channel");
     if( cv )
     {
@@ -666,7 +673,8 @@ int TpotMonDraw::Draw(const std::string &what)
         // maks scoz
         auto&& pad = cv->GetPad(9);
         pad->cd();
-        mask_scoz(0.17,0.02,0.55, 0.98);
+        mask_scoz(0.22,0.02,0.58, 0.98);
+        // mask_scoz(0.17,0.02,0.55, 0.98);
       }
     }
 
@@ -986,9 +994,9 @@ double TpotMonDraw::get_ref_scale_factor() const
   const auto m_counters_ref = get_ref_histogram( "m_counters");
   if( !( m_counters && m_counters_ref ) ) return 0;
 
-  const double full_events = m_counters->GetBinContent( TpotMonDefs::kFullEventCounter );
-  const double full_events_ref = m_counters_ref->GetBinContent( TpotMonDefs::kFullEventCounter );
-  return full_events_ref > 0 ? full_events/full_events_ref : 0;
+  const double triggercnt = m_counters->GetBinContent( TpotMonDefs::kTriggerCounter );
+  const double triggercnt_ref = m_counters_ref->GetBinContent( TpotMonDefs::kTriggerCounter );
+  return triggercnt_ref > 0 ? triggercnt/triggercnt_ref : 0;
 }
 
 //__________________________________________________________________________________
@@ -1021,6 +1029,10 @@ int TpotMonDraw::draw_array( const std::string& name, const TpotMonDraw::histogr
     { if( h ) maximum = std::max( maximum, h->GetMaximum() ); }
   }
 
+  // also scale by number of triggers if normalization is required
+  if((options&DrawOptions::Normalize) && (m_triggercnt>0))
+  { maximum/=m_triggercnt; }
+
   // draw
   for( size_t i = 0; i < histograms.size(); ++i )
   {
@@ -1049,6 +1061,14 @@ int TpotMonDraw::draw_array( const std::string& name, const TpotMonDraw::histogr
         copy->GetYaxis()->SetTitleSize( i<12 ? 0.08:0.07 );
         copy->GetYaxis()->SetLabelSize( i<12 ? 0.08:0.07 );
 
+        // normalize
+        if((options&DrawOptions::Normalize) && (m_triggercnt>0))
+        {
+          copy->Scale( 1./m_triggercnt );
+          copy->GetYaxis()->SetTitle("counts/trigger");
+        }
+
+        // equalize maximum
         if(options&DrawOptions::MatchRange)
         { copy->SetMaximum( 1.2*maximum ); }
 
@@ -1058,25 +1078,33 @@ int TpotMonDraw::draw_array( const std::string& name, const TpotMonDraw::histogr
       if( ref_histograms[i] )
       {
         ref_histograms[i]->SetLineColor(2);
-        ref_histograms[i]->Draw("hist same" );
-        ref_histograms[i]->SetStats(false);
+
+        const auto& ref_copy = ref_histograms[i]->DrawCopy("hist same" );
+        ref_copy->SetStats(false);
+
+        // normalize
+        if((options&DrawOptions::Normalize) && (m_triggercnt>0))
+        { ref_copy->Scale( 1./m_triggercnt ); }
+
       }
 
+      // apply log scales
       if( options&DrawOptions::Logx )
-      {
-        gPad->SetLogx( true );
-      }
+      { gPad->SetLogx( true ); }
 
       if( options&DrawOptions::Logy && histograms[i]->GetEntries() > 0 )
       {
         gPad->SetLogy( true );
-        copy->SetMinimum(1);
+        if((options&DrawOptions::Normalize) && (m_triggercnt>0))
+        {
+          copy->SetMinimum(1./m_triggercnt);
+        } else {
+          copy->SetMinimum(1);
+        }
       }
 
       if( options&DrawOptions::Logz )
-      {
-        gPad->SetLogz( true );
-      }
+      { gPad->SetLogz( true ); }
 
       // draw detector name
       draw_text( 0.7, 0.9, m_detnames_sphenix[i].c_str() );

--- a/subsystems/tpot/TpotMonDraw.cc
+++ b/subsystems/tpot/TpotMonDraw.cc
@@ -594,7 +594,10 @@ int TpotMonDraw::Draw(const std::string &what)
     for( const auto& h:h_array )
     {
       if( h )
-      { h->GetXaxis()->SetRangeUser( m_sample_window.first, m_sample_window.second ); }
+      {
+        h->GetXaxis()->SetRangeUser( m_sample_window.first, m_sample_window.second );
+        h->SetMinimum(0);
+      }
     }
 
     // iret += draw_array("TPOT_counts_vs_sample", h_array, get_ref_histograms_scaled( "m_counts_sample" ), DrawOptions::MatchRange );

--- a/subsystems/tpot/TpotMonDraw.cc
+++ b/subsystems/tpot/TpotMonDraw.cc
@@ -512,7 +512,7 @@ int TpotMonDraw::Draw(const std::string &what)
       { h->GetXaxis()->SetRangeUser( m_sample_window.first, m_sample_window.second ); }
     }
 
-    iret += draw_array("TPOT_adc_vs_sample", h_array, DrawOptions::Colz );
+    iret += draw_array("TPOT_adc_vs_sample", h_array, DrawOptions::Colz|DrawOptions::Logz );
     auto cv = get_canvas("TPOT_adc_vs_sample");
     if( cv )
     {
@@ -549,7 +549,7 @@ int TpotMonDraw::Draw(const std::string &what)
 
   if (what == "ALL" || what == "TPOT_adc_vs_channel")
   {
-    iret += draw_array("TPOT_adc_vs_channel", get_histograms( "m_adc_channel" ), DrawOptions::Colz );
+    iret += draw_array("TPOT_adc_vs_channel", get_histograms( "m_adc_channel" ), DrawOptions::Colz|DrawOptions::Logz );
     auto cv = get_canvas("TPOT_adc_vs_channel");
     if( cv )
     {
@@ -605,7 +605,6 @@ int TpotMonDraw::Draw(const std::string &what)
     auto cv = get_canvas("TPOT_counts_vs_sample");
     if( cv )
     {
-      std::cout << "TpotMonDraw::Draw - draw vertical lines" << std::endl;
       CanvasEditor cv_edit(cv);
       cv->Update();
       for( int i = 0; i < MicromegasDefs::m_nfee; ++i )
@@ -760,6 +759,8 @@ int TpotMonDraw::draw_counters()
 
   // get histograms
   auto m_counters =  get_histogram( "m_counters");
+  m_counters->SetMinimum(0);
+
   std::unique_ptr<TH1> m_counters_ref( normalize( get_ref_histogram( "m_counters" ), get_ref_scale_factor() ) );
 
   auto cv = get_canvas("TPOT_counters");

--- a/subsystems/tpot/TpotMonDraw.cc
+++ b/subsystems/tpot/TpotMonDraw.cc
@@ -897,6 +897,8 @@ int TpotMonDraw::draw_resist_occupancy()
     copy->GetYaxis()->SetTitleOffset(0.65);
     draw_detnames_sphenix( "Z" );
 
+    mask_scoz(0.1,0.4,0.18, 0.6);
+
     cv->cd(2);
     gPad->SetLeftMargin( 0.07 );
     gPad->SetRightMargin( 0.15 );

--- a/subsystems/tpot/TpotMonDraw.h
+++ b/subsystems/tpot/TpotMonDraw.h
@@ -81,7 +81,8 @@ class TpotMonDraw : public OnlMonDraw
     Logy = 1<<1,
     Logz = 1<<2,
     Colz = 1<<3,
-    MatchRange = 1<<4
+    MatchRange = 1<<4,
+    Normalize = 1<<5
   };
 
   /// get histogram by name
@@ -119,6 +120,9 @@ class TpotMonDraw : public OnlMonDraw
   /// draw detector names in current canvas
   /** only works if canvas contains one of the properly formated TH2Poly histograms */
   void draw_detnames_sphenix( const std::string& suffix = std::string());
+
+  /// keep track of trigger count
+  double m_triggercnt = 0;
 
   /// mapping
   MicromegasMapping m_mapping;


### PR DESCRIPTION
- This use GTM taggers to count number of received triggers, and estimate number of full events,
 which works also in ZS mode.
- improved rendering of logY histograms
- normalize hit profiles to number of triggers

