### PR TITLE
Adding histo for channel frequency normalized to LVL_1 TAGGERS per EBDC

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -64,15 +64,16 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("Stuck_Channels",servername);
     cl->registerHisto("Channels_in_Packet",servername);
     cl->registerHisto("Channels_Always",servername);
+    cl->registerHisto("LVL_1_TAGGER_per_EBDC",servername);
     cl->registerHisto("Num_non_ZS_channels_vs_SAMPA",servername);
     cl->registerHisto("First_ADC_vs_First_Time_Bin",servername);
     cl->registerHisto("ZS_Trigger_ADC_vs_Sample",servername);
     cl->registerHisto("ADC_vs_SAMPLE",servername); 
     cl->registerHisto("ADC_vs_SAMPLE_large",servername);
-    cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE",servername);
-    cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE_R1",servername);
-    cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE_R2",servername);
-    cl->registerHisto( "PEDEST_SUB_ADC_vs_SAMPLE_R3",servername);
+    cl->registerHisto("PEDEST_SUB_ADC_vs_SAMPLE",servername);
+    cl->registerHisto("PEDEST_SUB_ADC_vs_SAMPLE_R1",servername);
+    cl->registerHisto("PEDEST_SUB_ADC_vs_SAMPLE_R2",servername);
+    cl->registerHisto("PEDEST_SUB_ADC_vs_SAMPLE_R3",servername);
     cl->registerHisto("MAXADC",servername);
 
     cl->registerHisto("RAWADC_1D_R1",servername);

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -395,7 +395,7 @@ int TpcMon::Init()
   Channels_in_Packet -> GetYaxis() -> SetLabelSize(0.05);
   Channels_in_Packet -> GetYaxis() -> SetTitleSize(0.05);
   Channels_in_Packet -> GetYaxis() -> SetTitleOffset(1.0);  
-
+  
   // # of times channels could be in packet per RCDAQ event
   char chans_always_title_str[100];
   sprintf(chans_always_title_str,"Channel counts vs all channels (filled once per event w/ packets): SECTOR %i",MonitorServerId());  
@@ -409,6 +409,11 @@ int TpcMon::Init()
   Channels_Always -> GetYaxis() -> SetLabelSize(0.05);
   Channels_Always -> GetYaxis() -> SetTitleSize(0.05);
   Channels_Always -> GetYaxis() -> SetTitleOffset(1.0);
+
+  // # of LVL 1 tagger per EBDC
+  LVL_1_TAGGER_per_EBDC = new TH1F("LVL_1_TAGGER_per_EBDC","Number of LEVEL 1 TAGGERS PER EBDC",24,-0.5,23.5);
+  LVL_1_TAGGER_per_EBDC->SetXTitle("EBDC #");
+  LVL_1_TAGGER_per_EBDC->SetYTitle("N_{LVL_1_TAGGER}");  
 
   //ZS ADC vs Sample (small)
   char ZS_ADC_vs_SAMPLE_str[100];
@@ -697,7 +702,7 @@ int TpcMon::Init()
   se->registerHisto(this, Stuck_Channels);
   se->registerHisto(this, Channels_in_Packet);
   se->registerHisto(this, Channels_Always);
-  se->registerHisto(this, Channels_Always);
+  se->registerHisto(this, LVL_1_TAGGER_per_EBDC);
   se->registerHisto(this, Num_non_ZS_channels_vs_SAMPA);
   se->registerHisto(this, ZS_Trigger_ADC_vs_Sample);
   se->registerHisto(this, First_ADC_vs_First_Time_Bin);
@@ -871,6 +876,13 @@ int TpcMon::process_event(Event *evt/* evt */)
         if( p->iValue(wf,"TYPE")==5 ){Packet_Type_Fraction_ELSE->Fill(4.5);} //LARGE_DATA_T 0b101
         if( p->iValue(wf,"TYPE")==6 ){Packet_Type_Fraction_ELSE->Fill(5.5);} //TRIG_EARLY_DATA_T 0b110
         if( p->iValue(wf,"TYPE")==7 ){Packet_Type_Fraction_ELSE->Fill(6.5);} //TRIG_EARLY_LARGE_DATA_T 0b111
+
+        const int n_tagger = p->lValue(0, "N_TAGGER");
+        for (int t = 0; t < n_tagger; t++)
+        {
+          const bool is_lvl1_tagger( static_cast<uint8_t>(p->lValue(t, "IS_LEVEL1_TRIGGER" )));
+          if( is_lvl1_tagger ){ LVL_1_TAGGER_per_EBDC->Fill(MonitorServerId()); }
+	}
 
         int fee = p->iValue(wf, "FEE");
         int sampaAddress = p->iValue(wf, "SAMPAADDRESS");

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -107,6 +107,7 @@ class TpcMon : public OnlMon
   TH1 *Stuck_Channels = nullptr;
   TH1 *Channels_in_Packet = nullptr;
   TH1 *Channels_Always = nullptr;
+  TH1 *LVL_1_TAGGER_per_EBDC = nullptr;
 
   TH2 *Num_non_ZS_channels_vs_SAMPA = nullptr;
   TH2 *ZS_Trigger_ADC_vs_Sample = nullptr;

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -32,6 +32,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCCheckSum(const std::string &what = "ALL");
   int DrawTPCChansinPacketNS(const std::string &what = "ALL");
   int DrawTPCChansinPacketSS(const std::string &what = "ALL");
+  int DrawTPCChansperLVL1_NS(const std::string &what = "ALL");
+  int DrawTPCChansperLVL1_SS(const std::string &what = "ALL");
   int DrawTPCNonZSChannels(const std::string &what = "ALL");
   int DrawTPCZSTriggerADCSample(const std::string &what = "ALL");
   int DrawTPCFirstnonZSADCFirstnonZSSample(const std::string &what = "ALL");
@@ -59,8 +61,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawServerStats();
   time_t getTime();
   
-  TCanvas *TC[31] = {nullptr};
-  TPad *transparent[31] = {nullptr};
+  TCanvas *TC[33] = {nullptr};
+  TPad *transparent[33] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
subystems/tpc/TpcMon.cc
subystems/tpc/TpcMon.h
subystems/tpc/TpcMonDraw.cc
subystems/tpc/TpcMonDraw.h

**Changes:**

Adding in histo that looks at channel frequency normalized to LVL_1 TAGGERs per EBDC. Like the one that looks at channels/packet , it is split into 2 histos, NS and SS

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
