### PR TITLE
(INTT) Normalization fix (unique BCO counter), appearance changes

### DIFF
--- a/macros/run_Poms.C
+++ b/macros/run_Poms.C
@@ -79,6 +79,7 @@ void StartPoms()
   // subsys->AddAction("inttDraw(\"ladder_hitmap\")", "Ladder Hitmap");
   //  subsys->AddAction("inttDraw(\"chip_nll\")", "Chip NLL");
   subsys->AddAction("inttDraw(\"bco_diff\")", "BCO Diff");
+  subsys->AddAction("inttDraw(\"hitrates\")", "Hitrates");
   subsys->AddAction("inttDraw(\"SERVERSTATS\")", "Server Stats");
   subsys->AddAction(new SubSystemActionSavePlot(subsys));
   pmf->RegisterSubSystem(subsys);

--- a/subsystems/intt/InttMon.cc
+++ b/subsystems/intt/InttMon.cc
@@ -7,6 +7,9 @@
 
 #include <TH1.h>
 
+#include <iostream>
+#include <limits>
+
 InttMon::InttMon(const std::string &name)
   : OnlMon(name)
 {
@@ -24,7 +27,9 @@ int InttMon::Init()
   OnlMonServer *se = OnlMonServer::instance();
 
   // histograms
-  EvtHist = new TH1I("InttEvtHist", "InttEvtHist", 1, 0.0, 1.0);
+  // GetBinContent(1): # of rcdaq events, GetBinContent(2): # of unique BCOs, GetBinContent(3): BCO order error
+  EvtHist = new TH1I("InttEvtHist", "InttEvtHist", 3, 0.0, 1.0);
+  // # of unique bcos seen by Felix channel; GetBinContent(15) is a flag if bcos are out of order
   // 26*14
   HitHist = new TH1I("InttHitHist", "InttHitHist", (NFEES * NCHIPS), 0.0, 1.0);
   // 128*14
@@ -41,41 +46,86 @@ int InttMon::Init()
 
 int InttMon::BeginRun(const int /* run_num */)
 {
+  EvtHist->Reset();
+  HitHist->Reset();
+  BcoHist->Reset();
+
+  m_unique_bcos.clear();
+  m_unique_bco_count = 0;
+  m_most_recent_bco = std::numeric_limits<unsigned long long>::max();
+  m_last_flushed_bco = std::numeric_limits<unsigned long long>::max();
+
   return 0;
 }
 
 int InttMon::process_event(Event *evt)
 {
   for (int pid = 3001; pid < 3009; ++pid)
+  {
+    Packet *pkt = evt->getPacket(pid);
+    if (!pkt)
     {
-      Packet *p = evt->getPacket(pid);
-      if (!p)
-	    {
-	      continue;
-	    }
-
-      if (p)
-	    {
-	      for (int n = 0; n < p->iValue(0, "NR_HITS"); ++n)
-	      {
-	        int fee = p->iValue(n, "FEE");
-	        int chp = (p->iValue(n, "CHIP_ID") + 25) % 26;
-	        int bco = ((0x7f & p->lValue(n, "BCO")) - p->iValue(n, "FPHX_BCO") + 128) % 128;
-	        HitHist->AddBinContent(fee * NCHIPS + chp + 1);  // +1 to start at bin 1
-	        BcoHist->AddBinContent(fee * NBCOS + bco + 1);   // +1 to start at bin 1
-	      }
-	    delete p;
-	    }
+      continue;
     }
 
+	// hits
+    for (int n = 0; n < pkt->iValue(0, "NR_HITS"); ++n)
+    {
+      int fee = pkt->iValue(n, "FEE");
+      int chp = (pkt->iValue(n, "CHIP_ID") + 25) % 26;
+      int bco = ((0x7f & pkt->lValue(n, "BCO")) - pkt->iValue(n, "FPHX_BCO") + 128) % 128;
+      HitHist->AddBinContent(fee * NCHIPS + chp + 1);  // +1 to start at bin 1
+      BcoHist->AddBinContent(fee * NBCOS + bco + 1);   // +1 to start at bin 1
+    }
+
+	// bcos
+	for (int n = 0; n < pkt->iValue(0, "NR_BCOS"); ++n)
+	{
+      unsigned long long bco_full = pkt->lValue(n, "BCOLIST");
+
+  	  // more recent that the variable we track it with, or variable we track it with hasn't been set to a "real" value yet
+  	  if(m_bco_less(m_most_recent_bco, bco_full) || (m_most_recent_bco == std::numeric_limits<unsigned long long>::max()))
+  	  {
+          m_most_recent_bco = bco_full;
+  	  }
+
+  	  // make sure it's not in the range of bcos we've "flushed" into our counter (and that the variable we track it with has been set to a "real" value)
+  	  // This check should be moot--the fees have their BCOs in order--but I leave it in anyways b/c it is not expensive and confirms this assumption
+  	  if(!m_bco_less(m_last_flushed_bco, bco_full) && (m_last_flushed_bco != std::numeric_limits<unsigned long long>::max()))
+  	  {
+          EvtHist->SetBinContent(3, 1);
+		  continue;
+  	  }
+
+  	  m_unique_bcos.insert(bco_full);
+	}
+
+    delete pkt;
+  }
+
+  // Go through our list of unique BCOs and "flush" them into a counter
+  std::set<unsigned long long, bco_comparator_s>::const_iterator bco_itr = m_unique_bcos.begin();
+  for(bco_itr = m_unique_bcos.begin(); bco_itr != m_unique_bcos.end(); ++bco_itr)
+  {
+    if((m_most_recent_bco == std::numeric_limits<unsigned long long>::max()) || m_bco_less(m_most_recent_bco - m_max_size, *bco_itr))
+    {
+      break;
+    }
+
+    ++m_unique_bco_count;
+    m_last_flushed_bco = *bco_itr;
+  }
+  m_unique_bcos.erase(m_unique_bcos.begin(), bco_itr);
+
   EvtHist->AddBinContent(1);
+  EvtHist->SetBinContent(2, m_unique_bco_count + m_unique_bcos.size());
 
   return 0;
 }
 
 int InttMon::Reset()
 {
-  return 0;
+  	return 0;
 }
 
 int InttMon::MiscDebug()
@@ -97,6 +147,11 @@ int InttMon::MiscDebug()
   }
 
   return 0;
+}
+
+bool InttMon::bco_comparator_s::operator()(unsigned long long const& lhs, unsigned long long const& rhs) const
+{
+  return (rhs - lhs + 2 * MAX) % MAX < (lhs - rhs + 2 *MAX) % MAX;
 }
 
 //             Ladder Structure                //

--- a/subsystems/intt/InttMon.h
+++ b/subsystems/intt/InttMon.h
@@ -3,6 +3,7 @@
 
 #include <onlmon/OnlMon.h>
 
+#include <set>
 #include <string>
 
 class Packet;
@@ -25,10 +26,23 @@ class InttMon : public OnlMon
   static constexpr int NCHIPS = 26;
   static constexpr int NFEES = 14;
   static constexpr int NBCOS = 128;
+
   Packet** plist{nullptr};
   TH1* EvtHist{nullptr};
   TH1* HitHist{nullptr};
   TH1* BcoHist{nullptr};
+
+  struct bco_comparator_s
+  {
+	  unsigned long long static const MAX = (unsigned long long){1} << 40;
+	  bool operator()(unsigned long long const&, unsigned long long const&) const;
+  } const m_bco_less{};
+  std::set<unsigned long long, bco_comparator_s> m_unique_bcos;
+  unsigned long long m_most_recent_bco = {};
+  unsigned long long m_last_flushed_bco = {};
+
+  int m_max_size = 1000;
+  int m_unique_bco_count = {};
 };
 
 #endif

--- a/subsystems/intt/InttMonDraw.cc
+++ b/subsystems/intt/InttMonDraw.cc
@@ -402,7 +402,7 @@ int InttMonDraw::Draw_FelixBcoFphxBco()
     lgnd_text.SetTextAlign(12);
     lgnd_text.SetTextSize(lgnd_text_size);
     lgnd_text.SetTextColor(kBlack);
-    lgnd_text.DrawText(x0 + 1.5 * lgnd_box_width, y0, Form("Chip %2d", fee));
+    lgnd_text.DrawText(x0 + 1.5 * lgnd_box_width, y0, Form("FChn %2d", fee));
 
     x[0] = -1, x[1] = +1, x[2] = +1, x[3] = -1;
     y[0] = -1, y[1] = -1, y[2] = +1, y[3] = +1;

--- a/subsystems/intt/InttMonDraw.cc
+++ b/subsystems/intt/InttMonDraw.cc
@@ -465,9 +465,10 @@ int InttMonDraw::DrawHistPad_FelixBcoFphxBco(
   OnlMonClient* cl = OnlMonClient::instance();
 
   TH1* bco_hist = cl->getHisto(Form("INTTMON_%d", i), "InttBcoHist");
+  m_transparent_pad[k_felixbcofphxbco][i]->Clear();
   if (!bco_hist)
   {
-    m_transparent_pad[k_hitrates][i]->cd();
+    m_transparent_pad[k_felixbcofphxbco][i]->cd();
 	TText dead_text;
 	dead_text.SetTextColor(kBlue);
 	dead_text.SetTextAlign(22);
@@ -655,9 +656,10 @@ int InttMonDraw::DrawHistPad_HitMap(int i, int icnvs)
 
   TH1* evt_hist = cl->getHisto(Form("INTTMON_%d", i), "InttEvtHist");
   TH1* hit_hist = cl->getHisto(Form("INTTMON_%d", i), "InttHitHist");
+  m_transparent_pad[k_hitmap][i]->Clear();
   if (!evt_hist || !hit_hist)
   {
-    m_transparent_pad[k_hitrates][i]->cd();
+    m_transparent_pad[k_hitmap][i]->cd();
 	TText dead_text;
 	dead_text.SetTextColor(kBlue);
 	dead_text.SetTextAlign(22);

--- a/subsystems/intt/InttMonDraw.h
+++ b/subsystems/intt/InttMonDraw.h
@@ -53,7 +53,7 @@ class InttMonDraw : public OnlMonDraw
   int DrawDispPad_Generic(int icnvs, const std::string& title);
 
   int Draw_FelixBcoFphxBco();
-  int DrawHistPad_FelixBcoFphxBco(int icnvs);
+  int DrawHistPad_FelixBcoFphxBco(int i, int icnvs);
   Color_t static GetFeeColor(int const&);
 
   int Draw_HitMap();
@@ -90,6 +90,8 @@ class InttMonDraw : public OnlMonDraw
   TPad* m_disp_pad[k_end]{nullptr};
   TPad* m_lgnd_pad[k_end]{nullptr};
   TPad* m_hist_pad[k_end][10]{{nullptr}};
+  TPad* m_transparent_pad[k_end][10]{{nullptr}};
+
   TH1* m_hist_felixbcofphxbco[8][14]{{nullptr}};
   TH1* m_hist_hitrates[8]{nullptr};
   TH2* m_hist_hitmap[8]{nullptr};


### PR DESCRIPTION
Added a counter for unique BCOs
- Uses new API from Martin
- "chip_hitmap" and "hitrates" options are normalized accordingly

Fixed appearance in case of mix of alive/dead servers
- Added pads to draw text per histogram in case of dead server
- Text is drawn on top of (empty) histogram for dead servers
- DrawDeadServer is still called in the case non are found