### PR TITLE
OnlMon modified to use the GL1Manager (daq and cemc)

### DIFF
--- a/macros/run_cemc_server_at_SDCC.C
+++ b/macros/run_cemc_server_at_SDCC.C
@@ -1,0 +1,26 @@
+#include "ServerFuncs.C"
+
+#include <onlmon/cemc/CemcMon.h>
+
+#include <onlmon/OnlMonServer.h>
+
+// cppcheck-suppress unknownMacro
+R__LOAD_LIBRARY(libonlcemcmon_server.so)
+
+//  run an eventserver on the same machine this way:
+//  eventServer [-i] -x -f /sphenix/lustre01/sphnxpro/physics/GL1/physics/GL1_physics_gl1daq-00046767-0000.evt
+
+// void run_cemc_server(const char *prdffile = "/sphenix/data/data02/sphenix/t1044/rcdaq-00000221-0000.prdf")
+void run_cemc_server_at_SDCC(const std::string &name = "CEMCMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/lustre01/sphnxpro/physics/emcal/physics/physics_seb00-00046767-0000.prdf")
+{
+  OnlMon *m = new CemcMon(name, "localhost");                    // create subsystem Monitor object
+  m->SetMonitorServerId(serverid);
+                                                //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
+                                                //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
+  OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework
+  se->registerMonitor(m);                       // register subsystem Monitor with Framework
+  start_server(prdffile);
+  gStyle->SetOptStat(0);
+  // cemc_runningmean->SetMinimum(0);
+  return;
+}

--- a/macros/run_daq_server_at_SDCC.C
+++ b/macros/run_daq_server_at_SDCC.C
@@ -1,0 +1,24 @@
+#include "ServerFuncs.C"
+
+#include <onlmon/daq/DaqMon.h>
+
+#include <onlmon/OnlMonServer.h>
+
+// cppcheck-suppress unknownMacro
+R__LOAD_LIBRARY(libonldaqmon_server.so)
+
+//  run an eventserver on the same machine this way:
+//  eventServer [-i] -x -f /sphenix/lustre01/sphnxpro/physics/GL1/physics/GL1_physics_gl1daq-00046767-0000.evt
+
+
+void run_daq_server_at_SDCC(const std::string &name = "DAQMON", unsigned int serverid = 0, const std::string &prdffile = "/sphenix/lustre01/sphnxpro/physics/emcal/physics/physics_seb00-00046767-0000.prdf")
+{
+  OnlMon *m = new DaqMon(name, "localhost");    // create subsystem Monitor object  with localhst as the eventServer
+  m->SetMonitorServerId(serverid);
+                                                //  m->AddTrigger("PPG(Laser)");  // high efficiency triggers selection at et pool
+                                                //  m->AddTrigger("ONLMONBBCLL1"); // generic bbcll1 minbias trigger (defined in ServerFuncs.C)
+  OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework
+  se->registerMonitor(m);                       // register subsystem Monitor with Framework
+  start_server(prdffile);
+  return;
+}

--- a/onlmonutils/GL1Manager.cc
+++ b/onlmonutils/GL1Manager.cc
@@ -1,0 +1,269 @@
+
+#include "GL1Manager.h"
+
+#include <Event/eventReceiverClient.h>
+#include <Event/Event.h>
+#include <Event/packet.h>
+
+#include <algorithm>
+
+#define coutfl if (verbosity) std::cout << __FILE__<< "  " << __LINE__ << " "
+//#define coutfl std::cout << __FILE__<< "  " << __LINE__ << " "
+
+using namespace std;
+
+GL1Manager::GL1Manager (const char * hostname, const int h, const int d)
+{
+  _hostname = hostname;
+  _broken = 0;
+  pgl1 = 0;
+
+  history_length = h;
+  max_discrepancy = d;
+
+  Reset();
+
+  erc = new eventReceiverClient(hostname);
+}
+
+GL1Manager::~GL1Manager()
+{
+  if (pgl1) delete pgl1;
+  if ( erc) delete erc;
+}
+
+
+void GL1Manager::Reset()
+{
+  desireddiff = 0;
+  previousdiff = 0;
+  clockdiff = 0;
+  event_delta = 0;
+  eventMatch = 0;
+  packetRequested = 0;
+  gl1_clock = 0;
+  init_done = 0;
+  verbosity = 0;
+
+  previous_GL1clocks.clear();
+  previous_packetclocks.clear();
+  
+  diff_gl1clocks.clear();
+  diff_packetclocks.clear();
+
+  if (pgl1) delete pgl1;
+  pgl1 = 0;
+
+  return;
+}
+
+
+Packet *GL1Manager::getGL1Packet()
+{
+  if ( ! pgl1) return 0;
+  packetRequested = 1;
+  
+  return pgl1;
+
+}
+
+
+int GL1Manager::getClockSync(const int evtnr, Packet * p)
+{
+  return ClockSync ( evtnr, p);
+}
+
+
+Packet * GL1Manager::fetchGL1Packet( const int evtnr)
+{
+  if (pgl1 && packetRequested == 0)  delete pgl1;
+  pgl1 = 0;
+  packetRequested = 0;
+
+  coutfl << " asking for event " << evtnr + event_delta  << endl;
+  Event *gl1Event = erc->getEvent(evtnr + event_delta);
+
+  if ( !gl1Event) 
+    {
+      return 0;
+    }
+
+  pgl1 = gl1Event->getPacket(14001);
+  if ( ! pgl1)
+    {
+      delete gl1Event;
+      return 0;
+    }
+
+  pgl1->convert();
+
+  delete gl1Event;
+
+  return pgl1;
+}
+
+
+
+int GL1Manager::ClockSync(const int evtnr, Packet * p)
+{
+
+  pgl1 = fetchGL1Packet(evtnr);
+  if ( !pgl1 ) return -1;
+  
+  // if we are getting to the next event. delete what's left of the previous one, if any
+  gl1_clock = pgl1->lValue(0, "BCO"); 
+  long long packet_clock = p->lValue(0, "CLOCK");
+
+  // keep the 4 vectors trimmed at the envisioned size
+  while ( previous_GL1clocks.size() >= history_length)
+    {
+      previous_GL1clocks.pop_front();
+    }
+  while ( previous_packetclocks.size() >= history_length)
+    {
+      previous_packetclocks.pop_front();
+    }
+
+
+  // we will add to the vector in a moment. Remove the oldest element 
+  while ( diff_gl1clocks.size() >= history_length)
+    { 
+      diff_gl1clocks.pop_front();
+    }
+  
+  while ( diff_packetclocks.size() >= history_length)
+    {
+      diff_packetclocks.pop_front();
+    }
+
+
+
+
+  if (previous_GL1clocks.size())  // this starts at the 2nd event
+    {
+      uint32_t d = gl1_clock - previous_GL1clocks.back();
+      diff_gl1clocks.push_back(d);
+    }
+  
+  if (previous_packetclocks.size())
+    {
+      uint32_t d = packet_clock - previous_packetclocks.back();
+      diff_packetclocks.push_back(d);
+    }
+
+
+
+  previous_GL1clocks.push_back(gl1_clock);
+  previous_packetclocks.push_back(packet_clock);
+
+
+  // if we reach the desired size, we declare ourselves done with the init 
+  if  (init_done == 0 && diff_gl1clocks.size() >= history_length)
+    {
+      init_done = 1;
+      event_delta = findDelta();
+      
+      auto xx = previous_GL1clocks.begin() + event_delta;
+      auto yy = previous_packetclocks.begin();
+
+      desireddiff = ( *xx - *yy ) & 0xffffffff;
+      return GL1Manager_INITIALIZING;
+    }
+  if (init_done ==0 ) return GL1Manager_INITIALIZING;
+
+
+  previousdiff = clockdiff;
+  clockdiff = (gl1_clock - packet_clock) & 0xffffffff;
+  
+  if ( desireddiff == clockdiff)
+    {
+
+      eventMatch = 1;
+      return GL1Manager_MATCH;
+    }
+  else
+    {
+      // did we perhaps skip an rcdaq event?
+      
+      Reset();
+      //event_delta--;
+      eventMatch = 0;
+      return GL1Manager_MISMATCH;
+    }
+}
+
+uint32_t GL1Manager::getPacketClockDifference (Packet * p) const
+{
+
+  long long packet_clock = p->lValue(0, "CLOCK");
+
+  uint32_t cd = (gl1_clock - packet_clock) & 0xffffffff;
+  return cd;
+}
+
+
+int GL1Manager::checkPacket (Packet * p) const
+{
+  uint32_t cd = getPacketClockDifference ( p);
+  if ( cd == desireddiff) return 0;
+  return 1;
+}
+
+int GL1Manager::findDelta()
+{
+
+  if ( diff_gl1clocks.size() < history_length) return 2;
+
+
+  // check "packet" against "GL1" first
+
+
+  auto it = std::search(diff_gl1clocks.begin(), diff_gl1clocks.end(), diff_packetclocks.begin(), diff_packetclocks.begin() + diff_packetclocks.size() - max_discrepancy );
+
+  int ret = 0;
+
+  if ( it != diff_gl1clocks.end())
+    {
+
+      ret = std::distance(diff_gl1clocks.begin(), it);
+      return ret;
+
+    }
+  // else
+  //   {
+  //     cout << " no match of packets in GL1 " << endl;
+  //   }
+
+  auto it2 = std::search(diff_packetclocks.begin(), diff_packetclocks.end(), diff_gl1clocks.begin(), diff_gl1clocks.begin() + diff_gl1clocks.size() - max_discrepancy  );
+
+  if ( it2 != diff_packetclocks.end())
+    {
+      ret = -1 * std::distance(diff_packetclocks.begin(), it2);
+    }
+  // else
+  //   {
+  //     cout << " no match of packets in packet " << endl;
+  //   }
+
+  return ret;
+}
+
+
+
+ 
+
+
+
+//   uint32_t clockdiff = getPacketClockDifference ( p);
+//   if ( clockdiff == desireddiff) return 0;
+//   return 1;
+// }
+
+
+
+  
+
+
+
+
+

--- a/onlmonutils/GL1Manager.h
+++ b/onlmonutils/GL1Manager.h
@@ -1,0 +1,83 @@
+#ifndef __GL1MANAGER_H__
+#define __GL1MANAGER_H__
+
+
+#include <iostream>
+#include <string>
+#include <vector>
+#include <deque>
+
+
+enum GL1ManagerReturnCodes
+{
+  GL1Manager_MATCH = 0,
+  GL1Manager_MISMATCH = 1,
+  GL1Manager_INITIALIZING = 2
+};
+
+
+
+
+//#include <Event/eventReceiverClient.h>
+
+class eventReceiverClient;
+class Packet;
+
+
+class GL1Manager
+{
+ public:
+
+  GL1Manager (const char * /*hostname*/, const int /*history*/ = 6, const int /*maxdiscrepancy*/ = 3); // for eventReceiverclient
+  ~GL1Manager();
+
+  void Reset();
+
+  int getClockSync(const int /*evtnr*/, Packet * /*p*/);
+
+  int getDelta () const {return event_delta;};
+  void setDelta (const int d ) {event_delta = d;};
+  void setVerbosity (const int d ) {verbosity = d;};
+
+  int checkPacket (Packet * /*p*/) const;
+  uint32_t getPacketClockDifference (Packet * /*p*/) const;
+
+  Packet * getGL1Packet();
+
+ protected:
+
+  // the generic function
+  int ClockSync(const int evtnr, Packet * p);
+  Packet * fetchGL1Packet(const int /*evtnr*/);
+  int findDelta();
+  
+  Packet *pgl1;
+
+  std::string _hostname;
+
+  int eventMatch;
+  int packetRequested;
+
+  eventReceiverClient *erc;
+  uint32_t desireddiff;
+  uint32_t previousdiff;
+  uint32_t clockdiff;
+  long long gl1_clock;
+
+  unsigned int history_length;
+  int max_discrepancy;
+  int init_done;
+
+  std::deque<long long> previous_GL1clocks;
+  std::deque<uint32_t> previous_packetclocks;
+
+  std::deque<uint32_t> diff_gl1clocks;
+  std::deque<uint32_t> diff_packetclocks;
+
+  int event_delta;
+  int _broken;
+  int verbosity;
+};
+
+#endif
+

--- a/onlmonutils/Makefile.am
+++ b/onlmonutils/Makefile.am
@@ -21,12 +21,14 @@ libonlmonutils_la_LIBADD = \
 pkginclude_HEADERS = \
   runningMean.h \
   pseudoRunningMean.h \
-  fullRunningMean.h
+  fullRunningMean.h \
+  GL1Manager.h	
 
 libonlmonutils_la_SOURCES = \
   runningMean.cc \
   pseudoRunningMean.cc \
-  fullRunningMean.cc
+  fullRunningMean.cc \
+  GL1Manager.cc
 
 noinst_PROGRAMS = \
   testexternals

--- a/subsystems/cemc/CemcMon.cc
+++ b/subsystems/cemc/CemcMon.cc
@@ -19,6 +19,8 @@
 #include <Event/eventReceiverClient.h>
 #include <Event/msg_profile.h>
 
+#include <onlmon/GL1Manager.h>
+
 #include <TH1.h>
 #include <TH2.h>
 #include <TProfile.h>
@@ -45,13 +47,13 @@ const float waveform_hit_threshold = 100;
 
 using namespace std;
 
-CemcMon::CemcMon(const std::string &name)
+CemcMon::CemcMon(const std::string &name, const std::string& gl1_host)
   : OnlMon(name)
   , eventCounter(0)
 {
   // leave ctor fairly empty, its hard to debug if code crashes already
   // during a new CemcMon()
-
+  GL1host = gl1_host;
   return;
 }
 
@@ -67,7 +69,7 @@ CemcMon::~CemcMon()
   }
   delete WaveformProcessingFast;
   delete WaveformProcessingTemp;
-  delete erc;
+  delete gl1mgr;
   return;
 }
 
@@ -199,7 +201,7 @@ int CemcMon::Init()
 
   if (anaGL1)
   {
-    erc = new eventReceiverClient("gl1daq");
+    gl1mgr= new GL1Manager(GL1host.c_str());
   }
 
   return 0;
@@ -220,6 +222,8 @@ int CemcMon::BeginRun(const int /* runno */)
   {
     (*rm_it)->Reset();
   }
+
+  if ( gl1mgr) gl1mgr->Reset();
 
   return 0;
 }
@@ -320,249 +324,244 @@ int CemcMon::process_event(Event *e /* evt */)
   long long int gl1_clock = 0;
   bool have_gl1 = false;
   
-  if (anaGL1)
-  {
-    int evtnr = e->getEvtSequence();
-    Event *gl1Event = erc->getEvent(evtnr);
-    if (gl1Event)
-    {
-      have_gl1 = true;
-      Packet *p = gl1Event->getPacket(14001);
-      h_evtRec->Fill(0.0, 1.0);
-      if (p)
-      {
-        gl1_clock = p->lValue(0, "BCO");
-        uint64_t triggervec = p->lValue(0, "ScaledVector");
-        for (int i = 0; i < 64; i++)
-        {
-          bool trig_decision = ((triggervec & 0x1U) == 0x1U);
-          trig_bools[i] = trig_decision;
-          if (trig_decision)
-          {
-            h1_cemc_trig->Fill(i);
-          }
-          triggervec = (triggervec >> 1U) & 0xffffffffU;
-        }
-        delete p;
-      }
-      delete gl1Event;
-    }
-    else
-    {
-      std::cout << "GL1 event is null" << std::endl;
-      h_evtRec->Fill(0.0, 0.0);
-    }
-    
-    //this is for only process event with the MBD>=1 trigger
-    if(usembdtrig){
-      if(trig_bools.at(10) == 0){
-        fillhist = false;
-      }
-    }
-    
-  }
+  int evtnr = e->getEvtSequence();
 
   // loop over packets which contain a single sector
   eventCounter++;
   int one = 1;
   int zero = 0;
+  int first =1;
+
   for (int packet = packetlow; packet <= packethigh; packet++)
-  {
-    Packet *p = e->getPacket(packet);
-
-    if (p)
     {
-      unsigned int adc_skip_mask = cdbttree->GetIntValue(packet, "adcskipmask");
-      h1_packet_number->Fill(packet);
-      h1_packet_length->SetBinContent(packet - 6000, h1_packet_length->GetBinContent(packet - 6000) + p->getLength());
+      Packet *p = e->getPacket(packet);
 
-      h1_packet_event->SetBinContent(packet - 6000, p->lValue(0, "CLOCK"));
+      if (p)
+	{
+	  if (gl1mgr && first)
+	    {
+	      first = 0;
+	      int s = gl1mgr->getClockSync(evtnr,p );
+	      if ( s ==0 )
+		{
+		  h_evtRec->Fill(0.0, 1.0);
+		  have_gl1 =true;
+		  Packet *gl1p = gl1mgr->getGL1Packet();
+		  if ( gl1p)
+		    {
+		      //gl1p->identify();
+		      gl1_clock = gl1p->lValue(0, "BCO");
+		      uint64_t triggervec = gl1p->lValue(0, "ScaledVector");
+		      for (int i = 0; i < 64; i++)
+			{
+			  bool trig_decision = ((triggervec & 0x1U) == 0x1U);
+			  trig_bools[i] = trig_decision;
+			  if (trig_decision)
+			    {
+			      h1_cemc_trig->Fill(i);
+			    }
+			  triggervec = (triggervec >> 1U) & 0xffffffffU;
+			}
+		      delete gl1p;
+		    }
+		}
+	      else
+		{
+		  cout << " getClockSync status " << s << endl;
+		}
+	    }
+	  
+	  unsigned int adc_skip_mask = cdbttree->GetIntValue(packet, "adcskipmask");
+	  h1_packet_number->Fill(packet);
+	  h1_packet_length->SetBinContent(packet - 6000, h1_packet_length->GetBinContent(packet - 6000) + p->getLength());
+      
+	  h1_packet_event->SetBinContent(packet - 6000, p->lValue(0, "CLOCK"));
+      
+	  if (have_gl1)
+	    {
+	      long long int p_clock = p->lValue(0, "CLOCK");
+	      long long int diff = (p_clock - gl1_clock) % 65536;
+	      h2_caloPack_gl1_clock_diff->Fill(packet, diff);
+	    }
+	  int nChannels = p->iValue(0, "CHANNELS");
+	  int skiped_channel = 0;
+	  if (nChannels > m_nChannels)
+	    {
+	      return -1;  // packet is corrupted, reports too many channels
+	    }
+	  //print packet and nCHannels
+	  for (int c = 0; c < nChannels; c++)
+	    {
+	      h1_packet_chans->Fill(packet);
+	      // skip masked ADC board 
+	      if(c % 64 ==0){
+		unsigned int adcboard = (unsigned int) c / 64;
+		if ((adc_skip_mask >> adcboard) & 0x1U){
+	      
+		  towerNumber += 64;
+		  skiped_channel += 64;
+		}
+	      }
+	  
+	  
+	      towerNumber++;
+	      // channel mapping
+	      unsigned int key = TowerInfoDefs::encode_emcal(towerNumber - 1);
+	      unsigned int phi_bin = TowerInfoDefs::getCaloTowerPhiBin(key);
+	      unsigned int eta_bin = TowerInfoDefs::getCaloTowerEtaBin(key);
+	  
+	      // Commented until potential replacement by TProfile3D
+	      // for (int s = 0; s < p->iValue(0, "SAMPLES"); s++)
+	      //   {
+	      //     h2_waveform[phi_bin][eta_bin]->Fill(s,p->iValue(s,c));//for the moment only for good packet and with signal (potentially also bad packet later, not sure for zero suppressed)
+	      //   }
+	  
+	      ////Uninstrumented area
+	      // if ((packet==6019)||(packet==6073)){
+	      //   if(c>63&&c<128) continue;
+	      // }
+	      // if (packet==6030){
+	      //   if(c>127)continue;
+	      // }
+	  
+	      std::vector<float> resultFast = anaWaveformFast(p, c);  // fast waveform fitting
+	      float signalFast = resultFast.at(0);
+	      float timeFast = resultFast.at(1);
+	      float pedestalFast = resultFast.at(2);
+	  
+	      //________________________________for this part we only want to deal with the MBD>=1 trigger
+	      if (fillhist)
+		{
+		  if (p->iValue(c, "SUPPRESSED"))
+		    {
+		      p2_zsFrac_etaphi->Fill(eta_bin, phi_bin, 0);
+		    }
+		  else
+		    {
+		      p2_zsFrac_etaphi->Fill(eta_bin, phi_bin, 1);
+		    }
+	      
+		  h1_waveform_pedestal->Fill(pedestalFast);
+	      
+		  int bin = h2_cemc_mean->FindBin(eta_bin + 0.5, phi_bin + 0.5);
+	      
+		  rm_vector_twr[towerNumber - 1]->Add(&signalFast);
+	      
+	      
+	      
+	      
+		  if (signalFast > hit_threshold)
+		    {
+		      rm_vector_twrhits[towerNumber - 1]->Add(&one);
+		      h2_cemc_hits->SetBinContent(bin, h2_cemc_hits->GetBinContent(bin) + 1);
+		    }
+		  else
+		    {
+		      rm_vector_twrhits[towerNumber - 1]->Add(&zero);
+		    }
+		  h2_cemc_mean->SetBinContent(bin, h2_cemc_mean->GetBinContent(bin) + signalFast);
+		  h2_cemc_rm->SetBinContent(bin, rm_vector_twr[towerNumber - 1]->getMean(0));
+		  h2_cemc_rmhits->SetBinContent(bin, rm_vector_twrhits[towerNumber - 1]->getMean(0));
+		  h1_cemc_adc->Fill(signalFast);
+		}
+	      //_______________________________________________________end of MBD trigger requirement
+	      if (signalFast > waveform_hit_threshold)
+		{
+		  // check if hot tower and skip it
+		  if (!isHottower(packet, c))
+		    {
+		      for (int s = 0; s < p->iValue(0, "SAMPLES"); s++)
+			{
+			  h2_waveform_twrAvg->Fill(s, p->iValue(s, c) - pedestalFast);
+			}
+		      h1_waveform_time->Fill(timeFast);
+		    }
+		}
+	      if (signalFast > hit_threshold)
+		{
+		  // h2_cemc_hits->SetBinContent(bin, h2_cemc_hits->GetBinContent(bin) + signalFast);
+		  if (have_gl1)
+		    {
+		      for (int itrig = 0; itrig < 64; itrig++)
+			{
+			  if (trig_bools[itrig])
+			    {
+			      h2_cemc_hits_trig[itrig]->Fill(eta_bin + 0.5, phi_bin + 0.5);
+			    }
+			}
+		    }
+		}
+	  
+	      /*
+		if (!((eventCounter - 2) % 10000))
+		{
+		std::vector<float> resultTemp = anaWaveformTemp(p, c);  // template waveform fitting
+		float signalTemp = resultTemp.at(0);
+		float timeTemp = resultTemp.at(1);
+		float pedestalTemp = resultTemp.at(2);
+		h1_cemc_fitting_sigDiff->Fill(signalFast / signalTemp);
+		h1_cemc_fitting_pedDiff->Fill(pedestalFast / pedestalTemp);
+		h1_cemc_fitting_timeDiff->Fill(timeFast - timeTemp - 6);
+		}
+	      */
+	  
+	    }  // channel loop
+	  if ((nChannels + skiped_channel) < m_nChannels)
+	    {
+	  
+	      // still need to correctly set bad channels to zero.
+	      for (int channel = 0; channel < m_nChannels - (nChannels + skiped_channel); channel++)
+		{
+		  towerNumber++;
+	      
+		  unsigned int key = TowerInfoDefs::encode_emcal(towerNumber - 1);
+		  unsigned int phi_bin = TowerInfoDefs::getCaloTowerPhiBin(key);
+		  unsigned int eta_bin = TowerInfoDefs::getCaloTowerEtaBin(key);
+	      
+		  int sectorNumber = phi_bin / 8 + 1;
 
-      if (have_gl1)
-      {
-        long long int p_clock = p->lValue(0, "CLOCK");
-        long long int diff = (p_clock - gl1_clock) % 65536;
-        h2_caloPack_gl1_clock_diff->Fill(packet, diff);
-      }
-      int nChannels = p->iValue(0, "CHANNELS");
-      int skiped_channel = 0;
-      if (nChannels > m_nChannels)
-      {
-        return -1;  // packet is corrupted, reports too many channels
-      }
-      //print packet and nCHannels
-      for (int c = 0; c < nChannels; c++)
-      {
-        h1_packet_chans->Fill(packet);
-        // skip masked ADC board 
-        if(c % 64 ==0){
-          unsigned int adcboard = (unsigned int) c / 64;
-          if ((adc_skip_mask >> adcboard) & 0x1U){
-            
-             towerNumber += 64;
-             skiped_channel += 64;
-          }
-        }
+		  int bin = h2_cemc_mean->FindBin(eta_bin + 0.5, phi_bin + 0.5);
 
-        
-        towerNumber++;
-        // channel mapping
-        unsigned int key = TowerInfoDefs::encode_emcal(towerNumber - 1);
-        unsigned int phi_bin = TowerInfoDefs::getCaloTowerPhiBin(key);
-        unsigned int eta_bin = TowerInfoDefs::getCaloTowerEtaBin(key);
+		  sectorAvg[sectorNumber - 1] += 0.;
 
-        // Commented until potential replacement by TProfile3D
-        // for (int s = 0; s < p->iValue(0, "SAMPLES"); s++)
-        //   {
-        //     h2_waveform[phi_bin][eta_bin]->Fill(s,p->iValue(s,c));//for the moment only for good packet and with signal (potentially also bad packet later, not sure for zero suppressed)
-        //   }
+		  float signalFast = 0.0;
 
-        ////Uninstrumented area
-        // if ((packet==6019)||(packet==6073)){
-        //   if(c>63&&c<128) continue;
-        // }
-        // if (packet==6030){
-        //   if(c>127)continue;
-        // }
+		  rm_vector_twr[towerNumber - 1]->Add(&signalFast);
 
-        std::vector<float> resultFast = anaWaveformFast(p, c);  // fast waveform fitting
-        float signalFast = resultFast.at(0);
-        float timeFast = resultFast.at(1);
-        float pedestalFast = resultFast.at(2);
+		  h2_cemc_rm->SetBinContent(bin, rm_vector_twr[towerNumber - 1]->getMean(0));
+		  h2_cemc_rmhits->SetBinContent(bin, rm_vector_twrhits[towerNumber - 1]->getMean(0));
 
-        //________________________________for this part we only want to deal with the MBD>=1 trigger
-        if (fillhist)
-        {
-          if (p->iValue(c, "SUPPRESSED"))
-          {
-            p2_zsFrac_etaphi->Fill(eta_bin, phi_bin, 0);
-          }
-          else
-          {
-            p2_zsFrac_etaphi->Fill(eta_bin, phi_bin, 1);
-          }
+		  h2_cemc_mean->SetBinContent(bin, h2_cemc_mean->GetBinContent(bin));
+		}
+	    }
+	  delete p;
+	}     // if packet good
+      else  // packet is corrupted, treat all channels as zero suppressed
+	{
+	  for (int channel = 0; channel < m_nChannels; channel++)
+	    {
+	      towerNumber++;
+	      unsigned int key = TowerInfoDefs::encode_emcal(towerNumber - 1);
+	      unsigned int phi_bin = TowerInfoDefs::getCaloTowerPhiBin(key);
+	      unsigned int eta_bin = TowerInfoDefs::getCaloTowerEtaBin(key);
 
-          h1_waveform_pedestal->Fill(pedestalFast);
+	      int sectorNumber = phi_bin / 8 + 1;
 
-          int bin = h2_cemc_mean->FindBin(eta_bin + 0.5, phi_bin + 0.5);
+	      int bin = h2_cemc_mean->FindBin(eta_bin + 0.5, phi_bin + 0.5);
 
-          rm_vector_twr[towerNumber - 1]->Add(&signalFast);
+	      sectorAvg[sectorNumber - 1] += 0;
 
-         
+	      float signalFast = 0;
 
-         
-          if (signalFast > hit_threshold)
-          {
-            rm_vector_twrhits[towerNumber - 1]->Add(&one);
-            h2_cemc_hits->SetBinContent(bin, h2_cemc_hits->GetBinContent(bin) + 1);
-          }
-          else
-          {
-            rm_vector_twrhits[towerNumber - 1]->Add(&zero);
-          }
-          h2_cemc_mean->SetBinContent(bin, h2_cemc_mean->GetBinContent(bin) + signalFast);
-          h2_cemc_rm->SetBinContent(bin, rm_vector_twr[towerNumber - 1]->getMean(0));
-          h2_cemc_rmhits->SetBinContent(bin, rm_vector_twrhits[towerNumber - 1]->getMean(0));
-          h1_cemc_adc->Fill(signalFast);
-        }
-        //_______________________________________________________end of MBD trigger requirement
-        if (signalFast > waveform_hit_threshold)
-        {
-          // check if hot tower and skip it
-          if (!isHottower(packet, c))
-          {
-            for (int s = 0; s < p->iValue(0, "SAMPLES"); s++)
-            {
-              h2_waveform_twrAvg->Fill(s, p->iValue(s, c) - pedestalFast);
-            }
-            h1_waveform_time->Fill(timeFast);
-          }
-        }
-        if (signalFast > hit_threshold)
-        {
-          // h2_cemc_hits->SetBinContent(bin, h2_cemc_hits->GetBinContent(bin) + signalFast);
-          if (have_gl1)
-          {
-            for (int itrig = 0; itrig < 64; itrig++)
-            {
-              if (trig_bools[itrig])
-              {
-                h2_cemc_hits_trig[itrig]->Fill(eta_bin + 0.5, phi_bin + 0.5);
-              }
-            }
-          }
-        }
+	      rm_vector_twr[towerNumber - 1]->Add(&signalFast);
 
-        /*
-        if (!((eventCounter - 2) % 10000))
-        {
-          std::vector<float> resultTemp = anaWaveformTemp(p, c);  // template waveform fitting
-          float signalTemp = resultTemp.at(0);
-          float timeTemp = resultTemp.at(1);
-          float pedestalTemp = resultTemp.at(2);
-          h1_cemc_fitting_sigDiff->Fill(signalFast / signalTemp);
-          h1_cemc_fitting_pedDiff->Fill(pedestalFast / pedestalTemp);
-          h1_cemc_fitting_timeDiff->Fill(timeFast - timeTemp - 6);
-        }
-        */
+	      h2_cemc_rm->SetBinContent(bin, rm_vector_twr[towerNumber - 1]->getMean(0));
+	      h2_cemc_rmhits->SetBinContent(bin, rm_vector_twrhits[towerNumber - 1]->getMean(0));
 
-      }  // channel loop
-      if ((nChannels + skiped_channel) < m_nChannels)
-      {
-        
-        // still need to correctly set bad channels to zero.
-        for (int channel = 0; channel < m_nChannels - (nChannels + skiped_channel); channel++)
-        {
-          towerNumber++;
-
-          unsigned int key = TowerInfoDefs::encode_emcal(towerNumber - 1);
-          unsigned int phi_bin = TowerInfoDefs::getCaloTowerPhiBin(key);
-          unsigned int eta_bin = TowerInfoDefs::getCaloTowerEtaBin(key);
-
-          int sectorNumber = phi_bin / 8 + 1;
-
-          int bin = h2_cemc_mean->FindBin(eta_bin + 0.5, phi_bin + 0.5);
-
-          sectorAvg[sectorNumber - 1] += 0.;
-
-          float signalFast = 0.0;
-
-          rm_vector_twr[towerNumber - 1]->Add(&signalFast);
-
-          h2_cemc_rm->SetBinContent(bin, rm_vector_twr[towerNumber - 1]->getMean(0));
-          h2_cemc_rmhits->SetBinContent(bin, rm_vector_twrhits[towerNumber - 1]->getMean(0));
-
-          h2_cemc_mean->SetBinContent(bin, h2_cemc_mean->GetBinContent(bin));
-        }
-      }
-      delete p;
-    }     // if packet good
-    else  // packet is corrupted, treat all channels as zero suppressed
-    {
-      for (int channel = 0; channel < m_nChannels; channel++)
-      {
-        towerNumber++;
-        unsigned int key = TowerInfoDefs::encode_emcal(towerNumber - 1);
-        unsigned int phi_bin = TowerInfoDefs::getCaloTowerPhiBin(key);
-        unsigned int eta_bin = TowerInfoDefs::getCaloTowerEtaBin(key);
-
-        int sectorNumber = phi_bin / 8 + 1;
-
-        int bin = h2_cemc_mean->FindBin(eta_bin + 0.5, phi_bin + 0.5);
-
-        sectorAvg[sectorNumber - 1] += 0;
-
-        float signalFast = 0;
-
-        rm_vector_twr[towerNumber - 1]->Add(&signalFast);
-
-        h2_cemc_rm->SetBinContent(bin, rm_vector_twr[towerNumber - 1]->getMean(0));
-        h2_cemc_rmhits->SetBinContent(bin, rm_vector_twrhits[towerNumber - 1]->getMean(0));
-
-        h2_cemc_mean->SetBinContent(bin, h2_cemc_mean->GetBinContent(bin));
-      }
-    }  // zero filling bad packets
-  }    // packet loop
+	      h2_cemc_mean->SetBinContent(bin, h2_cemc_mean->GetBinContent(bin));
+	    }
+	}  // zero filling bad packets
+    }    // packet loop
 
   h1_event->Fill(0);
 

--- a/subsystems/cemc/CemcMon.h
+++ b/subsystems/cemc/CemcMon.h
@@ -17,11 +17,12 @@ class Packet;
 class runningMean;
 class eventReceiverClient;
 class CDBTTree;
+class GL1Manager;
 
 class CemcMon : public OnlMon
 {
  public:
-  explicit CemcMon(const std::string& name);
+  explicit CemcMon(const std::string& name, const std::string& gl1_host = "gl1daq");
   virtual ~CemcMon();
 
   int process_event(Event* evt);
@@ -38,6 +39,8 @@ class CemcMon : public OnlMon
   std::vector<float> getSignal(Packet* p, const int channel);
   std::vector<float> anaWaveformFast(Packet* p, const int channel);
   std::vector<float> anaWaveformTemp(Packet* p, const int channel);
+
+  std::string GL1host;
 
   int idummy = 0;
   TH1* h1_cemc_adc = nullptr;
@@ -82,7 +85,8 @@ class CemcMon : public OnlMon
 
   std::string runtypestr = "Unknown";
 
-  eventReceiverClient* erc = {nullptr};
+  //eventReceiverClient* erc = {nullptr};
+  GL1Manager *gl1mgr =  {nullptr};
   bool anaGL1 = true;
   bool usembdtrig = true;
 

--- a/subsystems/daq/DaqMon.cc
+++ b/subsystems/daq/DaqMon.cc
@@ -16,6 +16,9 @@
 #include <Event/eventReceiverClient.h>
 #include <Event/msg_profile.h>
 
+#include <onlmon/GL1Manager.h>
+
+
 #include <TH1.h>
 #include <TH2.h>
 #include <TRandom.h>
@@ -33,14 +36,17 @@ enum
   FILLMESSAGE = 2
 };
 
-DaqMon::DaqMon(const std::string &name)
+DaqMon::DaqMon(const std::string &name, const std::string& gl1_host)
   : OnlMon(name)
 {
+  GL1host = gl1_host;
+
   return;
 }
 
 DaqMon::~DaqMon()
 {
+  delete gl1mgr;
   return;
 }
 
@@ -84,7 +90,8 @@ int DaqMon::Init()
   se->registerHisto(this, h_gl1_clock_diff);  
   se->registerHisto(this, h_fem_match); 
   Reset();
-  erc = new eventReceiverClient("gl1daq");
+  //erc = new eventReceiverClient("gl1daq");
+  gl1mgr= new GL1Manager(GL1host.c_str());
 
 
   std::string mappingfile = std::string(daqcalib) + "/" + "packetid_seb_mapping.txt";
@@ -95,6 +102,11 @@ int DaqMon::Init()
 
 int DaqMon::BeginRun(const int /* runno */)
 {
+
+  gl1mgr->Reset();
+  // we need to reset the previousdiff values. 200 is hard-coded in the header
+  for (int i = 0; i < 200; i++) previousdiff[i] = 0;
+
   return 0;
 }
 
@@ -113,53 +125,68 @@ int DaqMon::process_event(Event *e /* evt */)
 
   evtcnt++;
   long long int gl1_clock = 0;
-  Event *gl1Event = erc->getEvent(evtnr);
 
-  if (!gl1Event)
-  {
-    return 0;
-  }
-  Packet *pgl1 = gl1Event->getPacket(14001);
-  if (pgl1)
-  {
-    gl1_clock = pgl1->lValue(0, "BCO");
-    delete pgl1;
-  }
-  delete gl1Event;
 
   Packet *plist[100];
   int npackets = e->getPacketList(plist,100);
+
+  int gl1status = -3; // outside of the range for getClockSync
+
+  if ( plist[0])
+    {
+      gl1status = gl1mgr->getClockSync(e->getEvtSequence(), plist[0] );
+
+      Packet *pgl1 = gl1mgr->getGL1Packet();
+      if (pgl1)
+	{
+	  gl1_clock = pgl1->lValue(0, "BCO");
+	  delete pgl1;
+	}
+    }
+
   bool mismatchfem = true;
   int femevtref = 0;
   int femclkref = 0;
   int sebid = 0;
-  for (int ipacket = 0; ipacket < npackets; ipacket++) {
-      Packet * p = plist[ipacket];
-      if (p) {
-          int pnum = p->getIdentifier();
-          int calomapid = CaloPacketMap(pnum);
-          long int packet_clock = p->lValue(0,"CLOCK");
-          clockdiff[ipacket] = gl1_clock  - packet_clock;
-          int fdiff = (clockdiff[ipacket] != previousdiff[ipacket]) ? 0 : 1;
-          previousdiff[ipacket] = clockdiff[ipacket];
 
-          int nADCs = p->iValue(0,"NRMODULES");
-          for(int iadc = 0; iadc<nADCs ; iadc++){
+  if ( gl1status == 0) // ignore all events with gl1 issues
+    {
+      { 
+	for (int ipacket = 0; ipacket < npackets; ipacket++) {
+	  Packet * p = plist[ipacket];
+	  if (p) {
+	    int pnum = p->getIdentifier();
+	    int calomapid = CaloPacketMap(pnum);
+	    long int packet_clock = p->lValue(0,"CLOCK");
+	    clockdiff[ipacket] = gl1_clock  - packet_clock;
+	    int fdiff = (clockdiff[ipacket] != previousdiff[ipacket]) ? 0 : 1;
+
+	    // this check will tell us if we have the first event where the previous diff is still 0
+	    if( previousdiff[ipacket] ) h_gl1_clock_diff->Fill(calomapid,fdiff);
+
+	    previousdiff[ipacket] = clockdiff[ipacket];
+	    
+	    int nADCs = p->iValue(0,"NRMODULES");
+	    for(int iadc = 0; iadc<nADCs ; iadc++){
               if(ipacket==0 && iadc==0){ femevtref = p->iValue(iadc,"FEMEVTNR"); femclkref = p->iValue(iadc,"FEMCLOCK");}
-
+	      
               if(femevtref !=  p->iValue(iadc,"FEMEVTNR") && fabs(femclkref - p->iValue(0,"FEMCLOCK"))>2)
-              {
+		{
                   mismatchfem = false;
                   sebid = getmapping(pnum);
-              }
+		}
+	    }
+          
           }
-          
-          if(evtcnt>3) h_gl1_clock_diff->Fill(calomapid,fdiff);
-          
+	}
       }
-      delete p;
-  }
-  if(mismatchfem == false) h_fem_match->Fill(sebid,1);
+      if(mismatchfem == false) h_fem_match->Fill(sebid,1);
+    }
+
+  for (int ipacket = 0; ipacket < npackets; ipacket++) 
+    {
+      delete plist[ipacket];
+    }
 
   return 0;
 }

--- a/subsystems/daq/DaqMon.h
+++ b/subsystems/daq/DaqMon.h
@@ -14,13 +14,13 @@ class Event;
 class TH1;
 class TH2;
 class runningMean;
-class eventReceiverClient;
+class GL1Manager;
 class Packet;
 
 class DaqMon : public OnlMon
 {
  public:
-  DaqMon(const std::string &name);
+  DaqMon(const std::string &name, const std::string& gl1_host = "gl1daq");
   virtual ~DaqMon();
 
   int process_event(Event *evt);
@@ -72,7 +72,10 @@ class DaqMon : public OnlMon
   //TH1D* h_unlock_hist = nullptr;
   //TH2* h_unlock_clock = nullptr;
 
-  eventReceiverClient *erc = {nullptr};
+  //  eventReceiverClient *erc = {nullptr};
+  GL1Manager *gl1mgr =  {nullptr};
+  std::string GL1host;
+
 };
 
 void DaqMon::loadpacketMapping(const std::string& filename) {

--- a/subsystems/daq/Makefile.am
+++ b/subsystems/daq/Makefile.am
@@ -18,6 +18,7 @@ libonldaqmon_server_la_LIBADD = \
   -L$(libdir) \
   -L$(ONLINE_MAIN)/lib \
   -lonlmonserver \
+  -lonlmonutils \
   -lonlmondb
 
 libonldaqmon_client_la_LIBADD = \


### PR DESCRIPTION
- I added the GL1Manager class to the framework (onlmonutils library)
- modified daq and cemc to make use of the new framework
- upgraded both systems' constructor to allow for a different eventServer host (for testing at the SDCC)
- added two macros (run_daq_server_at_SDCC.C and run_cemc_server_at_SDCC.C) for easy testing at the SDCC, rather than in 1008.