### PR TITLE
Tpot change default windows

### DIFF
--- a/macros/makehtml.C
+++ b/macros/makehtml.C
@@ -46,7 +46,7 @@ void makehtml(const std::string &filelist, const std::string &subsystem)
   OnlMonClient *cl = OnlMonClient::instance();
   OnlMonDraw *drawer = nullptr;
   std::cout << "If used with root.exe, use root.exe -q makehtml.C" << endl;
-  std::cout << "If you use -q it is batch which does not have an Xserver" 
+  std::cout << "If you use -q it is batch which does not have an Xserver"
 	    << " to create gifs/png and this macro will fail miserably" << std::endl;
   if (subsystem == "BBCMON")
   {
@@ -98,7 +98,19 @@ void makehtml(const std::string &filelist, const std::string &subsystem)
   }
   else if (subsystem == "TPOTMON")
   {
-    drawer = new TpotMonDraw("TPOTMONDRAW");
+    auto tpotmon = new TpotMonDraw("TPOTMONDRAW");
+
+    // prefer local calibration filename if exists
+    const std::string local_calibration_filename( "TPOT_Pedestal-000.root" );
+    if( std::ifstream( local_calibration_filename ).good() )
+    { tpotmon->set_calibration_file( local_calibration_filename ); }
+
+    // adjust sample and signal windows
+    tpotmon->set_sample_window( {0, 50} );
+    tpotmon->set_sample_window_signal( {3, 18} );
+
+    // assign
+    drawer = tpotmon;
   }
   else if (subsystem == "ZDCMON")
   {
@@ -111,10 +123,10 @@ void makehtml(const std::string &filelist, const std::string &subsystem)
   }
   cl->registerDrawer(drawer);
   ifstream listfile(filelist);
-  if (listfile.is_open()) 
+  if (listfile.is_open())
   {
     std::string line;
-    while (std::getline(listfile, line)) 
+    while (std::getline(listfile, line))
     {
       cl->ReadHistogramsFromFile(line, drawer);
     }

--- a/macros/run_tpot_client.C
+++ b/macros/run_tpot_client.C
@@ -22,7 +22,7 @@ void tpotDrawInit(const int online = 0)
   { tpotmon->set_calibration_file( local_calibration_filename ); }
 
   tpotmon->set_sample_window( {0, 50} );
-  tpotmon->set_sample_window_signal( {5, 20} );
+  tpotmon->set_sample_window_signal( {3, 18} );
 
   cl->registerDrawer(tpotmon);
 

--- a/macros/run_tpot_server.C
+++ b/macros/run_tpot_server.C
@@ -12,13 +12,14 @@ void run_tpot_server(
   const std::string &name = "TPOTMON",
   unsigned int serverid = 0,
   // const std::string &prdffile = "/sphenix/lustre01/sphnxpro/commissioning/TPOT/junk/TPOT_ebdc39_junk-00041227-0000.evt"
-  const std::string &prdffile = "/sphenix/lustre01/sphnxpro/physics/TPOT/junk/TPOT_ebdc39_junk-00043402-0000.evt"
+  // const std::string &prdffile = "/sphenix/lustre01/sphnxpro/physics/TPOT/junk/TPOT_ebdc39_junk-00043402-0000.evt"
+  const std::string &prdffile = "/sphenix/lustre01/sphnxpro/physics/TPOT/physics/TPOT_ebdc39_physics-00044133-0000.evt"
   )
 {
   // create subsystem Monitor object
   auto m = new TpotMon(name);
   m->SetMonitorServerId(serverid);
-  m->set_sample_window_signal( {5, 20} );
+  m->set_sample_window_signal( {3, 18} );
 
   // prefer local calibration filename if exists
   const std::string local_calibration_filename( "TPOT_Pedestal-000.root" );

--- a/subsystems/tpot/TpotMon.h
+++ b/subsystems/tpot/TpotMon.h
@@ -84,7 +84,7 @@ class TpotMon : public OnlMon
   int m_max_sample = 105;
 
   // sample window
-  sample_window_t m_sample_window_signal = {20, 40};
+  sample_window_t m_sample_window_signal = {3, 18};
 
   //! number of RMS sigma used to define threshold
   double m_n_sigma = 5;

--- a/subsystems/tpot/TpotMonDraw.h
+++ b/subsystems/tpot/TpotMonDraw.h
@@ -146,10 +146,10 @@ class TpotMonDraw : public OnlMonDraw
   int TimeOffsetTicks = -1;
 
   // sample window
-  sample_window_t m_sample_window = {0, 100};
+  sample_window_t m_sample_window = {0, 50};
 
   // sample window
-  sample_window_t m_sample_window_signal = {20, 40};
+  sample_window_t m_sample_window_signal = {3, 18};
 
   //! number of RMS sigma used to define threshold
   double m_n_sigma = 5;


### PR DESCRIPTION
This PR makes sure the same timing windows are used in makehtml.C and run_tpot_clients.
Also changed the default values in TpotMon and TPotMonDraw. 
Finally, added some code to 'backward compatibly' handle fiber swap
NOTE: might need to remove that one in the near future. 

@pinkenburg 
NOTE 2: I have not actually tested the change to makehtml.C 