### PR TITLE
Mvtx OM updates

### DIFF
--- a/subsystems/mvtx/MvtxMon.cc
+++ b/subsystems/mvtx/MvtxMon.cc
@@ -320,7 +320,7 @@ int MvtxMon::Init()
   mGeneralOccupancy->SetStats(false);
 
   mGeneralNoisyPixel = new TH2Poly();
-  mGeneralNoisyPixel->SetTitle("Noisy Pixel Number; ; ");
+  mGeneralNoisyPixel->SetTitle("Unmasked Noisy Pixel Number; ; ");
   mGeneralNoisyPixel->SetName("MVTXMON_General_Noisy_Pixel");
   mGeneralNoisyPixel->GetXaxis()->SetTitle("");
   mGeneralNoisyPixel->GetYaxis()->SetTitle("");

--- a/subsystems/mvtx/MvtxMon.cc
+++ b/subsystems/mvtx/MvtxMon.cc
@@ -203,7 +203,7 @@ int MvtxMon::Init()
 
   se->registerHisto(this, hErrorPlots);
 
-  hErrorPlotsTime = new TH1D("General_DecErrorsTime", "Decoding Errors Time Serie", 50, 0.5, 50.5);
+  hErrorPlotsTime = new TH1D("General_DecErrorsTime", "Rolling History Of Decoding Errors", 50, 0.5, 50.5);
   hErrorPlotsTime->GetYaxis()->SetTitle("Number of Errors");
   hErrorPlotsTime->GetXaxis()->SetTitle("Time");
   hErrorPlotsTime->SetMinimum(0);       // remove

--- a/subsystems/mvtx/MvtxMonDraw.cc
+++ b/subsystems/mvtx/MvtxMonDraw.cc
@@ -1714,12 +1714,12 @@ int MvtxMonDraw::PublishHistogram(TCanvas *c, int pad, TH1 *h, const char *opt, 
     }
     else if (palettestyle==1)
     {
-      h->SetMinimum(-1);
-      h->SetMaximum(1200);
+      h->SetMinimum(-1/48);
+      h->SetMaximum(1200/48);
       // palette only for noisy pixel
       h->DrawCopy(opt);
       const int numLevels = 3;
-      double levels[numLevels] = { 0, 200, 1000 };
+      double levels[numLevels] = { 0, 200/48, 1000/48 };
       h->SetContour(numLevels, levels);
       h->SetMarkerSize(2);
       TExec *ex1 = new TExec("ex1","MvtxMonDraw::setPalUser();");

--- a/subsystems/mvtx/MvtxMonDraw.cc
+++ b/subsystems/mvtx/MvtxMonDraw.cc
@@ -506,6 +506,9 @@ int MvtxMonDraw::DrawGeneral(const std::string & /* what */)
   if (mvtxmon_mGeneralOccupancy[NFlx])
   {
     mvtxmon_mGeneralOccupancy[NFlx]->GetYaxis()->SetTitleOffset(0.6);
+    mvtxmon_mGeneralOccupancy[NFlx]->SetMinimum(0);
+    mvtxmon_mGeneralOccupancy[NFlx]->SetMaximum(100E-6); // set max to 0.6% occupancy
+    mvtxmon_mGeneralOccupancy[NFlx]->SetContour(100);
   }
 
    if (mvtxmon_ChipStave1D[NFlx])
@@ -602,8 +605,8 @@ int MvtxMonDraw::DrawGeneral(const std::string & /* what */)
   //DrawPave(status, 0);
   //returnCode += PublishHistogram(Pad[padID], 2, mvtxmon_mGeneralOccupancy[NFlx]);
   returnCode += PublishHistogram(Pad[padID], 2, mvtxmon_mGeneralOccupancy[NFlx], "colz");
-  returnCode += PublishHistogram(Pad[padID], 3, mGeneralNoisyPixel[NFlx], "", 1);
-  returnCode += PublishHistogram(Pad[padID], 3, mGeneralNoisyPixel[NFlx], "colz same", 1);
+  returnCode += PublishHistogram(Pad[padID], 3, mGeneralNoisyPixel[NFlx], "colz", 1);
+  returnCode += PublishHistogram(Pad[padID], 3, mGeneralNoisyPixel[NFlx], "colztext same", 1);
   returnCode += PublishHistogram(Pad[padID], 5, mvtxmon_mGeneralErrorPlotsTime[NFlx]);
   //returnCode += PublishHistogram(Pad[padID], 5, hStrobesDMA[NFlx]);
   
@@ -718,15 +721,18 @@ int MvtxMonDraw::DrawGeneral(const std::string & /* what */)
   {
     if (status.at(0) == Quality::Medium)
     {
-      ptt4->AddText("#color[808]{QA Layer 0 Medium}");
+      // ptt4->AddText("#color[808]{Layer 0 Medium}");
+      ptt4->AddText("#color[808]{Lane error(s) in Layer 0}");
     }
     if (status.at(1) == Quality::Medium)
     {
-      ptt4->AddText("#color[808]{QA Layer 1 Medium}");
+      // ptt4->AddText("#color[808]{QA Layer 1 Medium}");
+      ptt4->AddText("#color[808]{Lane error(s) in Layer 1}");
     }
     if (status.at(2) == Quality::Medium)
     {
-      ptt4->AddText("#color[808]{QA Layer 2 Medium}");
+      // ptt4->AddText("#color[808]{QA Layer 2 Medium}");
+      ptt4->AddText("#color[808]{Lane error(s) in Layer 2}");
     }
     if (status.at(3) == Quality::Medium)
     {
@@ -807,15 +813,15 @@ int MvtxMonDraw::DrawGeneral(const std::string & /* what */)
   {
     if (status.at(0) == Quality::Bad)
     {
-      ptt4->AddText("#color[2]{QA Layer 0 Bad}");
+      ptt4->AddText("#color[2]{>1/5 of staves in Layer 0 BAD}");
     }
     if (status.at(1) == Quality::Bad)
     {
-      ptt4->AddText("#color[2]{QA Layer 1 Bad}");
+      ptt4->AddText("#color[2]{>1/5 of staves in Layer 1 BAD}");
     }
     if (status.at(2) == Quality::Bad)
     {
-      ptt4->AddText("#color[2]{QA Layer 2 Bad}");
+      ptt4->AddText("#color[2]{>1/5 of staves in Layer 2 BAD}");
     }
     if (status.at(3) == Quality::Bad)
     {
@@ -1680,6 +1686,7 @@ int MvtxMonDraw::PublishHistogram(TCanvas *c, int pad, TH1 *h, const char *opt, 
       const int numLevels = 3;
       double levels[numLevels] = { 0, 200, 1000 };
       h->SetContour(numLevels, levels);
+      h->SetMarkerSize(2);
       TExec *ex1 = new TExec("ex1","MvtxMonDraw::setPalUser();");
       ex1->Draw();
       h->DrawCopy(opt);

--- a/subsystems/mvtx/MvtxMonDraw.cc
+++ b/subsystems/mvtx/MvtxMonDraw.cc
@@ -507,7 +507,7 @@ int MvtxMonDraw::DrawGeneral(const std::string & /* what */)
   {
     mvtxmon_mGeneralOccupancy[NFlx]->GetYaxis()->SetTitleOffset(0.6);
     mvtxmon_mGeneralOccupancy[NFlx]->SetMinimum(0);
-    mvtxmon_mGeneralOccupancy[NFlx]->SetMaximum(100E-6); // set max to 0.6% occupancy
+    mvtxmon_mGeneralOccupancy[NFlx]->SetMaximum(100E-6); // set a fixed max value 
     mvtxmon_mGeneralOccupancy[NFlx]->SetContour(100);
   }
 
@@ -549,7 +549,10 @@ int MvtxMonDraw::DrawGeneral(const std::string & /* what */)
   Pad[padID]->Divide(4, 2);
   int returnCode = 0;
 
-  Pad[padID]->cd(4)->SetRightMargin(0.2);
+  // Pad[padID]->cd(1)->SetRightMargin(0.15);
+  Pad[padID]->cd(3)->SetRightMargin(0.16);
+  Pad[padID]->cd(4)->SetRightMargin(0.15);
+  Pad[padID]->cd(4)->SetLeftMargin(0.15);
   Pad[padID]->cd(6)->SetLeftMargin(0.16);
   Pad[padID]->cd(6)->SetTopMargin(0.16);
   Pad[padID]->cd(6)->SetBottomMargin(0.14);
@@ -573,6 +576,13 @@ int MvtxMonDraw::DrawGeneral(const std::string & /* what */)
     mvtxmon_mGeneralErrorPlots[NFlx]->GetXaxis()->SetTitleSize(0.045);
     mvtxmon_mGeneralErrorPlots[NFlx]->GetYaxis()->SetTitleSize(0.045);
   }
+
+   if (mvtxmon_mGeneralErrorPlotsTime[NFlx])
+  {
+    mvtxmon_mGeneralErrorPlotsTime[NFlx]->GetXaxis()->SetLabelOffset(999);
+    mvtxmon_mGeneralErrorPlotsTime[NFlx]->GetXaxis()->SetTickLength(0);
+  }
+
 
   hChipStrobes[NFlx]->SetMinimum(0);
   hChipStrobes[NFlx]->SetTitle("Strobe & L1 vs Chip");
@@ -601,13 +611,31 @@ int MvtxMonDraw::DrawGeneral(const std::string & /* what */)
   std::vector<MvtxMonDraw::Quality> status;
   status = analyseForError(mvtxmon_LaneStatusOverview[NFlx], mGeneralNoisyPixel[NFlx], hChipStrobes[NFlx], mvtxmon_mGeneralErrorFile[NFlx], mvtxmon_mGeneralErrorPlotsTime[NFlx],hDMAstatus[NFlx]);
 
-  returnCode += PublishHistogram(Pad[padID], 1, mvtxmon_LaneStatusOverview[NFlx], "lcolz");
+  returnCode += PublishHistogram(Pad[padID], 1, mvtxmon_LaneStatusOverview[NFlx], "col", 2);
+  returnCode += PublishHistogram(Pad[padID], 1, mvtxmon_LaneStatusOverview[NFlx], "colz same", 2);
   //DrawPave(status, 0);
   //returnCode += PublishHistogram(Pad[padID], 2, mvtxmon_mGeneralOccupancy[NFlx]);
-  returnCode += PublishHistogram(Pad[padID], 2, mvtxmon_mGeneralOccupancy[NFlx], "colz");
+  returnCode += PublishHistogram(Pad[padID], 2, mvtxmon_mGeneralOccupancy[NFlx], "col", 0);
+  returnCode += PublishHistogram(Pad[padID], 2, mvtxmon_mGeneralOccupancy[NFlx], "colz same", 0);
   returnCode += PublishHistogram(Pad[padID], 3, mGeneralNoisyPixel[NFlx], "colz", 1);
   returnCode += PublishHistogram(Pad[padID], 3, mGeneralNoisyPixel[NFlx], "colztext same", 1);
   returnCode += PublishHistogram(Pad[padID], 5, mvtxmon_mGeneralErrorPlotsTime[NFlx]);
+
+  if (mvtxmon_mGeneralErrorPlotsTime[NFlx])
+  {
+    // Redraw the new axis
+    gPad->Update();
+    TGaxis *newaxis = new TGaxis(gPad->GetUxmax(),
+                                  gPad->GetUymin(),
+                                  gPad->GetUxmin(),
+                                  gPad->GetUymin(),
+                                  mvtxmon_mGeneralErrorPlotsTime[NFlx]->GetXaxis()->GetXmin(),
+                                  mvtxmon_mGeneralErrorPlotsTime[NFlx]->GetXaxis()->GetXmax(),
+                                  510,"-");
+    newaxis->SetLabelOffset(-0.04);
+    newaxis->SetLabelSize(0.04);
+    newaxis->Draw();
+  }
   //returnCode += PublishHistogram(Pad[padID], 5, hStrobesDMA[NFlx]);
   
   returnCode += PublishHistogram(Pad[padID], 4, hChipStrobes[NFlx]);
@@ -1152,6 +1180,7 @@ int MvtxMonDraw::DrawOCC(const std::string & /* what */)
       hChipStaveOccupancy[i][NFlx]->GetYaxis()->SetLabelSize(0.06);
       hChipStaveOccupancy[i][NFlx]->GetYaxis()->SetTitleSize(0.05);
       hChipStaveOccupancy[i][NFlx]->GetYaxis()->SetTitleOffset(0.7);
+      hChipStaveOccupancy[i][NFlx]->SetContour(100);
 
       hChipStaveOccupancy_low[i] = (TH2D *) (hChipStaveOccupancy[i][NFlx])->Clone(Form("hChipStaveOccupancy_low_%d", i));
       TString tmp = "Chip Occupancy < 1\%";
@@ -1237,6 +1266,10 @@ int MvtxMonDraw::DrawOCC(const std::string & /* what */)
   Pad[padID]->cd(1)->SetLogy();
   Pad[padID]->cd(2)->SetLogy();
   Pad[padID]->cd(3)->SetLogy();
+  Pad[padID]->cd(5)->SetRightMargin(0.15);
+  Pad[padID]->cd(6)->SetRightMargin(0.15);
+  Pad[padID]->cd(7)->SetRightMargin(0.15);
+
    //Pad[padID]->cd(1)->SetLogx();
   //[padID]->cd(2)->SetLogx();
   //Pad[padID]->cd(3)->SetLogx();
@@ -1244,6 +1277,7 @@ int MvtxMonDraw::DrawOCC(const std::string & /* what */)
   hChipStaveOccupancy[0][NFlx]->GetZaxis()->SetTitle("");
   hChipStaveOccupancy[1][NFlx]->GetZaxis()->SetTitle("");
   hChipStaveOccupancy[2][NFlx]->GetZaxis()->SetTitle("");
+
 
   hChipStrobes[NFlx]->SetTitle("Chip Strobes (L1 triggers) vs Chip*Stave");
   hChipStrobes[NFlx]->GetYaxis()->SetTitle("Number of strobes");
@@ -1673,6 +1707,7 @@ int MvtxMonDraw::PublishHistogram(TCanvas *c, int pad, TH1 *h, const char *opt, 
   {
     if (palettestyle==0)
     {
+      h->DrawCopy(opt);
       TExec *ex1 = new TExec("ex1","MvtxMonDraw::setPalDefault();");
       ex1->Draw();
       h->DrawCopy(opt);
@@ -1689,6 +1724,22 @@ int MvtxMonDraw::PublishHistogram(TCanvas *c, int pad, TH1 *h, const char *opt, 
       h->SetMarkerSize(2);
       TExec *ex1 = new TExec("ex1","MvtxMonDraw::setPalUser();");
       ex1->Draw();
+      h->DrawCopy(opt);
+    }
+    else if (palettestyle==2)
+    {
+      h->SetMinimum(0);
+      h->SetMaximum(1);
+      h->DrawCopy(opt);
+      const int numLevels = 3;
+      double levels[numLevels] = { 0, 0.11, 0.22 };
+      h->SetContour(numLevels, levels);
+      TExec *ex1 = new TExec("ex1","MvtxMonDraw::setPalUser();");
+      ex1->Draw();
+      h->DrawCopy(opt);
+    }
+    else
+    {
       h->DrawCopy(opt);
     }
     return 0;


### PR DESCRIPTION
- Simplied color scheme for "Fraction of lanes in PROBLEM"
- Corrected scale for "Noisy Pixel Numbers"
- Rename "Noisy Pixel Numbers" to "Unmasked Noisy Pixel Number"
- Fixed Z-axis scale for "General Occupancy"
- Rename "Decoding Error Time Series" to "Rolling History Of Decoding Errors"
- Reversed X-axis of "Rolling History Of Decoding Errors" such that recent events that appear on the right now have small
numbers, older events one the left would have large numbers