### PR TITLE
Fix CEMC ZS plot html making

### DIFF
--- a/subsystems/cemc/CemcMonDraw.cc
+++ b/subsystems/cemc/CemcMonDraw.cc
@@ -2764,7 +2764,6 @@ int CemcMonDraw::DrawSeventh(const std::string &what)
   gStyle->SetTitleFontSize(0.06);
   gStyle->SetPalette(57);
   // gStyle->SetPalette(255, ZSPalette);
-  gStyle->SetNumberContours(255);
   p2_zsFrac_etaphiCombined->GetXaxis()->SetTitle("eta index");
   p2_zsFrac_etaphiCombined->GetYaxis()->SetTitle("phi index");
   p2_zsFrac_etaphiCombined->SetTitle(Form("Average unsuppressed rate: %.3f%%", averagezs));


### PR DESCRIPTION
During the EMCal ZS plot html making process we see this error:
```
void OnlMonHtml::addMenu(const string&, const string&, const string&)Reading file /sphenix/WWW/run/2025/OnlMonHtml/physics/run_0000066000_0
000067000/66636/menu
Error in <TGX11TTF::WriteGIF>: Cannot create GIF of image containing more than 256 colors. Try in batch mode.
Error in <TASImage::WriteImage>: no image in memory. Draw something first
Error removing /tmp/TC6b6291b5-fe94-4be8-a5ba-e5389e43d222
```
It is likely due to too many colors are set for the z axis.
