### PR TITLE
remove event size limit

### DIFF
--- a/onlmonserver/pmonitorInterface.cc
+++ b/onlmonserver/pmonitorInterface.cc
@@ -145,6 +145,7 @@ int process_event(Event *evt)
 #endif
     eorticks = borticks;
   }
+  /*
   if (evt->getEvtLength() <= 0 || evt->getEvtLength() > 2500000)
   {
     std::ostringstream msg;
@@ -154,7 +155,7 @@ int process_event(Event *evt)
     se->AddBadEvent();
     return 0;
   }
-
+  */
   int oldrun;
   if ((oldrun = se->RunNumber()) != evt->getRunNumber())
   {


### PR DESCRIPTION
From the PHENIX days we still had a limit on the event sizes which were passed down from pmonitorinterface. I guess this currently removes the BOR events from the monitoring. Hoping that our event sizes are all reasonable this PR removes this check