### PR TITLE
First Draft of OnlMon horizontal tracks diagnostic

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -96,6 +96,7 @@ void tpcDrawInit(const int online = 0)
 
     cl->registerHisto("Layer_ChannelPhi_ADC_weighted",servername);
     cl->registerHisto("NEvents_vs_EBDC",servername);
+    cl->registerHisto("NStreaks_vs_EventNo",servername);
   } //
 
 

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -132,6 +132,8 @@ class TpcMon : public OnlMon
   TH2 *Layer_ChannelPhi_ADC_weighted = nullptr;
   TH1 *NEvents_vs_EBDC = nullptr;
 
+  TH1 *NStreaks_vs_EventNo = nullptr;
+
   TpcMap M; //declare Martin's map
 
   int starting_BCO;

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -53,12 +53,13 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCZYclusters(const std::string &what = "ALL");
   int DrawTPCZYclusters_unweighted(const std::string &what = "ALL");
   int DrawTPCchannelphi_layer_weighted(const std::string &what = "ALL");
+  int DrawTPCNStreaksvsEventNo(const std::string &what = "ALL");
   int DrawTPCNEventsvsEBDC(const std::string &wht = "ALL");
   int DrawServerStats();
   time_t getTime();
   
-  TCanvas *TC[29] = {nullptr};
-  TPad *transparent[29] = {nullptr};
+  TCanvas *TC[30] = {nullptr};
+  TPad *transparent[30] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
subystems/tpc/TpcMonDraw.cc
subystems/tpc/TpcMonDraw.h
subystems/tpc/TpcMon.cc
subystems/tpc/TpcMon.h

**Changes:**

Added Histograms that track the number of streakers in each sector, then plots those in 2 canvases (TOP: North, BOTTOM: South). A streaker is currently defined as a channel that is not stuck w/ no checksum error that has AT LEAST 15 entries w/ greater than 25 ADC over pedestal. The noise calculation is not considered as these channels may not have reliable std. dev. calculation.
 

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

 - ~~FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC~~
 - ~~FOR TOM: diagnostic of horizontal streakers~~
           - NEED TO ADD ABILITY TO SEND TO MCR
 - FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5 
  -  FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5 
  - Persistent Scope Plot (ask Jin)
  - ADC vs ADC Bin per FEE
  - ADC vs Channel - Evgeny 2D plot in pad row coordinates
  - Stuck Channel Detection
  - BCO Plots?
  - Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
