### PR TITLE
get rid of get_old_fee_id.

### DIFF
--- a/macros/run_tpot_server.C
+++ b/macros/run_tpot_server.C
@@ -13,8 +13,8 @@ void run_tpot_server(
   unsigned int serverid = 0,
   // const std::string &evtfile = "/sphenix/lustre01/sphnxpro/commissioning/TPOT/junk/TPOT_ebdc39_junk-00041227-0000.evt"
   // const std::string &evtfile = "/sphenix/lustre01/sphnxpro/physics/TPOT/junk/TPOT_ebdc39_junk-00043402-0000.evt"
-  const std::string &evtfile = "/sphenix/lustre01/sphnxpro/physics/TPOT/physics/TPOT_ebdc39_physics-00045550-0000.evt"
-  // const std::string &evtfile = "/sphenix/lustre01/sphnxpro/physics/TPOT/physics/TPOT_ebdc39_physics-00045890-0000.evt"
+  // const std::string &evtfile = "/sphenix/lustre01/sphnxpro/physics/TPOT/physics/TPOT_ebdc39_physics-00045550-0000.evt"
+  const std::string &evtfile = "/sphenix/lustre01/sphnxpro/physics/TPOT/physics/TPOT_ebdc39_physics-00045890-0000.evt"
   )
 {
   // create subsystem Monitor object

--- a/subsystems/tpot/TpotMon.cc
+++ b/subsystems/tpot/TpotMon.cc
@@ -31,18 +31,6 @@ namespace
     FILLMESSAGE = 2
   };
 
-  /*
-   * on May 29 2024, we the fiber arriving on fee_id 11 was moved to fee_id 21
-   * since fee_id 11 was not assigned before, we can internally convert all call to fee_id 21 to fee_id11,
-   * while keeping backward compatibility
-  */
-  int get_old_fee_id( int fee_id )
-  {
-    static const std::map<int,int> internal_fee_id_map( {{21,11}} );
-    const auto& iter = internal_fee_id_map.find( fee_id );
-    return iter == internal_fee_id_map.end() ? fee_id:iter->second;
-  }
-
   // get first member of pairs into a list
   std::vector<double> get_x( const MicromegasGeometry::point_list_t& point_list )
   {
@@ -345,7 +333,7 @@ int TpotMon::process_event(Event* event)
       }
 
       // account for fiber swapping
-      const int fee_id = get_old_fee_id( packet->iValue(i, "FEE" ) );
+      const int fee_id = packet->iValue(i, "FEE");
 
       // get detector index from fee id
       const auto iter = m_detector_histograms.find( fee_id );


### PR DESCRIPTION
This is the online monitoring equivalent of https://github.com/sPHENIX-Collaboration/coresoftware/pull/2878
To @pinkenburg : for this to work you would have to update (again) the online version of the offline build.
Thanks !
Hugo
