### PR TITLE
Fix tpc leak

### DIFF
--- a/macros/ServerFuncs.C
+++ b/macros/ServerFuncs.C
@@ -17,7 +17,7 @@ void start_server(const std::string &prdffile = "")
   }
   if (prdffile.find("seb") == 0 || prdffile.find("ebdc") == 0 || prdffile.find("intt") == 0 || prdffile.find("mvtx") == 0 || prdffile.find("test") == 0 || prdffile.find("gl1") == 0)
   {
-    pidentify(0);
+    //pidentify(0);
     rcdaqopen(prdffile.c_str());
     prun();
     //  if the rcdaq server is terminated we execute the EndRun and then
@@ -26,6 +26,26 @@ void start_server(const std::string &prdffile = "")
     se->WriteHistoFile();
     //      delete enablecorbabuf;
     CleanUpServer();
+  }
+  else
+  {
+    pfileopen(prdffile.c_str());
+  }
+  return;
+}
+
+void start_server_debug(const std::string &prdffile = "")
+{
+  OnlMonServer *se = OnlMonServer::instance();  // get pointer to Server Framework
+  if (prdffile.empty())
+  {
+    cout << "No Input file given" << endl;
+    return;
+  }
+  if (prdffile.find("seb") == 0 || prdffile.find("ebdc") == 0 || prdffile.find("intt") == 0 || prdffile.find("mvtx") == 0 || prdffile.find("test") == 0 || prdffile.find("gl1") == 0)
+  {
+    //pidentify(0);
+    rcdaqopen(prdffile.c_str());
   }
   else
   {

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -837,16 +837,16 @@ int TpcMon::process_event(Event *evt/* evt */)
   // the range for the TPC is really 4001...4032
   // we assume we start properly at 4001, but check if not
   
-  int firstpacket=4001;
+  int firstpacket=4000;
   //if (evt->existPacket(4000))
   //{
   //Packet *p = evt->getPacket(4000);
-  if(evt->getPacket(4000))
-  {
-    Packet *p = evt->getPacket(4000);
-    if (p->getHitFormat() == IDTPCFEEV3 || p->getHitFormat() == IDTPCFEEV4) firstpacket = 4000;
-    delete p;
-  }
+  // if(evt->getPacket(4000))
+  // {
+  //   Packet *p = evt->getPacket(4000);
+  //   if (p->getHitFormat() == IDTPCFEEV3 || p->getHitFormat() == IDTPCFEEV4) firstpacket = 4000;
+  //   delete p;
+  // }
   //}
   int lastpacket = firstpacket+232;
 

--- a/subsystems/tpot/TpotMonDraw.cc
+++ b/subsystems/tpot/TpotMonDraw.cc
@@ -19,8 +19,6 @@
 #include <TSystem.h>
 #include <TText.h>
 
-#include <boost/format.hpp>
-
 #include <cstring>  // for memset
 #include <ctime>
 #include <fstream>
@@ -1190,7 +1188,7 @@ void TpotMonDraw::draw_occupancy( TH2Poly* h)
     const auto bin = h->FindBin(x,y);
     const auto value =h->GetBinContent(bin);
     // const auto value = std::round(h->GetBinContent( bin )*100)/100;
-    TText().DrawText( x-0.8*m_geometry.m_tile_length/2, y, (boost::format("%.2f %%")%value).str().c_str() );
+    TText().DrawText( x-0.8*m_geometry.m_tile_length/2, y, Form("%.2f %%",value));
   }
 }
 
@@ -1375,8 +1373,8 @@ int TpotMonDraw::draw_array( const std::string& name, const TpotMonDraw::histogr
       { gPad->SetLogz( true ); }
 
       // draw detector name
-      const auto label = boost::format( "%s (%02i)" ) %  m_detnames_sphenix[i] % m_mapping.get_fee_id_list()[i];
-      draw_text( (i%4) ? 0.5:0.6, 0.9, label.str().c_str(), (i%4) ? 0.1:0.094 );
+      const auto label = Form( "%s (%02i)", m_detnames_sphenix[i].c_str(), m_mapping.get_fee_id_list()[i]);
+      draw_text( (i%4) ? 0.5:0.6, 0.9, label, (i%4) ? 0.1:0.094 );
       // draw_text( 0.7, 0.9, m_detnames_sphenix[i].c_str(), (i%4) ? 0.1:0.094 );
       drawn = true;
     }


### PR DESCRIPTION
This PR fixes a leak in the check for packet 4000. In the end it must be a decoder problem. It fetched packet 4000, deleted it and then fetched it again. This lead to a leak in the first fetching.
The tpot used boost::format, but sadly boost is not installed on all ebdc's so the monitoring doesn't compile on e.g. ebdc00. Falling back to TString::Form