### PR TITLE
going back to rollover BCO for DC_SAMPA_vs_TIME Plots

### DIFF
--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -753,9 +753,9 @@ int TpcMon::Init()
     // SAMPA vs Time (weighted by DC)
   char SAMPA_vs_Time_DC_title_str[100];
   sprintf(SAMPA_vs_Time_DC_title_str,"SAMPA ID vs TIME (WTD. by DC = #Sigma ADC - 60*BIN_SUM): SECTOR %i",ebdc_from_serverid( MonitorServerId() ));  
-  //DC_SAMPA_vs_TIME = new TH2F("DC_SAMPA_vs_TIME",SAMPA_vs_Time_DC_title_str,6000,-660000,2000000,208,-0.5,207.5); //rollover
+  DC_SAMPA_vs_TIME = new TH2F("DC_SAMPA_vs_TIME",SAMPA_vs_Time_DC_title_str,6000,-660000,1200000,208,-0.5,207.5); //rollover
   //DC_SAMPA_vs_TIME = new TH2F("DC_SAMPA_vs_TIME",SAMPA_vs_Time_DC_title_str,10050,-49500000,150000000,208,-0.5,207.5); // no rollover
-  DC_SAMPA_vs_TIME = new TH2F("DC_SAMPA_vs_TIME",SAMPA_vs_Time_DC_title_str,1256,-49500000,150000000,208,-0.5,207.5); // no rollover
+  //DC_SAMPA_vs_TIME = new TH2F("DC_SAMPA_vs_TIME",SAMPA_vs_Time_DC_title_str,1256,-49500000,150000000,208,-0.5,207.5); // no rollover
   DC_SAMPA_vs_TIME->SetXTitle("BCO");
   DC_SAMPA_vs_TIME->SetYTitle("SAMPA ID: SAMPA # + (feeID *8)");
 
@@ -949,16 +949,18 @@ int TpcMon::process_event(Event *evt/* evt */)
 
 	    int current_BCO_DC = p->iValue(i,"BCO_DC") + rollover_value_DC;
 	    if ( starting_BCO_DC < 0){starting_BCO_DC = p->iValue(i,"BCO_DC");}
-	    int conv_starting_BCO_DC = starting_BCO_DC; //no rollover
-	    if( current_BCO_DC < conv_starting_BCO_DC ) //no rollover
-	      //if(current_BCO_DC < starting_BCO_DC ) //rollover
+	    //int conv_starting_BCO_DC = starting_BCO_DC; //no rollover
+	    //if( current_BCO_DC < conv_starting_BCO_DC ) //no rollover
+            /*
+	    if(current_BCO_DC < starting_BCO_DC ) //rollover
 	    {
 	      //std::cout<<"you had a rollover"<<std::endl;
               rollover_value_DC += 0x100000;
 	      current_BCO_DC = p->iValue(i,"BCO_DC") + rollover_value_DC;
 	      starting_BCO_DC =  p->iValue(i,"BCO_DC") + rollover_value_DC;
 	    }
-	    starting_BCO_DC =  p->iValue(i,"BCO_DC") + rollover_value_DC; //no rollover
+	    */
+	    //starting_BCO_DC =  p->iValue(i,"BCO_DC") + rollover_value_DC; //no rollover
             //std::cout<<"Corrected BCO = "<<current_BCO_DC<<std::endl;
 	    
 	    for(int j = 0; j< 8; j++)

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -4661,32 +4661,32 @@ int TpcMonDraw::DrawDCSAMPAvsTIME(const std::string & /* what */)
       MyTC->Update();
 
       for (int j = 0; j < 25; j++) {
-        //t2->DrawLine( -659999, (j+1)*8, 2000000.5, (j+1)*8); //rollover
-        t2->DrawLine( -49499999, (j+1)*8, 150000000.5, (j+1)*8); //no rollover
+        t2->DrawLine( -659999, (j+1)*8, 1200000.5, (j+1)*8); //rollover
+        //t2->DrawLine( -49499999, (j+1)*8, 150000000.5, (j+1)*8); //no rollover
       }
       // FEE ID labels
       for (int k = 0; k < 26; k++) {
         sprintf(title, "%d", FEEid[k]);
-        //if(FEEid[k] >9){tt2->DrawText(-250000,k*8+2, title);} //rollover
- 	//else {tt2->DrawText(-250000,k*8 + 2,title);} //rollover
-        if(FEEid[k] >9){tt2->DrawText(-17040000,k*8+2, title);} //no rollover
-	else {tt2->DrawText(-17040000,k*8 + 2,title);} //no rollover
+        if(FEEid[k] >9){tt2->DrawText(-250000,k*8+2, title);} //rollover
+ 	else {tt2->DrawText(-250000,k*8 + 2,title);} //rollover
+        //if(FEEid[k] >9){tt2->DrawText(-17040000,k*8+2, title);} //no rollover
+	//else {tt2->DrawText(-17040000,k*8 + 2,title);} //no rollover
       }
       // Region labels
       tt1->SetTextSize(0.06);
-      //tt1->DrawText(-550000,25, "R1"); //rollover
-      //tt1->DrawText(-550000,77, "R2"); //rollover
-      //tt1->DrawText(-550000,163, "R3"); //rollover
-      tt1->DrawText(-41250000,25, "R1"); //no rollover
-      tt1->DrawText(-41250000,77, "R2"); //no rollover
-      tt1->DrawText(-41250000,163, "R3"); // no rollover
+      tt1->DrawText(-550000,25, "R1"); //rollover
+      tt1->DrawText(-550000,77, "R2"); //rollover
+      tt1->DrawText(-550000,163, "R3"); //rollover
+      //tt1->DrawText(-41250000,25, "R1"); //no rollover
+      //tt1->DrawText(-41250000,77, "R2"); //no rollover
+      //tt1->DrawText(-41250000,163, "R3"); // no rollover
       tt1->SetTextSize(0.05);
 
      // Solid region boundary lines
-      //t1->DrawLine(-659999,48,2000000.5,48); //rollover
-      //t1->DrawLine(-659999,112,2000000.5,112); //rollover
-      t1->DrawLine( -49499999,48,150000000.5,48); // no rollover
-      t1->DrawLine( -49499999,112,150000000.5,112); // no rollover
+      t1->DrawLine(-659999,48,1200000.5,48); //rollover
+      t1->DrawLine(-659999,112,1200000.5,112); //rollover
+      //t1->DrawLine( -49499999,48,150000000.5,48); // no rollover
+      //t1->DrawLine( -49499999,112,150000000.5,112); // no rollover
 
     }
   }


### PR DESCRIPTION
**Files Affected:**

subsystems/tpc/TpcMon.cc
subsystems/tpc/TpcMonDraw.cc

**Changes:**

- TpcMon.cc: L755-L756 - define histos, axes, etc..., L952-964 - commenting out parts that are only necessary when not rolling over
- TpcMonDraw.cc: L4672-4689 adjusting ranges etc...
**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart
    Add messages back into diffuse laser and the transmission plotsx`

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module