### PR TITLE
adding blue fill color to checksumerror and parityerror ratio plots

### DIFF
--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -347,6 +347,7 @@ int TpcMon::Init()
   Check_Sums->SetXTitle("FEE_NUM*8 + SAMPA_ADRR");
   Check_Sums->SetYTitle("Entries");
   Check_Sums->Sumw2(kFALSE); //explicity turn off Sumw2 - we do not want it
+  Check_Sums->SetFillColor(4);
 
   Check_Sums -> GetXaxis() -> SetLabelSize(0.05);
   Check_Sums -> GetXaxis() -> SetTitleSize(0.05);
@@ -361,6 +362,7 @@ int TpcMon::Init()
   Check_Sum_Error->SetXTitle("FEE_NUM*8 + SAMPA_ADDR");
   Check_Sum_Error->SetYTitle("Prob. Check Sum. Err.");
   Check_Sum_Error->Sumw2(kFALSE); //explicity turn off Sumw2 - we do not want it
+  Check_Sum_Error->SetFillColor(4);
 
   Check_Sum_Error -> GetXaxis() -> SetLabelSize(0.05);
   Check_Sum_Error -> GetXaxis() -> SetTitleSize(0.05);
@@ -375,6 +377,7 @@ int TpcMon::Init()
   Parity_Error->SetXTitle("FEE_NUM*8 + SAMPA_ADDR");
   Parity_Error->SetYTitle("Prob. Parity Err.");
   Parity_Error->Sumw2(kFALSE); //explicity turn off Sumw2 - we do not want it
+  Parity_Error->SetFillColor(4);
 
   Parity_Error -> GetXaxis() -> SetLabelSize(0.05);
   Parity_Error -> GetXaxis() -> SetTitleSize(0.05);


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.cc

**Changes:**

TpcMon.cc - L350 + L365 + L380. Adding fill color 4 (blue) to these histograms. This propagates all the way to client.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module

