### PR TITLE
Additonal nice things for shifter drifter plot

### DIFF
--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -3858,6 +3858,17 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
       tpcmon_DriftWindow_shifter[i][2] = (TH1*) cl->getHisto(TPCMON_STR,"COUNTS_vs_SAMPLE_1D_R3");
     }
   }
+
+  // also get # of events that made it into each OnlMon Server
+  TH1 *tpcmoneventsebdc[24] = {nullptr}; 
+
+  char TPCMON_STR2[100];
+  for( int i=0; i<24; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR2,"TPCMON_%i",i);
+    tpcmoneventsebdc[i] = (TH1*) cl->getHisto(TPCMON_STR2,"NEvents_vs_EBDC");
+  }
   
   if (!gROOT->FindObject("ShifterTPCDriftWindow"))
   {
@@ -3955,7 +3966,23 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
     //messages->Clear();
     messages[i] = new TPaveText(0.1,0.5,0.4,0.9,"brNDC");  
     
-    if(  (R1_bad==1 || R2_bad==1) || R3_bad==1 )
+    if( (i == 21 || i == 22) || (i == 23) )
+    {
+      messages[i]->AddText("SECTOR NOT MONITORED"); ((TText*)messages[i]->GetListOfLines()->Last())->SetTextColor(kBlack);
+      MyTC->cd(i+5);
+      messages[i]->Draw("same");      
+    }
+    else if( tpcmoneventsebdc[i] )
+    {
+      if(tpcmoneventsebdc[i]->GetEntries() <  8000)
+      {
+        messages[i]->AddText("NOT ENOUGH STATS"); ((TText*)messages[i]->GetListOfLines()->Last())->SetTextColor(kBlue);
+        messages[i]->AddText("CHECK AGAIN"); ((TText*)messages[i]->GetListOfLines()->Last())->SetTextColor(kBlue);
+        MyTC->cd(i+5);
+        messages[i]->Draw("same");
+      }
+    }
+    else if(  (R1_bad==1 || R2_bad==1) || R3_bad==1 )
     {
       //std::cout<<"made it into the if statement for bad timing"<<std::endl;
       sprintf(bad_message,"Sector %i BAD",i);


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMonDraw.cc

**Changes:**

- Now we say EBDC21 - 23 are not monitored (as these correspond to the WC0 laser which is out for Run 24).
- Now we ask if an OnlMon server has > 8K Events, if not, say there's not enough stats to determine

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module

