### PR TITLE
Removing the call to existPacket due to bug found 08.20.24

### DIFF
--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -838,15 +838,16 @@ int TpcMon::process_event(Event *evt/* evt */)
   // we assume we start properly at 4001, but check if not
   
   int firstpacket=4001;
-  if (evt->existPacket(4000))
-    {
-      Packet *p = evt->getPacket(4000);
-      if(p)
-      {
-        if (p->getHitFormat() == IDTPCFEEV3 || p->getHitFormat() == IDTPCFEEV4) firstpacket = 4000;
-        delete p;
-      }
-    }
+  //if (evt->existPacket(4000))
+  //{
+  //Packet *p = evt->getPacket(4000);
+  if(evt->getPacket(4000))
+  {
+    Packet *p = evt->getPacket(4000);
+    if (p->getHitFormat() == IDTPCFEEV3 || p->getHitFormat() == IDTPCFEEV4) firstpacket = 4000;
+    delete p;
+  }
+  //}
   int lastpacket = firstpacket+232;
 
   NEvents_vs_EBDC->Fill(MonitorServerId());


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.cc

**Changes:**

- Commented out L841-843 & L850
- L844 is not not nested in outer if - we only check if it has packet(4000) without call to existPacket
- @pinkenburg and @mpurschke found error with existPacket in [oncsEvent::existPacket](https://github.com/tsakagu/online_distribution/blob/8d28717616dca29317f59b419f8b8baf38b7161f/newbasic/oncsEvent.cc#L372).
- Error is 2 fold:
- - 
```
Thread 1 "root.exe" received signal SIGINT, Interrupt.
0x00007f5258d05b93 in oncsEvent::existPacket (this=<optimized out>, id=4000)
    at /home/sphnxbuild/pro_installation/Debian/online_distribution/newbasic/oncsEvent.cc:416
```
- - i+ EventData->data[i] may never increment and result in infinite loop

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module

