### PR TITLE
Fixing issue where shifter drift plots incorrectly say peak is wrong

### DIFF
--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -3891,6 +3891,10 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
     int R2_max = std::numeric_limits<int>::min(); // start with smalles possible value
     int R3_max = std::numeric_limits<int>::min(); // start with smalles possible value
 
+    bool R1_bad = 0;
+    bool R2_bad = 0;
+    bool R3_bad = 0;
+
     for( int j = 2; j>-1; j-- )
     {
       if( tpcmon_DriftWindow_shifter[i][j] )
@@ -3906,6 +3910,10 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
       }
     }
 
+
+    if( (R1_max>std::numeric_limits<int>::min() && (R1_max < 413)) || R1_max > 423 ){ R1_bad = 1;} 
+    if( (R2_max>std::numeric_limits<int>::min() && (R2_max < 413)) || R2_max > 423 ){ R2_bad = 1;} 
+    if( (R3_max>std::numeric_limits<int>::min() && (R3_max < 413)) || R3_max > 423 ){ R3_bad = 1;}
 
     for( int l = 2; l>-1; l-- )
     {
@@ -3935,14 +3943,14 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
       legend->AddEntry(tpcmon_DriftWindow_shifter[i][2], "R3");
       MyTC->cd(i+5);
       legend->Draw();
-      draw_leg = 1; //for these plots draw legend everywhere
+      draw_leg = 1; //draw legend only once
     }
 
     //std::cout<<"R1_max = "<<R1_max<<" R2_max = "<<R2_max<<" R3_max = "<<R3_max<<std::endl;
     //messages->Clear();
     messages[i] = new TPaveText(0.1,0.5,0.4,0.9,"brNDC");  
     
-    if( ((R1_max>std::numeric_limits<int>::min() && (R1_max < 413 || R1_max > 423)) ||  (R2_max>std::numeric_limits<int>::min() && (R2_max < 413 || R2_max > 423))) || ( R3_max>std::numeric_limits<int>::min() && (R3_max < 413 || R3_max > 423)) )
+    if(  (R1_bad==1 || R2_bad==1) || R3_bad==1 )
     {
       //std::cout<<"made it into the if statement for bad timing"<<std::endl;
       sprintf(bad_message,"Sector %i BAD",i);
@@ -3954,6 +3962,12 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
     else if( tpcmon_DriftWindow_shifter[i][0] && (tpcmon_DriftWindow_shifter[i][1] && tpcmon_DriftWindow_shifter[i][2]) )
     {
       messages[i]->AddText("ALL GOOD"); ((TText*)messages[i]->GetListOfLines()->Last())->SetTextColor(kGreen);
+      MyTC->cd(i+5);
+      messages[i]->Draw("same");
+    }
+    else
+    {
+      messages[i]->AddText("MISSING DATA"); ((TText*)messages[i]->GetListOfLines()->Last())->SetTextColor(kBlack);
       MyTC->cd(i+5);
       messages[i]->Draw("same");
     }


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMonDraw.cc

**Changes:**

- Simplified logic with booleans to determine bad peaks. Since I cannot reproduce error offline, have to hope it works.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module

