### PR TITLE
If only one trigger set, use as main trigger

### DIFF
--- a/subsystems/bbc/BbcMon.h
+++ b/subsystems/bbc/BbcMon.h
@@ -33,6 +33,7 @@ class BbcMon : public OnlMon
   int Reset() override;
 
   void set_GL1(const int g) { useGL1 = g; }
+  void set_skipto(const int s) { skipto = s; }
 
  protected:
   int DBVarInit();
@@ -57,7 +58,12 @@ class BbcMon : public OnlMon
   uint64_t hcal{0};           // all hcal triggers, no bbc
   uint64_t emcalmbd{0};       // all emcal triggers, with bbc
   uint64_t hcalmbd{0};        // all hcal triggers, with bbc
+  int      ntrigs_defined{0}; // for runs with one trigger defined
+  uint64_t orig_mbdns{0};     // store for recovering from runs with one trigger defined
+  uint64_t orig_mbdtrig{0};   // store for recovering from runs with one trigger defined
+  uint64_t orig_trigmask{0};   // store for recovering from runs with one trigger defined
   eventReceiverClient *erc{nullptr};
+  int      skipto{0};
   //GL1Manager *gl1mgr{nullptr};
   RunDBodbc *rdb{nullptr};
 

--- a/subsystems/bbc/calib/BbcMonData.dat
+++ b/subsystems/bbc/calib/BbcMonData.dat
@@ -1,5 +1,7 @@
 MBDNS           0x0c00
 MBDTRIG         0x7c00
+#MBDNS        0xffffffffffff
+#MBDTRIG      0xffffffffffff
 MBDNSVTX10      0x1000
 MBDNSVTX30      0x2000
 MBDNSVTX60      0x4000
@@ -10,4 +12,5 @@ HCAL          0xf00000
 EMCALMBD     0xf000000
 HCALMBD        0xf0000
 TRIGMASK     0xf0fff00
+#TRIGMASK     0xffffffffffff
 #USEGL1              1


### PR DESCRIPTION
We figure out using the prescale settings whether only one trigger is set.  If so, we use that as the main trigger.