### PR TITLE
Tpc pkt vector

### DIFF
--- a/onlmonserver/pmonitorInterface.cc
+++ b/onlmonserver/pmonitorInterface.cc
@@ -254,10 +254,7 @@ static void *server(void * /* arg */)
   sleep(5);
   do
   {
-    if (ss)
-    {
-      delete ss;
-    }
+    delete ss; // ok to delete nullptr
     ss = new TServerSocket(MoniPort, kTRUE);
     // Accept a connection and return a full-duplex communication socket.
     Onlmonserver->PortNumber(MoniPort);

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -837,7 +837,7 @@ int TpcMon::process_event(Event *evt/* evt */)
   // the range for the TPC is really 4001...4032
   // we assume we start properly at 4001, but check if not
   
-  int firstpacket=4000;
+//  int firstpacket=4000;
   //if (evt->existPacket(4000))
   //{
   //Packet *p = evt->getPacket(4000);
@@ -848,15 +848,17 @@ int TpcMon::process_event(Event *evt/* evt */)
   //   delete p;
   // }
   //}
-  int lastpacket = firstpacket+232;
+//  int lastpacket = firstpacket+232;
 
   NEvents_vs_EBDC->Fill(MonitorServerId());
   //std::cout<<"Event #"<< evtcnt <<std::endl;
 
+    std::vector<Packet *> pktvec = evt->getPacketVector();
   //  if( evtcnt >= 1200 ){ //evtcnt debug  
-  for( int packet = firstpacket; packet < lastpacket; packet++) //packet 4001 or 4002 = Sec 00, packet 4231 or 4232 = Sec 23
+  //for( int packet = firstpacket; packet < lastpacket; packet++) //packet 4001 or 4002 = Sec 00, packet 4231 or 4232 = Sec 23
+    for (auto p : pktvec)
   {
-    Packet* p = evt->getPacket(packet);
+//    Packet* p = evt->getPacket(packet);
     if (!p)
     {
       //std::cout << "TpcMon::process_event - No packet numbered " << packet << " in this event!!" << std::endl;
@@ -890,14 +892,41 @@ int TpcMon::process_event(Event *evt/* evt */)
           current_BCOBIN++;
         }
 
-
-        if( p->iValue(wf,"TYPE")==0 ){Packet_Type_Fraction_HB->Fill(0.5);} //HEARTBEAT_T 0b000
-        if( p->iValue(wf,"TYPE")==1 ){Packet_Type_Fraction_ELSE->Fill(1.5);} //TRUNCATED_DATA_T 0b001
-        if( p->iValue(wf,"TYPE")==3 ){Packet_Type_Fraction_ELSE->Fill(2.5);} //TRUNCATED_TRIG_EARLY_DATA_T 0b011
-        if( p->iValue(wf,"TYPE")==4 ){Packet_Type_Fraction_NORM->Fill(3.5);} //NORMAL_DATA_T 0b100
-        if( p->iValue(wf,"TYPE")==5 ){Packet_Type_Fraction_ELSE->Fill(4.5);} //LARGE_DATA_T 0b101
-        if( p->iValue(wf,"TYPE")==6 ){Packet_Type_Fraction_ELSE->Fill(5.5);} //TRIG_EARLY_DATA_T 0b110
-        if( p->iValue(wf,"TYPE")==7 ){Packet_Type_Fraction_ELSE->Fill(6.5);} //TRIG_EARLY_LARGE_DATA_T 0b111
+	int type = p->iValue(wf,"TYPE");
+	switch(type)
+	{
+	case 0:
+	  Packet_Type_Fraction_HB->Fill(0.5); //HEARTBEAT_T 0b000
+	  break;
+	case 1:
+	  Packet_Type_Fraction_ELSE->Fill(1.5); //TRUNCATED_DATA_T 0b001
+	  break;
+	case 3:
+	  Packet_Type_Fraction_ELSE->Fill(2.5); //TRUNCATED_TRIG_EARLY_DATA_T 0b011
+	  break;
+	case 4:
+	  Packet_Type_Fraction_NORM->Fill(3.5); //NORMAL_DATA_T 0b100
+	  break;
+	case 5:
+	  Packet_Type_Fraction_ELSE->Fill(4.5); //LARGE_DATA_T 0b101
+	  break;
+	case 6:
+	  Packet_Type_Fraction_ELSE->Fill(5.5); //TRIG_EARLY_DATA_T 0b110
+	  break;
+	case 7:
+	  Packet_Type_Fraction_ELSE->Fill(6.5); //TRIG_EARLY_LARGE_DATA_T 0b111
+	  break;
+	default:
+	  std::cout << "unhandled type: " << type << std::endl;
+	  break;
+	}
+        // if( p->iValue(wf,"TYPE")==0 ){Packet_Type_Fraction_HB->Fill(0.5);} //HEARTBEAT_T 0b000
+        // if( p->iValue(wf,"TYPE")==1 ){Packet_Type_Fraction_ELSE->Fill(1.5);} //TRUNCATED_DATA_T 0b001
+        // if( p->iValue(wf,"TYPE")==3 ){Packet_Type_Fraction_ELSE->Fill(2.5);} //TRUNCATED_TRIG_EARLY_DATA_T 0b011
+        // if( p->iValue(wf,"TYPE")==4 ){Packet_Type_Fraction_NORM->Fill(3.5);} //NORMAL_DATA_T 0b100
+        // if( p->iValue(wf,"TYPE")==5 ){Packet_Type_Fraction_ELSE->Fill(4.5);} //LARGE_DATA_T 0b101
+        // if( p->iValue(wf,"TYPE")==6 ){Packet_Type_Fraction_ELSE->Fill(5.5);} //TRIG_EARLY_DATA_T 0b110
+        // if( p->iValue(wf,"TYPE")==7 ){Packet_Type_Fraction_ELSE->Fill(6.5);} //TRIG_EARLY_LARGE_DATA_T 0b111
 
         const int n_tagger = p->lValue(0, "N_TAGGER");
         for (int t = 0; t < n_tagger; t++)


### PR DESCRIPTION
This PR replaces the hardcoded packet range by using the vector api, where the decoder hands off a vector with packet pointers. Looking at the TpcMon code - it ignores special events (e.g. begin/end run) which contain different packets. So this should be safe