### PR TITLE
Excluding HB packets from parity and checksum error rate calculations

### DIFF
--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -905,10 +905,12 @@ int TpcMon::process_event(Event *evt/* evt */)
         int parityError = p->iValue(wf, "DATAPARITYERROR");
         int channel = p->iValue(wf, "CHANNEL");
 
-        Check_Sums->Fill(FEE_transform[fee]*8 + sampaAddress); 
-        if( checksumError == 1){Check_Sum_Error->Fill(FEE_transform[fee]*8 + sampaAddress);}
-        if( parityError == 1){Parity_Error->Fill(FEE_transform[fee]*8 + sampaAddress);}
-
+        if( p->iValue(wf,"TYPE")!=0 ){
+          Check_Sums->Fill(FEE_transform[fee]*8 + sampaAddress); 
+          if( checksumError == 1){Check_Sum_Error->Fill(FEE_transform[fee]*8 + sampaAddress);}
+          if( parityError == 1){Parity_Error->Fill(FEE_transform[fee]*8 + sampaAddress);}
+        }
+ 
         if( (checksumError == 0 && parityError == 0) &&  p->iValue(wf,"TYPE")!= 0){Channels_in_Packet->Fill(channel + (256*FEE_transform[fee]));} // do not fill for heartbeat WFs
 
         int nr_Samples = p->iValue(wf, "SAMPLES");


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.cc

**Changes:**

TpcMon.cc - L908 - make it to exclude WF type 0 (heartbeat packets) from the checksumerror and parity error calculations. Excluded numerator and denominator. 

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module
