### PR TITLE
(INTT) Changed logic of BCO counter to reduce errors

### DIFF
--- a/subsystems/intt/InttMon.cc
+++ b/subsystems/intt/InttMon.cc
@@ -187,13 +187,13 @@ int InttMon::process_event(Event *evt)
   //   std::cout << "decoded " << m_unique_bco_count + m_unique_bcos.size() - m_logged_bcos << std::endl;
   // }
 
-  if(!((int)(EvtHist->GetBinContent(1)) % m_evt_per_cout))
-  {
-    std::cout << std::hex;
-    std::cout << "last flushed: 0x" << m_last_flushed_bco << std::endl;
-    std::cout << "most recent:  0x" << m_most_recent_bco << std::endl;
-    std::cout << std::dec;
-  }
+  // if(!((int)(EvtHist->GetBinContent(1)) % m_evt_per_cout))
+  // {
+  //   std::cout << std::hex;
+  //   std::cout << "last flushed: 0x" << m_last_flushed_bco << std::endl;
+  //   std::cout << "most recent:  0x" << m_most_recent_bco << std::endl;
+  //   std::cout << std::dec;
+  // }
 
 
   return 0;

--- a/subsystems/intt/InttMon.cc
+++ b/subsystems/intt/InttMon.cc
@@ -124,18 +124,29 @@ int InttMon::process_event(Event *evt)
   }
 
   // Go through our list of unique BCOs and "flush" them into a counter
-  std::set<unsigned long long, bco_comparator_s>::const_iterator bco_itr = m_unique_bcos.begin();
-  for(bco_itr = m_unique_bcos.begin(); bco_itr != m_unique_bcos.end(); ++bco_itr)
+  if(100 < m_unique_bcos.size())
   {
-    if((m_most_recent_bco == std::numeric_limits<unsigned long long>::max()) || m_bco_less(m_most_recent_bco - m_MAX_BCO_DIFF, *bco_itr))
+    std::set<unsigned long long, bco_comparator_s>::const_iterator bco_itr = m_unique_bcos.begin();
+    // for(bco_itr = m_unique_bcos.begin(); bco_itr != m_unique_bcos.end(); ++bco_itr)
+    for(int n = 0; n < 10; ++n)
     {
-      break;
-    }
+      if(bco_itr == m_unique_bcos.end())
+      {
+	    break;
+      }
 
-    ++m_unique_bco_count;
-    m_last_flushed_bco = *bco_itr;
+      // if((m_most_recent_bco == std::numeric_limits<unsigned long long>::max()) || m_bco_less(m_most_recent_bco - m_MAX_BCO_DIFF, *bco_itr))
+      if( m_most_recent_bco == std::numeric_limits<unsigned long long>::max() )
+      {
+        break;
+      }
+
+      ++m_unique_bco_count;
+      m_last_flushed_bco = *bco_itr;
+	  ++bco_itr;
+    }
+    m_unique_bcos.erase(m_unique_bcos.begin(), bco_itr);
   }
-  m_unique_bcos.erase(m_unique_bcos.begin(), bco_itr);
 
   EvtHist->AddBinContent(1);
   EvtHist->SetBinContent(2, m_unique_bco_count + m_unique_bcos.size());
@@ -176,6 +187,15 @@ int InttMon::process_event(Event *evt)
   //   std::cout << "decoded " << m_unique_bco_count + m_unique_bcos.size() - m_logged_bcos << std::endl;
   // }
 
+  if(!((int)(EvtHist->GetBinContent(1)) % m_evt_per_cout))
+  {
+    std::cout << std::hex;
+    std::cout << "last flushed: 0x" << m_last_flushed_bco << std::endl;
+    std::cout << "most recent:  0x" << m_most_recent_bco << std::endl;
+    std::cout << std::dec;
+  }
+
+
   return 0;
 }
 
@@ -186,21 +206,21 @@ int InttMon::Reset()
 
 int InttMon::MiscDebug()
 {
-  for (int fee = 0; fee < 14; ++fee)
-  {
-    for (int chp = 0; chp < 26; ++chp)
-    {
-      HitHist->SetBinContent(fee * NCHIPS + chp + 1, chp);
-    }
-  }
+  // for (int fee = 0; fee < 14; ++fee)
+  // {
+  //   for (int chp = 0; chp < 26; ++chp)
+  //   {
+  //     HitHist->SetBinContent(fee * NCHIPS + chp + 1, chp);
+  //   }
+  // }
 
-  for (int fee = 0; fee < 14; ++fee)
-  {
-    for (int bco = 0; bco < 128; ++bco)
-    {
-      BcoHist->SetBinContent(fee * NBCOS + bco + 1, fee);
-    }
-  }
+  // for (int fee = 0; fee < 14; ++fee)
+  // {
+  //   for (int bco = 0; bco < 128; ++bco)
+  //   {
+  //     BcoHist->SetBinContent(fee * NBCOS + bco + 1, fee);
+  //   }
+  // }
 
   return 0;
 }

--- a/subsystems/intt/InttMon.h
+++ b/subsystems/intt/InttMon.h
@@ -51,6 +51,7 @@ class InttMon : public OnlMon
   int m_unique_bco_count = {};
   int m_log_bin = 0;
   int m_logged_bcos = 0;
+  int m_evt_per_cout = 50000;
 
   std::chrono::time_point<std::chrono::system_clock> m_start_time{};
 };

--- a/subsystems/intt/InttMon.h
+++ b/subsystems/intt/InttMon.h
@@ -28,10 +28,10 @@ class InttMon : public OnlMon
   static constexpr int NFEES = 14;
   static constexpr int NBCOS = 128;
 
-  int static const m_MAX_BCO_DIFF = 1000;
+  // int static const m_MAX_BCO_DIFF = 1000;
 
   int static const m_LOG_DURATION = 3600; // seconds
-  int static const m_LOG_INTERVAL = 3;    // seconds
+  int static const m_LOG_INTERVAL = 15;   // seconds
 
   Packet** plist{nullptr};
   TH1* EvtHist{nullptr};

--- a/subsystems/intt/InttMonDraw.cc
+++ b/subsystems/intt/InttMonDraw.cc
@@ -1301,7 +1301,7 @@ int InttMonDraw::Draw_History()
 	// if the rate is identically 0, say it is dead
 	bool is_dead = true;
     int buff_index = log_hist->GetBinContent(N);
-    for(double duration = 0; duration < 180; duration += w)
+    for(double duration = 0; duration < 90; duration += w)
     {
       double rate = log_hist->GetBinContent(buff_index);
 	  if(0 < rate)
@@ -1430,7 +1430,7 @@ int InttMonDraw::Draw_History()
   }
 
   m_single_transparent_pad[k_history]->Clear();
-  if(2 < num_dead)
+  if(0 < num_dead)
   {
     m_single_transparent_pad[k_history]->cd();
     TText dead_text;


### PR DESCRIPTION
This change recovered the decoding rate for intt1 in run 49224. I think strange BCO values were tripping a guard clause, which has now been changed. I'll test it more make the logic cleaner in a later PR, but I think it's safe to run for the weekend.