### PR TITLE
Update ZdcMonDraw.cc-- SMD ADC canvas title

### DIFF
--- a/subsystems/zdc/ZdcMonDraw.cc
+++ b/subsystems/zdc/ZdcMonDraw.cc
@@ -2083,8 +2083,8 @@ int ZdcMonDraw::MakeHtml(const std::string &what)
   int icnt = 0;
   std::set <int> expert_indices; // these canvases end up under expert
   expert_indices.insert(2);
-  expert_indices.insert(4);
-  expert_indices.insert(5);
+  // expert_indices.insert(4);
+  // expert_indices.insert(5);
 
   for (TCanvas* canvas : TC)
   {


### PR DESCRIPTION
remove "expert" in SMD ADC canvas title