### PR TITLE
New monitor for finding noisy channels in pedestal runs

### DIFF
--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -103,6 +103,8 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("Packet_Type_Fraction_HB",servername);
     cl->registerHisto("Packet_Type_Fraction_NORM",servername);
     cl->registerHisto("Packet_Type_Fraction_ELSE",servername);
+
+    cl->registerHisto("Noise_Channel_Plots",servername);
   } //
 
 

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -709,6 +709,19 @@ int TpcMon::Init()
   Packet_Type_Fraction_ELSE -> GetYaxis() -> SetTitleSize(0.08);
   Packet_Type_Fraction_ELSE -> GetYaxis() -> SetTitleOffset(0.6);
 
+  char Noise_Channel_Plots_title_str[256];
+  sprintf(Noise_Channel_Plots_title_str,"Counts of ADC-Ped. > 300, t < 360 ,Sector # %i",MonitorServerId());
+  Noise_Channel_Plots = new TH1F("Noise_Channel_Plots","",6656,-0.5,6655.5);
+  Noise_Channel_Plots -> GetXaxis() -> SetLabelSize(0.05);
+  Noise_Channel_Plots -> GetXaxis() -> SetTitleSize(0.05);
+  Noise_Channel_Plots -> GetYaxis() -> SetLabelSize(0.05);
+  Noise_Channel_Plots -> GetYaxis() -> SetTitleSize(0.05);
+  Noise_Channel_Plots -> GetYaxis() -> SetTitleOffset(1.0);
+
+  Noise_Channel_Plots->SetXTitle("(FEE # * 256) + chan. #");
+  Noise_Channel_Plots->SetYTitle("Counts/Event");
+  Noise_Channel_Plots->SetStats(0); 
+
   OnlMonServer *se = OnlMonServer::instance();
   // register histograms with server otherwise client won't get them
   se->registerHisto(this, NorthSideADC);
@@ -788,6 +801,8 @@ int TpcMon::Init()
   se->registerHisto(this, Packet_Type_Fraction_HB);
   se->registerHisto(this, Packet_Type_Fraction_NORM);
   se->registerHisto(this, Packet_Type_Fraction_ELSE);
+
+  se->registerHisto(this, Noise_Channel_Plots);
 
   Reset();
   return 0;
@@ -1076,6 +1091,11 @@ int TpcMon::process_event(Event *evt/* evt */)
           //int t = s + 2 * (current_BCO - starting_BCO);
 
           int adc = p->iValue(wf,s);
+
+          if( ((adc-pedestal) > 300 && (adc < 1500)) && s < 360){
+	    //std::cout<<"FEE #: "<<fee<<", channel #: "<<channel<<", sample: "<<s<<", adc-pedestal: "<<(adc-pedestal)<<std::endl;
+            Noise_Channel_Plots->Fill(channel + (256*FEE_transform[fee]));
+          } // only intended to be looked at during pedestal runs with 360 time samples
 
 	  //std::cout<<"adc = "<<adc<<" ADC, FEE = "<<fee<<", channel: "<<channel<<", layer: "<<layer<<", phi: "<<phi<<", event num: "<<evtcnt<<std::endl;
 

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -48,7 +48,12 @@ TpcMon::TpcMon(const std::string &name)
   starting_BCO = -1;
   rollover_value = 0;
   current_BCOBIN = 0;
+  //Evgeny Map
   M.setMapNames("AutoPad-R1-RevA.sch.ChannelMapping.csv", "AutoPad-R2-RevA-Pads.sch.ChannelMapping.csv", "AutoPad-R3-RevA.sch.ChannelMapping.csv");
+  //Mariia MAp
+  // M.setMapNames("../../../../../../../../../../../sphenix/user/mitrankova/PadPlane_Readout/map/AutoPad-R1-RevA.sch.ChannelMapping.csv", 
+  //               "../../../../../../../../../../../sphenix/user/mitrankova/PadPlane_Readout/map/AutoPad-R2-RevA-Pads.sch.ChannelMapping.csv", 
+  //               "../../../../../../../../../../../sphenix/user/mitrankova/PadPlane_Readout/map/AutoPad-R3-RevA.sch.ChannelMapping.csv");
   return;
 }
 
@@ -230,7 +235,7 @@ int TpcMon::Init()
   char ADC_vs_SAMPLE_str[100];
   char ADC_vs_SAMPLE_xaxis_str[100];
   sprintf(ADC_vs_SAMPLE_str,"ADC Counts vs Sample: SECTOR %i",MonitorServerId());
-  sprintf(ADC_vs_SAMPLE_xaxis_str,"Sector %i: ADC Time bin [1/20MHz]",MonitorServerId());
+  sprintf(ADC_vs_SAMPLE_xaxis_str,"Sector %i: ADC Time bin [1/17.5MHz]",MonitorServerId());
   ADC_vs_SAMPLE = new TH2F("ADC_vs_SAMPLE", ADC_vs_SAMPLE_str, 500, 0, 500, 256, 0, 1024);
   ADC_vs_SAMPLE -> SetXTitle(ADC_vs_SAMPLE_xaxis_str);
   ADC_vs_SAMPLE -> SetYTitle("ADC [ADU]");
@@ -245,7 +250,7 @@ int TpcMon::Init()
   char PEDEST_SUB_ADC_vs_SAMPLE_str[100];
   char PEDEST_SUB_ADC_vs_SAMPLE_xaxis_str[100];
   sprintf(PEDEST_SUB_ADC_vs_SAMPLE_str,"ADC Counts vs Sample: SECTOR %i",MonitorServerId());
-  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_xaxis_str,"Sector %i: ADC Time bin [1/20MHz]",MonitorServerId());
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_xaxis_str,"Sector %i: ADC Time bin [1/17.5MHz]",MonitorServerId());
   PEDEST_SUB_ADC_vs_SAMPLE = new TH2F("PEDEST_SUB_ADC_vs_SAMPLE", PEDEST_SUB_ADC_vs_SAMPLE_str, 500, 0, 500, 281, -100, 1024);
   PEDEST_SUB_ADC_vs_SAMPLE -> SetXTitle(PEDEST_SUB_ADC_vs_SAMPLE_xaxis_str);
   PEDEST_SUB_ADC_vs_SAMPLE -> SetYTitle("ADC-ped. [ADU]");
@@ -260,7 +265,7 @@ int TpcMon::Init()
   char PEDEST_SUB_ADC_vs_SAMPLE_R1_str[100];
   char PEDEST_SUB_ADC_vs_SAMPLE_R1_xaxis_str[100];
   sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R1_str,"ADC Counts vs Sample: SECTOR %i R1",MonitorServerId());
-  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R1_xaxis_str,"Sector %i R1: ADC Time bin [1/20MHz]",MonitorServerId());
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R1_xaxis_str,"Sector %i R1: ADC Time bin [1/17.5MHz]",MonitorServerId());
   PEDEST_SUB_ADC_vs_SAMPLE_R1 = new TH2F("PEDEST_SUB_ADC_vs_SAMPLE_R1", PEDEST_SUB_ADC_vs_SAMPLE_R1_str, 500, 0, 500, 281, -100, 1024);
   PEDEST_SUB_ADC_vs_SAMPLE_R1 -> SetXTitle(PEDEST_SUB_ADC_vs_SAMPLE_R1_xaxis_str);
   PEDEST_SUB_ADC_vs_SAMPLE_R1 -> SetYTitle("ADC-ped. [ADU]");
@@ -275,7 +280,7 @@ int TpcMon::Init()
   char PEDEST_SUB_ADC_vs_SAMPLE_R2_str[100];
   char PEDEST_SUB_ADC_vs_SAMPLE_R2_xaxis_str[100];
   sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R2_str,"ADC Counts vs Sample: SECTOR %i R2",MonitorServerId());
-  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R2_xaxis_str,"Sector %i R2: ADC Time bin [1/20MHz]",MonitorServerId());
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R2_xaxis_str,"Sector %i R2: ADC Time bin [1/17.5MHz]",MonitorServerId());
   PEDEST_SUB_ADC_vs_SAMPLE_R2 = new TH2F("PEDEST_SUB_ADC_vs_SAMPLE_R2", PEDEST_SUB_ADC_vs_SAMPLE_R2_str, 500, 0, 500, 281, -100, 1024);
   PEDEST_SUB_ADC_vs_SAMPLE_R2 -> SetXTitle(PEDEST_SUB_ADC_vs_SAMPLE_R2_xaxis_str);
   PEDEST_SUB_ADC_vs_SAMPLE_R2 -> SetYTitle("ADC-ped. [ADU]");
@@ -290,7 +295,7 @@ int TpcMon::Init()
   char PEDEST_SUB_ADC_vs_SAMPLE_R3_str[100];
   char PEDEST_SUB_ADC_vs_SAMPLE_R3_xaxis_str[100];
   sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R3_str,"ADC Counts vs Sample: SECTOR %i R3",MonitorServerId());
-  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R3_xaxis_str,"Sector %i R3: ADC Time bin [1/20MHz]",MonitorServerId());
+  sprintf(PEDEST_SUB_ADC_vs_SAMPLE_R3_xaxis_str,"Sector %i R3: ADC Time bin [1/17.5MHz]",MonitorServerId());
   PEDEST_SUB_ADC_vs_SAMPLE_R3 = new TH2F("PEDEST_SUB_ADC_vs_SAMPLE_R3", PEDEST_SUB_ADC_vs_SAMPLE_R3_str, 500, 0, 500, 281, -100, 1024);
   PEDEST_SUB_ADC_vs_SAMPLE_R3 -> SetXTitle(PEDEST_SUB_ADC_vs_SAMPLE_R3_xaxis_str);
   PEDEST_SUB_ADC_vs_SAMPLE_R3 -> SetYTitle("ADC-ped. [ADU]");
@@ -305,7 +310,7 @@ int TpcMon::Init()
   char ADC_vs_SAMPLE_large_str[100];
   char ADC_vs_SAMPLE_xaxis_large_str[100];
   sprintf(ADC_vs_SAMPLE_large_str,"ADC Counts vs Large Sample: SECTOR %i",MonitorServerId());
-  sprintf(ADC_vs_SAMPLE_xaxis_large_str,"Sector %i: ADC Time bin [1/20MHz]",MonitorServerId());
+  sprintf(ADC_vs_SAMPLE_xaxis_large_str,"Sector %i: ADC Time bin [1/17.5MHz]",MonitorServerId());
   ADC_vs_SAMPLE_large = new TH2F("ADC_vs_SAMPLE_large", ADC_vs_SAMPLE_large_str, 1080, 0, 1080, 256, 0, 1024);
   ADC_vs_SAMPLE_large -> SetXTitle(ADC_vs_SAMPLE_xaxis_large_str);
 
@@ -436,8 +441,8 @@ int TpcMon::Init()
   char ZS_ADC_vs_SAMPLE_str[100];
   char ZS_ADC_vs_SAMPLE_xaxis_str[100];
   sprintf(ZS_ADC_vs_SAMPLE_str,"ADC Counts vs Sample - Trigger QA: SECTOR %i",MonitorServerId());
-  sprintf(ZS_ADC_vs_SAMPLE_xaxis_str,"Sector %i: ADC Time bin [1/20MHz]",MonitorServerId());
-  ZS_Trigger_ADC_vs_Sample = new TH2F("ZS_Trigger_ADC_vs_Sample", ZS_ADC_vs_SAMPLE_str, 500, -0.5, 499.5, 1024, 0, 1024);
+  sprintf(ZS_ADC_vs_SAMPLE_xaxis_str,"Sector %i: ADC Time bin [1/17.5MHz]",MonitorServerId());
+  ZS_Trigger_ADC_vs_Sample = new TH2F("ZS_Trigger_ADC_vs_Sample", ZS_ADC_vs_SAMPLE_str, 500, 0, 500, 1024, 0, 1024);
   ZS_Trigger_ADC_vs_Sample -> SetXTitle(ZS_ADC_vs_SAMPLE_xaxis_str);
   ZS_Trigger_ADC_vs_Sample -> SetYTitle("ADC [ADU]");
 
@@ -451,8 +456,8 @@ int TpcMon::Init()
   char First_ADC_vs_First_Time_Bin_str[100];
   char First_ADC_vs_First_Time_Bin_xaxis_str[100];
   sprintf(First_ADC_vs_First_Time_Bin_str,"1st nonZS ADC vs 1st nonZS Sample Time: SECTOR %i",MonitorServerId());
-  sprintf(First_ADC_vs_First_Time_Bin_xaxis_str,"Sector %i: 1st non-ZS Time bin [1/20MHz]",MonitorServerId());
-  First_ADC_vs_First_Time_Bin = new TH2F("First_ADC_vs_First_Time_Bin", First_ADC_vs_First_Time_Bin_str, 500, -0.5, 499.5, 256, 0, 1024);
+  sprintf(First_ADC_vs_First_Time_Bin_xaxis_str,"Sector %i: 1st non-ZS Time bin [1/17.5MHz]",MonitorServerId());
+  First_ADC_vs_First_Time_Bin = new TH2F("First_ADC_vs_First_Time_Bin", First_ADC_vs_First_Time_Bin_str, 500, 0, 500, 256, 0, 1024);
   First_ADC_vs_First_Time_Bin -> SetXTitle(First_ADC_vs_First_Time_Bin_xaxis_str);
   First_ADC_vs_First_Time_Bin -> SetYTitle("1st non-ZS ADC [ADU]");
 
@@ -492,7 +497,7 @@ int TpcMon::Init()
   sprintf(MAXADC_1D_titlestr,"MAX ADC in SLIDING WINDOW for Sector %i R1",MonitorServerId());
   sprintf(SUBADC_1D_titlestr,"PEDEST_SUB RAW ADC for Sector %i R1",MonitorServerId());
   sprintf(COUNTS_SAMPLE_1D_titlestr,"COUNTS_vs_SAMPLE for Sector %i R1",MonitorServerId());
-  sprintf(COUNTS_SAMPLE_1D_xtitlestr,"Sector %i: Time bin [1/20MHz]",MonitorServerId()); 
+  sprintf(COUNTS_SAMPLE_1D_xtitlestr,"Sector %i: Time bin [1/17.5MHz]",MonitorServerId()); 
 
   RAWADC_1D_R1 = new TH1F("RAWADC_1D_R1",RAWADC_1D_titlestr,1025,-0.5,1024.5);
   MAXADC_1D_R1 = new TH1F("MAXADC_1D_R1",MAXADC_1D_titlestr,1025,-0.5,1024.5);
@@ -908,7 +913,7 @@ int TpcMon::process_event(Event *evt/* evt */)
         }
 
 	int type = p->iValue(wf,"TYPE");
-	switch(type)
+        switch(type)
 	{
 	case 0:
 	  Packet_Type_Fraction_HB->Fill(0.5); //HEARTBEAT_T 0b000
@@ -991,7 +996,7 @@ int TpcMon::process_event(Event *evt/* evt */)
         // getting R and Phi coordinates
         double R = M.getR(feeM, channel);
         double padphi = 0;
-
+	
         if( side(serverid) == 0 ) //NS
         {
           padphi =  M.getPad(feeM, channel) + (serverid ) * (2304./12.); 
@@ -1000,12 +1005,14 @@ int TpcMon::process_event(Event *evt/* evt */)
         {
           padphi = -M.getPad(feeM, channel) - (serverid-12) * (2304./12) ; 
         }
-
+	        
         int layer = M.getLayer(feeM, channel) + (serverid);
         double phi = 0;
 
         //double phi = M.getPhi(feeM, channel) + (serverid - 12*side(serverid)) * M_PI / 6 ;
 
+	
+        //Evgeny Map
         if( side(serverid) == 0 ) //NS
         {
           phi = M.getPhi(feeM, channel) + (serverid ) * M_PI / 6 ; 
@@ -1014,7 +1021,19 @@ int TpcMon::process_event(Event *evt/* evt */)
         {
           phi = M.getPhi(feeM, channel) + (18 - serverid ) * M_PI / 6 ; 
         }
+	
 
+        /*
+        //Mariia map
+        if( side(serverid) == 0 ) //NS
+        {
+          phi = M.getPhi(feeM, channel) + (serverid ) * M_PI / 6    - (M_PI/2.) ; 
+        }
+        else if( side(serverid) == 1 ) //SS
+        {
+          phi = M.getPhi(feeM, channel) + (18 - serverid ) * M_PI / 6 - (- M_PI/2.) ; 
+        }
+	*/
         //std::cout<<"Sector = "<< serverid <<" FEE = "<<fee<<" channel = "<<channel<<std::endl;
 
         //int mid = floor(360/2); //get median sample from 0-360 (we are assuming the sample > 360 is not useful to us as of 05.01.24)
@@ -1106,7 +1125,7 @@ int TpcMon::process_event(Event *evt/* evt */)
 
           if( adc > wf_max){ wf_max = adc; t_max = s; pedest_sub_wf_max = adc - pedestal;}
 
-          if( (s> 410 && s < 422) && (adc > wf_max_laser_peak) ){ wf_max_laser_peak = adc; pedest_sub_wf_max_laser_peak = adc - pedestal; }   
+          if( (s> 362 && s < 374) && (adc > wf_max_laser_peak) ){ wf_max_laser_peak = adc; pedest_sub_wf_max_laser_peak = adc - pedestal; } //old peak near 416, new peak near 403-404 wth 50 ns clock, 368 with 57.14 ns clock   
 
           if( (store_ten.size() < 10) ) // get first 10
           {
@@ -1181,7 +1200,8 @@ int TpcMon::process_event(Event *evt/* evt */)
 	  //old gas (Ar:CF4 - 60:40)
           //if( t_max >= 10 && t_max <=255 ){z = 1030 - (t_max - 10)*(50 * 0.084);NorthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);NorthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
           //new gas (Ar:CF4:ISO - 75:20:5)
-          if( t_max >= 40 && t_max <=320 ){z = 1030 - (t_max - 40)*(50 * 0.0735);NorthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);NorthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
+          //if( t_max >= 40 && t_max <=320 ){z = 1030 - (t_max - 40)*(50 * 0.0735);NorthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);NorthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}//50 clock
+          if( t_max >= 50 && t_max <=330 ){z = 1030 - (t_max - 50)*(57.14 * 0.0735);NorthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);NorthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}//57 clock
         }
         else if( (serverid >=12 && (pedest_sub_wf_max) > std::max(5.0*noise,20.)) && layer != 0)
         {
@@ -1192,17 +1212,18 @@ int TpcMon::process_event(Event *evt/* evt */)
           //old gas (Ar:CF4 - 60:40)
           //if( t_max >= 10 && t_max <=255 ){z = -1030 + (t_max - 10)*(50 * 0.084);SouthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
           //new gas (Ar:CF4:ISO - 75:20:5)
-          if( t_max >= 40 && t_max <=320 ){z = -1030 + (t_max - 40)*(50 * 0.0735);SouthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}
+          //if( t_max >= 40 && t_max <=320 ){z = -1030 + (t_max - 40)*(50 * 0.0735);SouthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}//50 clock
+          if( t_max >= 50 && t_max <=330 ){z = -1030 + (t_max - 50)*(57.14 * 0.0735);SouthSideADC_clusterZY->Fill(z,R*sin(phi),pedest_sub_wf_max);SouthSideADC_clusterZY_unw->Fill(z,R*sin(phi));}//57 clock
         }
         //________________________________________________________________________________
         //XY laser peak
-        if( (serverid < 12 && (pedest_sub_wf_max_laser_peak) > std::max(5.0*noise,20.)) && ((t_max > 410 && t_max < 422) && (layer != 0))) // only fill if the laser was the max
+        if( (serverid < 12 && (pedest_sub_wf_max_laser_peak) > std::max(5.0*noise,20.)) && ((t_max > 362 && t_max < 374) && (layer != 0))) // only fill if the laser was the max old peak 416, new 403 w/ 50 clock, 368 w/ 57.14 clock
         {
           if(Module_ID(fee)==0){NorthSideADC_clusterXY_R1_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R1
           else if(Module_ID(fee)==1){NorthSideADC_clusterXY_R2_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R2
           else if(Module_ID(fee)==2){NorthSideADC_clusterXY_R3_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R3
         }
-        else if( (serverid >=12 && (pedest_sub_wf_max_laser_peak) > std::max(5.0*noise,20.)) && ((t_max > 410 && t_max < 422) && (layer != 0))) // only fill if the laser was the max
+        else if( (serverid >=12 && (pedest_sub_wf_max_laser_peak) > std::max(5.0*noise,20.)) && ((t_max > 362 && t_max < 374) && (layer != 0))) // only fill if the laser was the max old peak 416, new 403 w/ 50 clock, 368 w/ 57.14 clock 
         {
           if(Module_ID(fee)==0){SouthSideADC_clusterXY_R1_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R1
           else if(Module_ID(fee)==1){SouthSideADC_clusterXY_R2_LASER->Fill(R*cos(phi),R*sin(phi),pedest_sub_wf_max_laser_peak);} //Raw 1D for R2

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -140,6 +140,8 @@ class TpcMon : public OnlMon
   TH1 *Packet_Type_Fraction_NORM = nullptr;
   TH1 *Packet_Type_Fraction_ELSE = nullptr;
 
+  TH1 *Noise_Channel_Plots = nullptr;
+
   TpcMap M; //declare Martin's map
 
   int starting_BCO;

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -3257,10 +3257,10 @@ int TpcMonDraw::DrawTPCDriftWindow(const std::string & /* what */)
     {
       if( tpcmon_DriftWindow[i][j] )
       {
-        for( int k = 1; k < tpcmon_DriftWindow[i][j]->GetNbinsX(); k++ )
+        for( int k = 1; k < tpcmon_DriftWindow[i][j]->GetNbinsX(); k++ ) // old laser peak 416, new laser peak 403, new laser peak w/ 57.14 ns clock 368
 	{
-          if( (k>=0 && k<=390) || (k>420) ){ no_laser_window = 1;}
-          if( k>390 && k<=420){ no_laser_window = 0;}
+          if( (k>=0 && k<=350) || (k>380) ){ no_laser_window = 1;}
+          if( k>350 && k<=380){ no_laser_window = 0;}
           if( (tpcmon_DriftWindow[i][j]->GetBinContent(k) > no_laser_max && tpcmon_DriftWindow[i][j]->GetBinContent(k) > 0) && (no_laser_window==1) ){no_laser_max = tpcmon_DriftWindow[i][j]->GetBinContent(k);}
           if( tpcmon_DriftWindow[i][j]->GetBinContent(k) > max && tpcmon_DriftWindow[i][j]->GetBinContent(k) > 0 ){max = tpcmon_DriftWindow[i][j]->GetBinContent(k);}
           if( tpcmon_DriftWindow[i][j]->GetBinContent(k) < min && tpcmon_DriftWindow[i][j]->GetBinContent(k) > 0 ){min = tpcmon_DriftWindow[i][j]->GetBinContent(k);}
@@ -3942,15 +3942,15 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
     if( tpcmon_DriftWindow_shifter[i][1] ){  R2_max = tpcmon_DriftWindow_shifter[i][1]->GetBinCenter(tpcmon_DriftWindow_shifter[i][1]->GetMaximumBin());}
     if( tpcmon_DriftWindow_shifter[i][2] ){  R3_max = tpcmon_DriftWindow_shifter[i][2]->GetBinCenter(tpcmon_DriftWindow_shifter[i][2]->GetMaximumBin());}
 
-    if( (R1_max>std::numeric_limits<int>::min() && (R1_max < 413)) || R1_max > 423 ){ R1_bad = 1;} 
-    if( (R2_max>std::numeric_limits<int>::min() && (R2_max < 413)) || R2_max > 423 ){ R2_bad = 1;} 
-    if( (R3_max>std::numeric_limits<int>::min() && (R3_max < 413)) || R3_max > 423 ){ R3_bad = 1;}
+    if( (R1_max>std::numeric_limits<int>::min() && (R1_max < 365)) || R1_max > 374 ){ R1_bad = 1;} // old peak - 416, new peak 403 50 ns clock, new peak 368 57.14 ns clock 
+    if( (R2_max>std::numeric_limits<int>::min() && (R2_max < 365)) || R2_max > 374 ){ R2_bad = 1;} 
+    if( (R3_max>std::numeric_limits<int>::min() && (R3_max < 365)) || R3_max > 374 ){ R3_bad = 1;}
 
     for( int l = 2; l>-1; l-- )
     {
       if( tpcmon_DriftWindow_shifter[i][l] )
       {
-        tpcmon_DriftWindow_shifter[i][l]->GetXaxis()->SetRangeUser(390,440);
+        tpcmon_DriftWindow_shifter[i][l]->GetXaxis()->SetRangeUser(346,396); // old peak - 416, new peak 403, new peak 368 57.14 ns clock
         if(l == 2)
         { 
           tpcmon_DriftWindow_shifter[i][l]->GetYaxis()->SetRangeUser(0.9*min,1.3*max);tpcmon_DriftWindow_shifter[i][l] -> DrawCopy("HIST");
@@ -3962,8 +3962,8 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
       }
     }
 
-    t2->DrawLine(413,0.9*min,413,1.3*max);
-    t2->DrawLine(423,0.9*min,423,1.3*max);
+    t2->DrawLine(365,0.9*min,365,1.3*max);
+    t2->DrawLine(375,0.9*min,375,1.3*max);
     
     gPad->Update();  
 

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -59,12 +59,13 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCNStreaksvsEventNo(const std::string &what = "ALL");
   int DrawTPCNEventsvsEBDC(const std::string &what = "ALL");
   int DrawTPCPacketTypes(const std::string &what = "ALL");
+  int DrawTPCNoiseChannelPlots(const std::string &what = "ALL");
   int DrawShifterTPCDriftWindow(const std::string &what = "ALL");
   int DrawServerStats();
   time_t getTime();
   
-  TCanvas *TC[35] = {nullptr};
-  TPad *transparent[35] = {nullptr};
+  TCanvas *TC[36] = {nullptr};
+  TPad *transparent[36] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

subystems/tpc/TpcMon.cc
subystems/tpc/TpcMon.h
subystems/tpc/TpcMonDraw.cc
subystems/tpc/TpcMonDraw.h
macros/run_tpc_client.C

**Changes:**

- Adding monitor which identifies channels w/ adc-pedestal > 300 for s < 360 & adc > 2000. Meant for use in pedestal runs ONLY.

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module

