### PR TITLE
Fixed dangling pointer/moved delete

### DIFF
--- a/subsystems/intt/InttMon.cc
+++ b/subsystems/intt/InttMon.cc
@@ -56,8 +56,11 @@ int InttMon::process_event(Event *evt)
       int bco = ((0x7f & plist[0]->lValue(n, "BCO")) - plist[0]->iValue(n, "FPHX_BCO") + 128) % 128;
       HitHist->AddBinContent(fee * NCHIPS + chp + 1);  // +1 to start at bin 1
       BcoHist->AddBinContent(fee * NBCOS + bco + 1);   // +1 to start at bin 1
-      delete plist[0];
     }
+    delete plist[0];
+	plist[0] = nullptr;
+	// getPacketList doesn't set plist to an array of nullptrs if it fails
+	// you just get the dangling pointer from the previous loop
   }
 
   EvtHist->AddBinContent(1);


### PR DESCRIPTION
The getPacketList method might not set the values of the array it takes to null if it doesn't get a packet from the event, and it was bypassing the usual guard clause.

I'll check on the InttMonDraw side of things later but I thought this was something you might want to know in case you wanted to use it for other subsystems