### PR TITLE
Fixing TPCCHANSINPACKETSS and TPCCHANNELSPERLVL1SS

### DIFF
--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -3057,7 +3057,7 @@ int TpcMonDraw::DrawTPCChansinPacketSS(const std::string & /* what */)
 
   MyTC->SetEditable(true);
   MyTC->Clear("D");
-  for( int i=0; i<12; i++ ) 
+  for( int i=12; i<24; i++ ) 
   {
     if( tpcmon_chanpacketSS[i] && tpcmon_chanpacketalwaysSS[i] )
     {
@@ -3871,7 +3871,7 @@ int TpcMonDraw::DrawTPCChansperLVL1_SS(const std::string & /* what */)
 
   MyTC->SetEditable(true);
   MyTC->Clear("D");
-  for( int i=0; i<12; i++ ) 
+  for( int i=12; i<24; i++ ) 
   {
     if( tpcmon_chanlvl1SS[i] && lvl1_per_EBDC[i] )
     {
@@ -4631,7 +4631,7 @@ void TpcMonDraw::add_TH1(TH1* hist[48], TH1* histadd[24]) {
       if(!hist[i] && !hist[i+24]){continue;}
       if(hist[i] && !hist[i+24]){histadd[i] = (TH1*)hist[i]->Clone(Form("histadd_%d",i));}
       if(!hist[i] && hist[i+24]){histadd[i] = (TH1*)hist[i+24]->Clone(Form("histadd_%d",i));}
-      if(hist[i] && hist[i+24]){
+      if(hist[i] && hist[i+24]){;
 	histadd[i] = (TH1*)hist[i]->Clone(Form("histadd_%d",i));
         histadd[i]->Add(hist[i+24]);
       }


### PR DESCRIPTION
**Files Affected:**

subsystems/tpc/TpcMonDraw.cc

**Changes:**

- L3060 & L3874. Fixes bug where SS looping index wasn't right

**CAVEAT - TRANSMISSION METHOD ONLY WORKS IN COSMICS RIGHT NOW**

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart
    Add messages back into diffuse laser and the transmission plotsx`

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module

