### PR TITLE
Adding shifter transmission button Poms GUI

### DIFF
--- a/macros/run_Poms.C
+++ b/macros/run_Poms.C
@@ -170,6 +170,7 @@ void StartPoms()
   subsys = new SubSystem("TPC SHIFTER", "tpc");
   subsys->AddAction("tpcDraw(\"SHIFTER_DRIFT_PLOT\")", "SHIFTER TPC DRIFT");
   subsys->AddAction("tpcDraw(\"TPCCLUSTERSXYWEIGTHED\")", "SHIFTER TPC ACCEPTANCE");
+  subsys->AddAction("tpcDraw(\"SHIFTER_TRANSMISSION_PLOT\")", "SHIFTER TPC TRANSMISSION");
   subsys->AddAction("tpcDraw(\"TPCCHANSPERLVL1NS\")", "SHIFTER TPC NS OCCUP.");
   subsys->AddAction("tpcDraw(\"TPCCHANSPERLVL1SS\")", "SHIFTER TPC SS OCCUP.");
   subsys->AddAction("tpcDraw(\"SERVERSTATS\")", "Server Stats");


### PR DESCRIPTION
**Files Affected:**

macros/run_Poms.C

**Changes:**

- L173, adding button for the TPC electron transmission

**CAVEAT - METHOD ONLY WORKS IN COSMICS RIGHT NOW**

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart
    Add messages back into diffuse laser and the transmission plots

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module

