### PR TITLE
Adding histogram to Packet Types by WF fraction in events

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -97,6 +97,7 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("Layer_ChannelPhi_ADC_weighted",servername);
     cl->registerHisto("NEvents_vs_EBDC",servername);
     cl->registerHisto("NStreaks_vs_EventNo",servername);
+    cl->registerHisto("Packet_Type_Fraction",servername);
   } //
 
 

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -652,6 +652,19 @@ int TpcMon::Init()
   NEvents_vs_EBDC->SetXTitle("EBDC #");
   NEvents_vs_EBDC->SetYTitle("N_{Events}");  
 
+  char Packet_Type_Fraction_title_str[256];
+  sprintf(Packet_Type_Fraction_title_str,"Numer of Waveforms per Packet Type, Sector # %i",MonitorServerId());
+  Packet_Type_Fraction = new TH1F("Packet_Type_Fraction",Packet_Type_Fraction_title_str,7,0,7);
+  //Packet_Type_Fraction->SetXTitle("EBDC #");
+  Packet_Type_Fraction->SetYTitle("N_{Waveforms}");
+ 
+  const char* label[7] = { "HEARTBEAT_T", "TRUNCATED_DATA_T ", "TRUNCATED_TRIG_EARLY_DATA_T", "NORMAL_DATA_T", "LARGE_DATA_T", "TRIG_EARLY_DATA_T", "TRIG_EARLY_LARGE_DATA_T" };
+  for (int i=0; i!=7; ++i) {Packet_Type_Fraction->GetXaxis()->SetBinLabel(i+1,label[i]);}
+  Packet_Type_Fraction -> GetXaxis() -> SetLabelSize(0.08);
+  Packet_Type_Fraction -> GetYaxis() -> SetLabelSize(0.08);
+  Packet_Type_Fraction -> GetYaxis() -> SetTitleSize(0.08);
+  Packet_Type_Fraction -> GetYaxis() -> SetTitleOffset(0.6);
+
   OnlMonServer *se = OnlMonServer::instance();
   // register histograms with server otherwise client won't get them
   se->registerHisto(this, NorthSideADC);
@@ -727,6 +740,7 @@ int TpcMon::Init()
   se->registerHisto(this, Layer_ChannelPhi_ADC_weighted); 
   se->registerHisto(this, NEvents_vs_EBDC);
   se->registerHisto(this, NStreaks_vs_EventNo);
+  se->registerHisto(this, Packet_Type_Fraction);
 
   Reset();
   return 0;
@@ -825,6 +839,14 @@ int TpcMon::process_event(Event *evt/* evt */)
           current_BCOBIN++;
         }
 
+
+        if( p->iValue(wf,"TYPE")==0 ){Packet_Type_Fraction->Fill(0.5);} //HEARTBEAT_T 0b000
+        if( p->iValue(wf,"TYPE")==1 ){Packet_Type_Fraction->Fill(1.5);} //TRUNCATED_DATA_T 0b001
+        if( p->iValue(wf,"TYPE")==3 ){Packet_Type_Fraction->Fill(2.5);} //TRUNCATED_TRIG_EARLY_DATA_T 0b011
+        if( p->iValue(wf,"TYPE")==4 ){Packet_Type_Fraction->Fill(3.5);} //NORMAL_DATA_T 0b100
+        if( p->iValue(wf,"TYPE")==5 ){Packet_Type_Fraction->Fill(4.5);} //LARGE_DATA_T 0b101
+        if( p->iValue(wf,"TYPE")==6 ){Packet_Type_Fraction->Fill(5.5);} //TRIG_EARLY_DATA_T 0b110
+        if( p->iValue(wf,"TYPE")==7 ){Packet_Type_Fraction->Fill(6.5);} //TRIG_EARLY_LARGE_DATA_T 0b111
 
         int fee = p->iValue(wf, "FEE");
         int sampaAddress = p->iValue(wf, "SAMPAADDRESS");

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -133,6 +133,7 @@ class TpcMon : public OnlMon
   TH1 *NEvents_vs_EBDC = nullptr;
 
   TH1 *NStreaks_vs_EventNo = nullptr;
+  TH1 *Packet_Type_Fraction = nullptr;
 
   TpcMap M; //declare Martin's map
 

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -385,6 +385,18 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     transparent[29]->Draw();
     TC[29]->SetEditable(false);
   }
+  else if (name == "TPCPacketType")
+  {
+    TC[30] = new TCanvas(name.c_str(), "",-1, 0, xsize , ysize);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[30]->Divide(4,7);
+    transparent[30] = new TPad("transparent30", "this does not show", 0, 0, 1, 1);
+    transparent[30]->SetFillStyle(4000);
+    transparent[30]->Draw();
+    TC[30]->SetEditable(false);
+  }
+
      
   return 0;
 }
@@ -541,6 +553,11 @@ int TpcMonDraw::Draw(const std::string &what)
   if (what == "ALL" || what == "TPCNSTREAKERSVSEVENTNO")
   {
     iret += DrawTPCNStreaksvsEventNo(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCPACKETYPEFRACTION")
+  {
+    iret +=  DrawTPCPacketTypes(what);
     idraw++;
   }
   if (!idraw)
@@ -3340,6 +3357,67 @@ int TpcMonDraw::DrawTPCNStreaksvsEventNo(const std::string & /* what */)
 
   return 0;
 }
+
+int TpcMonDraw::DrawTPCPacketTypes(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH1 *tpcmon_PacketType[24] = {nullptr};
+
+  char TPCMON_STR[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_PacketType[i] = (TH1*) cl->getHisto(TPCMON_STR,"Packet_Type_Fraction");
+  }
+
+  if (!gROOT->FindObject("TPCPacketType"))
+  {
+    MakeCanvas("TPCPacketType");
+  }
+
+  TCanvas *MyTC = TC[30];
+  TPad *TransparentTPad = transparent[30];
+  MyTC->SetEditable(true);
+  MyTC->Clear("D");
+
+  gStyle->SetOptStat(0);
+  gStyle->SetPalette(57); //kBird CVD friendly
+
+  for( int i=0; i<24; i++ ) 
+  {
+    if( tpcmon_PacketType[i] )
+    {
+      MyTC->cd(i+5);
+      tpcmon_PacketType[i]->Scale(1/(tpcmon_PacketType[i]->GetEntries()),"width");
+      gPad->SetLogy(kTRUE);
+      tpcmon_PacketType[i]->DrawCopy("HIST");
+    }
+  }
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  time_t evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_WF PACKET FRACTION Run " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime);
+  runstring = runnostream.str();
+  TransparentTPad->cd();
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+  MyTC->Update();
+  MyTC->Show();
+  MyTC->SetEditable(false);
+
+  return 0;
+}
+
 
 int TpcMonDraw::SavePlot(const std::string &what, const std::string &type)
 {

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -54,12 +54,13 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCZYclusters_unweighted(const std::string &what = "ALL");
   int DrawTPCchannelphi_layer_weighted(const std::string &what = "ALL");
   int DrawTPCNStreaksvsEventNo(const std::string &what = "ALL");
-  int DrawTPCNEventsvsEBDC(const std::string &wht = "ALL");
+  int DrawTPCNEventsvsEBDC(const std::string &what = "ALL");
+  int DrawTPCPacketTypes(const std::string &what = "ALL");
   int DrawServerStats();
   time_t getTime();
   
-  TCanvas *TC[30] = {nullptr};
-  TPad *transparent[30] = {nullptr};
+  TCanvas *TC[31] = {nullptr};
+  TPad *transparent[31] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMonDraw.cc
subystems/tpc/TpcMonDraw.h
subystems/tpc/TpcMon.cc
subystems/tpc/TpcMon.h
macros/run_tpc_client.C

**Changes:**

Adding plots that show the fraction of WFs which come from the following packets:

HEARTBEAT_T                 = 0b000,
TRUNCATED_DATA_T            = 0b001,
TRUNCATED_TRIG_EARLY_DATA_T = 0b011,
NORMAL_DATA_T               = 0b100,
LARGE_DATA_T                = 0b101,
TRIG_EARLY_DATA_T           = 0b110,
TRIG_EARLY_LARGE_DATA_T     = 0b111,

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
