### PR TITLE
draw ALLTRIGZS instead of SEVENTH in html which is done in Poms

### DIFF
--- a/subsystems/cemc/CemcMonDraw.cc
+++ b/subsystems/cemc/CemcMonDraw.cc
@@ -379,10 +379,10 @@ int CemcMonDraw::Draw(const std::string &what)
 // DO NOT ADD ANY OTHER METHOD AFTER THIS which gets called by "ALL"
   if (what == "ALL")
   {
-    iret += DrawSeventh("SEVENTH");
-    idraw++;
-    // iret += DrawSeventh("ALLTRIGZS");
-    // idraw++;
+//    iret += DrawSeventh("SEVENTH");
+//    idraw++;
+     iret += DrawSeventh("ALLTRIGZS");
+     idraw++;
   }
   if(what == "SEVENTH" || what == "ALLTRIGZS")
   {


### PR DESCRIPTION
The html by default created a different plot than what the shift crew saw for the zero suppression. It is now hardcoded to do the same things as Poms - please remember this when you change the drawing in Poms