### PR TITLE
add 30 and 150 cm trigger to fill requirement.

### DIFF
--- a/subsystems/cemc/CemcMon.cc
+++ b/subsystems/cemc/CemcMon.cc
@@ -382,7 +382,7 @@ int CemcMon::process_event(Event *e /* evt */)
     //this is for only process event with the MBD>=2 trigger
     //use MBD>=2 for AuAu
     if(usembdtrig){
-      if(trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX10) == 0){
+      if(trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX30) == 0 &&trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX150) == 0){
         fillhist = false;
       }
     }

--- a/subsystems/cemc/CemcMon.cc
+++ b/subsystems/cemc/CemcMon.cc
@@ -382,7 +382,7 @@ int CemcMon::process_event(Event *e /* evt */)
     //this is for only process event with the MBD>=2 trigger
     //use MBD>=2 for AuAu
     if(usembdtrig){
-      if(trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX30) == 0 &&trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX150) == 0){
+      if(trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX30) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX150) == 0){
         fillhist = false;
       }
     }

--- a/subsystems/hcal/HcalMon.cc
+++ b/subsystems/hcal/HcalMon.cc
@@ -438,7 +438,7 @@ int HcalMon::process_event(Event* e /* evt */)
     if (usetrig4_10)
     {
       // commenting out until we have a better way to handle cosmic bits -- tanner
-      if (trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::HCAL_SINGLES) == 0)
+      if (trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX30) == 0 &&trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX150) == 0 && trig_bools.at(TriggerEnum::BitCodes::HCAL_SINGLES) == 0)
       {
         fillhist = false;
       }

--- a/subsystems/hcal/HcalMon.cc
+++ b/subsystems/hcal/HcalMon.cc
@@ -438,7 +438,7 @@ int HcalMon::process_event(Event* e /* evt */)
     if (usetrig4_10)
     {
       // commenting out until we have a better way to handle cosmic bits -- tanner
-      if (trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX30) == 0 &&trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX150) == 0 && trig_bools.at(TriggerEnum::BitCodes::HCAL_SINGLES) == 0)
+      if (trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX30) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX150) == 0 && trig_bools.at(TriggerEnum::BitCodes::HCAL_SINGLES) == 0)
       {
         fillhist = false;
       }


### PR DESCRIPTION
Previously we used only 10cm as the fill requirement.
Now, if we are not running 10 cm, 30cm, or 150cm only THEN will histograms not fill. 

The HCal has an additional requirement for the cosmics trigger