### PR TITLE
add new MVTX plot NumberOfRDHErrors vs FeeId

### DIFF
--- a/macros/run_mvtx_client.C
+++ b/macros/run_mvtx_client.C
@@ -69,6 +69,9 @@ void mvtxDrawInit(const int online = 0)
     {
       cl->registerHisto(Form("MVTXMON_Occupancy_Layer%d_Layer%dDeadChipPos", mLayer, mLayer), servername);
     }
+
+    cl->registerHisto("RDHErrors_hfeeRDHErrors", servername);
+
   }
 
   // for local host, just call mvtxDrawInit(2)

--- a/subsystems/mvtx/MvtxMon.cc
+++ b/subsystems/mvtx/MvtxMon.cc
@@ -299,6 +299,12 @@ int MvtxMon::Init()
   hFeeL1->SetStats(0);
   se->registerHisto(this, hFeeL1);
 
+  hFeeRDHErrors = new TH1I("RDHErrors_hfeeRDHErrors", "RDH Errors vs FeeId", NFees,0,NFees);
+  hFeeRDHErrors->GetXaxis()->SetTitle("FEE ID");
+  hFeeRDHErrors->GetYaxis()->SetTitle("Number of MVTX RDH Errors");
+  hFeeRDHErrors->SetStats(0);
+  se->registerHisto(this, hFeeRDHErrors);
+
   // fhr
   mErrorVsFeeid = new TH2I("FHR_ErrorVsFeeid", "Decoder error vs FeeID", 3 * StaveBoundary[3], 0, 3 * StaveBoundary[3], NError, 0.5, NError + 0.5);;
   mErrorVsFeeid->GetXaxis()->SetTitle("FEE ID");
@@ -463,6 +469,7 @@ int MvtxMon::process_event(Event* evt)
         auto feeId = plist[i]->iValue(i_fee, "FEEID");
         auto link = DecodeFeeid(feeId);
         auto num_strobes = plist[i]->iValue(feeId, "NR_STROBES");
+        auto num_RDHErrors = plist[i]->iValue(feeId, "RDH_ERRORS");
         ntriggers = num_strobes;
         auto num_L1Trgs = plist[i]->iValue(feeId, "NR_PHYS_TRG");
         for (int iL1 = 0; iL1 < num_L1Trgs; ++iL1)
@@ -472,6 +479,11 @@ int MvtxMon::process_event(Event* evt)
           hChipL1->Fill((StaveBoundary[link.layer] + link.stave % 20) * 9 + 3 * link.gbtid + 1);
           hChipL1->Fill((StaveBoundary[link.layer] + link.stave % 20) * 9 + 3 * link.gbtid + 2);
           hFeeL1->Fill((StaveBoundary[link.layer] + link.stave % 20) * 3 + link.gbtid);
+        }
+
+        for (int irdhe = 0; irdhe < num_RDHErrors; ++irdhe)
+        {
+          hFeeRDHErrors->Fill((StaveBoundary[link.layer] + link.stave % 20) * 3 + link.gbtid);
         }
 
         for (int i_strb{0}; i_strb < num_strobes; ++i_strb)

--- a/subsystems/mvtx/MvtxMon.h
+++ b/subsystems/mvtx/MvtxMon.h
@@ -74,6 +74,7 @@ class MvtxMon : public OnlMon
   TH1I* hChipL1 = nullptr;
   TH1I* hFeeStrobes = nullptr;
   TH1I* hFeeL1 = nullptr;
+  TH1I* hFeeRDHErrors = nullptr;
   // fee
   TH2I* mTriggerVsFeeId = nullptr;
   TH1I* mTrigger = nullptr;

--- a/subsystems/mvtx/MvtxMonDraw.cc
+++ b/subsystems/mvtx/MvtxMonDraw.cc
@@ -920,6 +920,7 @@ int MvtxMonDraw::DrawFEE(const std::string & /* what */)
   //TH1I *mLaneStatusSummaryIB[NFlx + 1] = {nullptr};
   TH1D *mvtxmon_mGeneralErrorPlots[NFlx + 1] = {nullptr};
   TH2D *mvtxmon_mGeneralErrorFile[NFlx + 1] = {nullptr};
+  TH1I *hRDHErrors[NFlx + 1] = {nullptr};
 
   for (int iFelix = 0; iFelix < NFlx; iFelix++)
   {
@@ -935,6 +936,7 @@ int MvtxMonDraw::DrawFEE(const std::string & /* what */)
       mLaneStatusCumulative[i][iFelix] = dynamic_cast<TH2I *>(cl->getHisto(Form("MVTXMON_%d", iFelix), Form("FEE_LaneStatusFromSOX_Flag_%s", mLaneStatusFlag[i].c_str())));
       //mLaneStatusSummary[i][iFelix] = dynamic_cast<TH1I *>(cl->getHisto(Form("MVTXMON_%d", iFelix), Form("FEE_LaneStatusSummary_Layer_%i", i)));
     }
+    hRDHErrors[iFelix] = dynamic_cast<TH1I *>(cl->getHisto(Form("MVTXMON_%d", iFelix), "RDHErrors_hfeeRDHErrors"));
   }
 
   for (int i = 0; i < 3; i++)
@@ -949,6 +951,7 @@ int MvtxMonDraw::DrawFEE(const std::string & /* what */)
   MergeServers<TH2I *>(FHR_ErrorVsFeeid);
     MergeServers<TH1D *>(mvtxmon_mGeneralErrorPlots);
       MergeServers<TH2D *>(mvtxmon_mGeneralErrorFile);
+  MergeServers<TH1I *>(hRDHErrors);
 
   if (!gROOT->FindObject("MvtxMon_FEE"))
   {
@@ -957,7 +960,7 @@ int MvtxMonDraw::DrawFEE(const std::string & /* what */)
 
   TC[canvasID]->SetEditable(true);
   TC[canvasID]->Clear("D");
-  Pad[padID]->Divide(3, 3);
+  Pad[padID]->Divide(4, 3);
 
   for (int i = 0; i < 3; i++)
   {
@@ -1036,9 +1039,10 @@ int MvtxMonDraw::DrawFEE(const std::string & /* what */)
 
   int returnCode = 0;
  // Pad[padID]->cd(1)->SetLeftMargin(0.16);
-  returnCode += PublishHistogram(Pad[padID], 7, mvtxmon_mGeneralErrorPlots[NFlx]);
-  returnCode += PublishHistogram(Pad[padID], 8, mvtxmon_mGeneralErrorFile[NFlx], "lcol");
-  returnCode += PublishHistogram(Pad[padID], 9, FHR_ErrorVsFeeid[NFlx], "lcol");
+  returnCode += PublishHistogram(Pad[padID], 9, mvtxmon_mGeneralErrorPlots[NFlx]);
+  returnCode += PublishHistogram(Pad[padID], 10, mvtxmon_mGeneralErrorFile[NFlx], "lcol");
+  returnCode += PublishHistogram(Pad[padID], 11, FHR_ErrorVsFeeid[NFlx], "lcol");
+  returnCode += PublishHistogram(Pad[padID], 12, hRDHErrors[NFlx], "lcol");
   //returnCode += PublishHistogram(Pad[padID], 1, mTriggerVsFeeId[NFlx], "lcol");
   //returnCode += PublishHistogram(Pad[padID], 5, mTrigger[NFlx]);
   // returnCode += PublishHistogram(Pad[9],3,mLaneInfo[NFlx]);
@@ -1057,17 +1061,17 @@ int MvtxMonDraw::DrawFEE(const std::string & /* what */)
   {
     i->Draw();
   }*/
-  returnCode += PublishHistogram(Pad[padID], 4, mLaneStatusCumulative[0][NFlx], "lcol");
+  returnCode += PublishHistogram(Pad[padID], 5, mLaneStatusCumulative[0][NFlx], "lcol");
   /*for (auto &i : tlayer)
   {
     i->Draw();
   }*/
-  returnCode += PublishHistogram(Pad[padID], 5, mLaneStatusCumulative[1][NFlx], "lcol");
+  returnCode += PublishHistogram(Pad[padID], 6, mLaneStatusCumulative[1][NFlx], "lcol");
   /*for (auto &i : tlayer)
   {
     i->Draw();
   }*/
-  returnCode += PublishHistogram(Pad[padID], 6, mLaneStatusCumulative[2][NFlx], "lcol");
+  returnCode += PublishHistogram(Pad[padID], 7, mLaneStatusCumulative[2][NFlx], "lcol");
   /*for (auto &i : tlayer)
   {
     i->Draw();


### PR DESCRIPTION
Add Number of RDH Errors vs FeeId plots in FEE tab for expert checking how many RDH errors when decoding data. Should merge after online distribution PR merged https://github.com/sPHENIX-Collaboration/online_distribution/pull/174, otherwise we can not get Number of RDH info.