### PR TITLE
added gl1badflag that bypasses triggervector if we miss most gl1packets

### DIFF
--- a/macros/run_Poms.C
+++ b/macros/run_Poms.C
@@ -29,6 +29,7 @@ void StartPoms()
   subsys->AddAction("bbcDraw(\"SECOND\")", "MBD Timing Monitor");
   subsys->AddAction("bbcDraw(\"THIRD\")", "MBD Triggered Monitor");
   subsys->AddAction("bbcDraw(\"MBD2MCR\")", "MBD TOGGLE VTX TO MCR");
+  subsys->AddAction("bbcDraw(\"BADGL1\")", "MBD TOGGLE IGNORE GL1 MISS");
   subsys->AddAction(new SubSystemActionSavePlot(subsys));
   pmf->RegisterSubSystem(subsys);
 

--- a/subsystems/bbc/BbcMon.h
+++ b/subsystems/bbc/BbcMon.h
@@ -58,6 +58,7 @@ class BbcMon : public OnlMon
   uint64_t emcalmbd{0};       // all emcal triggers, with bbc
   uint64_t hcalmbd{0};        // all hcal triggers, with bbc
   eventReceiverClient *erc{nullptr};
+  //GL1Manager *gl1mgr{nullptr};
   RunDBodbc *rdb{nullptr};
 
   int evtcnt{0};
@@ -74,6 +75,12 @@ class BbcMon : public OnlMon
   int GetFillNumber();
   int GetSendFlag();
   int UpdateSendFlag(const int flag);
+
+  // kludge to work around situations when gl1 events are being received
+  int gl1badflag{0};   // 0 = normal, 1 = gl1 bad, accept all events
+  std::string gl1badflagfname;
+  int GetGL1BadFlag();
+  int UpdateGL1BadFlag(const int flag);
 
   TH1 *bbc_trigs{nullptr};
   TH2 *bbc_adc{nullptr};

--- a/subsystems/bbc/BbcMonDraw.cc
+++ b/subsystems/bbc/BbcMonDraw.cc
@@ -284,6 +284,41 @@ int BbcMonDraw::GetSendFlag()
   return sendflag;
 }
 
+int BbcMonDraw::UpdateGL1BadFlag(const int flag)
+{
+  gl1badflag = flag;
+  std::ofstream gl1badflagfile( gl1badflagfname );
+  if ( gl1badflagfile.is_open() )
+  {
+    gl1badflagfile << gl1badflag << std::endl;
+  }
+  else
+  {
+    std::cout << "unable to open file " << gl1badflagfname << std::endl;
+    return 0;
+  }
+  gl1badflagfile.close();
+  return 1;
+}
+
+int BbcMonDraw::GetGL1BadFlag()
+{
+  std::ifstream gl1badflagfile( gl1badflagfname );
+  if ( gl1badflagfile.is_open() )
+  {
+    gl1badflagfile >> gl1badflag;
+  }
+  else
+  {
+    std::cout << "unable to open file " << gl1badflagfname << std::endl;
+    gl1badflag = 0;
+  }
+  gl1badflagfile.close();
+
+  return gl1badflag;
+}
+
+
 int BbcMonDraw::Init()
 {
   PRINT_DEBUG("In BbcMonDraw::Init()");
@@ -972,46 +1007,64 @@ int BbcMonDraw::Draw(const std::string &what)
 
   //
   if ( what == "MBD2MCR" )
-    {
-      if (!gROOT->FindObject("BbcVertexSend"))
+  {
+    if (!gROOT->FindObject("BbcVertexSend"))
 	{
 	  MakeCanvas("BbcVertexSend");
 	}
-      TC[4]->Clear("D");
-      TC[4]->SetEditable(true);
-      transparent[4]->cd();
+    TC[4]->Clear("D");
+    TC[4]->SetEditable(true);
+    transparent[4]->cd();
 
-      TText PrintRun;
-      PrintRun.SetTextFont(62);
-      PrintRun.SetNDC();          // set to normalized coordinates
-      PrintRun.SetTextAlign(23);  // center/top alignment
-      PrintRun.SetTextSize(0.04);
-      PrintRun.SetTextColor(1);
+    TText PrintRun;
+    PrintRun.SetTextFont(62);
+    PrintRun.SetNDC();          // set to normalized coordinates
+    PrintRun.SetTextAlign(23);  // center/top alignment
+    PrintRun.SetTextSize(0.04);
+    PrintRun.SetTextColor(1);
 
-      GetSendFlag();
-      if ( sendflag==0 )
-	{
-	  UpdateSendFlag( 1 );
-	  PrintRun.DrawText(0.5, 0.5, "MBD: NOW Sending vertex to MCR");
-	  std::cout << "MBD: NOW Sending vertex to MCR" << std::endl;
-	}
-      else if ( sendflag==1 )
-	{
-	  UpdateSendFlag( 0 );
-	  PrintRun.DrawText(0.5, 0.5, "MBD: STOP sending vertex to MCR");
-	  std::cout << "MBD: STOP sending vertex to MCR" << std::endl;
-	}
-      else
-	{
-	  UpdateSendFlag( 0 );
-	  PrintRun.DrawText(0.5, 0.5, "MBD: something wrong with sendflag, setting to 0");
-	  std::cout << "MBD: something wrong with sendflag, setting to 0" << std::endl;
-	}
-      TC[4]->Update();
-      TC[4]->Show();
-      TC[4]->SetEditable(false);
-      return 0;
+    GetSendFlag();
+    if ( sendflag==0 )
+    {
+      UpdateSendFlag( 1 );
+      PrintRun.DrawText(0.5, 0.5, "MBD: NOW Sending vertex to MCR");
+      std::cout << "MBD: NOW Sending vertex to MCR" << std::endl;
     }
+    else if ( sendflag==1 )
+    {
+      UpdateSendFlag( 0 );
+      PrintRun.DrawText(0.5, 0.5, "MBD: STOP sending vertex to MCR");
+      std::cout << "MBD: STOP sending vertex to MCR" << std::endl;
+    }
+    else
+    {
+      UpdateSendFlag( 0 );
+      PrintRun.DrawText(0.5, 0.5, "MBD: something wrong with sendflag, setting to 0");
+      std::cout << "MBD: something wrong with sendflag, setting to 0" << std::endl;
+    }
+    TC[4]->Update();
+    TC[4]->Show();
+    TC[4]->SetEditable(false);
+    return 0;
+  }
+
+  if ( what == "BADGL1" )
+  {
+    GetGL1BadFlag();
+    if ( gl1badflag==0 )
+    {
+      UpdateGL1BadFlag( 1 );
+    }
+    else if ( gl1badflag==1 )
+    {
+      UpdateGL1BadFlag( 0 );
+    }
+    else
+    {
+      UpdateGL1BadFlag( 0 );
+    }
+    return 0;
+  }
 
   ClearWarning();
 

--- a/subsystems/bbc/BbcMonDraw.h
+++ b/subsystems/bbc/BbcMonDraw.h
@@ -60,6 +60,12 @@ class BbcMonDraw : public OnlMonDraw
   int GetSendFlag();
   int UpdateSendFlag(const int flag);
 
+  // bad gl1 variables
+  int gl1badflag{0};      // 0 = normal, 1 = gl1bad
+  std::string gl1badflagfname;
+  int GetGL1BadFlag();
+  int UpdateGL1BadFlag(const int flag);
+
   TCanvas *TC[nCANVAS] = {nullptr};
   TPad *transparent[nCANVAS] = {nullptr};
 


### PR DESCRIPTION
If the gl1badflag is set, then we fill almost every histogram even if the triggervectors are zero.  The minbias wide z-vertex distribution still requires the gl1 scaled trigger, since otherwise this gets too biased
