### PR TITLE
Removing Sector Not Monitored from Sectors 21,22,23

### DIFF
--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -3966,13 +3966,15 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
     //messages->Clear();
     messages[i] = new TPaveText(0.1,0.5,0.4,0.9,"brNDC");  
     
+    /*
     if( (i == 21 || i == 22) || (i == 23) )
     {
       messages[i]->AddText("SECTOR NOT MONITORED"); ((TText*)messages[i]->GetListOfLines()->Last())->SetTextColor(kBlack);
       MyTC->cd(i+5);
       messages[i]->Draw("same");      
     }
-    else if( tpcmoneventsebdc[i] )
+    */
+    if( tpcmoneventsebdc[i] )
     {
       if(tpcmoneventsebdc[i]->GetEntries() <  8000)
       {


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMonDraw.cc

**Changes:**

- Since 10/01, the six diffuse laser (WC0 - Sectors 21,22,23,12 - 6-9 o'clock SS) [has been installed](https://docs.google.com/document/d/1uUoqg_9nrN5zMWRCbUrCh0MwYy4pxXea5pnjOaUwecc/edit). Therefore, we are NOW monitoring those sectors. Comment out L3970-3975 and change else if -> if on L3977.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module

