### PR TITLE
Fixing divide by zero bug in PACKET TYPE client side histo

### DIFF
--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -3390,7 +3390,7 @@ int TpcMonDraw::DrawTPCPacketTypes(const std::string & /* what */)
     if( tpcmon_PacketType[i] )
     {
       MyTC->cd(i+5);
-      tpcmon_PacketType[i]->Scale(1/(tpcmon_PacketType[i]->GetEntries()),"width");
+      if(tpcmon_PacketType[i]->GetEntries() > 0){tpcmon_PacketType[i]->Scale(1/(tpcmon_PacketType[i]->GetEntries()),"width");}
       gPad->SetLogy(kTRUE);
       tpcmon_PacketType[i]->DrawCopy("HIST");
     }


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMonDraw.cc

**Changes:**

Adding a catch that ensures we don't divide by zero when scaling by NEntries() in the pack type histo on client side.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
