### PR TITLE
root can now saved directly to png file

### DIFF
--- a/onlmonclient/OnlMonClient.cc
+++ b/onlmonclient/OnlMonClient.cc
@@ -1542,19 +1542,20 @@ int OnlMonClient::CanvasToPng(TCanvas *canvas, std::string const &pngfilename)
               << canvas->GetName() << std::endl;
     return -1;
   }
-  uuid_t uu;
-  uuid_generate(uu);
-  char uuid[50];
-  uuid_unparse(uu, uuid);
-  std::string tmpname = "/tmp/TC" + std::string(uuid);
-  canvas->Print(tmpname.c_str(), "gif");  // write gif format
-  TImage *img = TImage::Open(tmpname.c_str());
-  img->WriteImage(pngfilename.c_str());
-  delete img;
-  if (remove(tmpname.c_str()))
-  {
-    std::cout << "Error removing " << tmpname << std::endl;
-  }
+  // uuid_t uu;
+  // uuid_generate(uu);
+  // char uuid[50];
+  // uuid_unparse(uu, uuid);
+  // std::string tmpname = "/tmp/TC" + std::string(uuid);
+  // canvas->Print(tmpname.c_str(), "gif");  // write gif format
+  // TImage *img = TImage::Open(tmpname.c_str());
+  // img->WriteImage(pngfilename.c_str());
+  // delete img;
+  // if (remove(tmpname.c_str()))
+  // {
+  //   std::cout << "Error removing " << tmpname << std::endl;
+  // }
+  canvas->SaveAs(pngfilename.c_str());
   return 0;
 }
 


### PR DESCRIPTION
from the dawn of the monitoring on we had to go via gif files (TCanvas wasn't able to save other formats) and then convert it via TImage into a png file. gif can only save 256 colors, so we were always limited to 256 colors (and those colormaps ran into problems). TCanvas can now save png files and we don't go via gif files anymore, so this limitation is gone.