### PR TITLE
Changing drift velocity in ZY to accomodate Ar:CF4:Iso (75:20:5)

### DIFF
--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -1158,7 +1158,10 @@ int TpcMon::process_event(Event *evt/* evt */)
           else if(Module_ID(fee)==1){NorthSideADC_clusterXY_R2->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max);NorthSideADC_clusterXY_R2_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R2
           else if(Module_ID(fee)==2){NorthSideADC_clusterXY_R3->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max);NorthSideADC_clusterXY_R3_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R3
 
-          if( t_max >= 10 && t_max <=255 ){z = 1030 - (t_max - 10)*(50 * 0.084);NorthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);NorthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
+	  //old gas (Ar:CF4 - 60:40)
+          //if( t_max >= 10 && t_max <=255 ){z = 1030 - (t_max - 10)*(50 * 0.084);NorthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);NorthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
+          //new gas (Ar:CF4:ISO - 75:20:5)
+          if( t_max >= 40 && t_max <=320 ){z = 1030 - (t_max - 40)*(50 * 0.0735);NorthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);NorthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
         }
         else if( (serverid >=12 && (pedest_sub_wf_max) > std::max(5.0*noise,20.)) && layer != 0)
         {
@@ -1166,7 +1169,10 @@ int TpcMon::process_event(Event *evt/* evt */)
           else if(Module_ID(fee)==1){SouthSideADC_clusterXY_R2->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterXY_R2_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R2
           else if(Module_ID(fee)==2){SouthSideADC_clusterXY_R3->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterXY_R3_unw->Fill(R*cos(phi),R*sin(phi));} //Raw 1D for R3
 
-          if( t_max >= 10 && t_max <=255 ){z = -1030 + (t_max - 10)*(50 * 0.084);SouthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
+          //old gas (Ar:CF4 - 60:40)
+          //if( t_max >= 10 && t_max <=255 ){z = -1030 + (t_max - 10)*(50 * 0.084);SouthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
+          //new gas (Ar:CF4:ISO - 75:20:5)
+          if( t_max >= 40 && t_max <=320 ){z = -1030 + (t_max - 40)*(50 * 0.0735);SouthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
         }
         //________________________________________________________________________________
         //XY laser peak


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.cc

**Changes:**

- L1164 & L1175 - making drift velocity 0.0735 (mm/ns). And the T0 is approx 40 samples in w/ T_drift_end is approx 320.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module

