### PR TITLE
Adding in protections for parity errors in plotting + parity error rate

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -60,6 +60,7 @@ void tpcDrawInit(const int online = 0)
 
     cl->registerHisto("sample_size_hist",servername);
     cl->registerHisto("Check_Sum_Error",servername);
+    cl->registerHisto("Parity_Error",servername);
     cl->registerHisto("Check_Sums",servername);
     cl->registerHisto("Stuck_Channels",servername);
     cl->registerHisto("Channels_in_Packet",servername);

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -103,6 +103,7 @@ class TpcMon : public OnlMon
 
   TH1 *sample_size_hist = nullptr;
   TH1 *Check_Sum_Error = nullptr;
+  TH1 *Parity_Error = nullptr;
   TH1 *Check_Sums = nullptr;
   TH1 *Stuck_Channels = nullptr;
   TH1 *Channels_in_Packet = nullptr;

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -30,6 +30,7 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCSampleSize(const std::string &what = "ALL");
   int DrawTPCStuckChannels(const std::string &what = "ALL");
   int DrawTPCCheckSum(const std::string &what = "ALL");
+  int DrawTPCParity(const std::string &what = "ALL");
   int DrawTPCChansinPacketNS(const std::string &what = "ALL");
   int DrawTPCChansinPacketSS(const std::string &what = "ALL");
   int DrawTPCChansperLVL1_NS(const std::string &what = "ALL");
@@ -61,8 +62,8 @@ class TpcMonDraw : public OnlMonDraw
   int DrawServerStats();
   time_t getTime();
   
-  TCanvas *TC[33] = {nullptr};
-  TPad *transparent[33] = {nullptr};
+  TCanvas *TC[34] = {nullptr};
+  TPad *transparent[34] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
subystems/tpc/TpcMon.h
subystems/tpc/TpcMon.cc
subystems/tpc/TpcMonDraw.h
subystems/tpc/TpcMonDraw.cc

**Changes:**

TpcMon.cc - L912, 1068, 1080, adding protections against parity errors for plotting. In general added 24 panel plot for parity error rate which is similar to that of the checksumerror rate.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
