### PR TITLE
Removing EXPERT from Digital Current Tab

### DIFF
--- a/macros/run_Poms.C
+++ b/macros/run_Poms.C
@@ -184,7 +184,7 @@ void StartPoms()
   subsys->AddAction(new SubSystemActionSavePlot(subsys));
   pmf->RegisterSubSystem(subsys);
 
-  subsys = new SubSystem("TPC EXPERT DIGITAL CURRENT", "tpc");
+  subsys = new SubSystem("TPC DIGITAL CURRENT", "tpc");
   subsys->AddAction("tpcDraw(\"TPCDCVSSAMPA\")", "TPC DIGITAL CURRENT VS SAMPA");
   subsys->AddAction("tpcDraw(\"TPCDCSAMPAVSTIME\")", "TPC SAMPA VS TIME WTD. BY DC");
   subsys->AddAction("tpcDraw(\"SERVERSTATS\")", "Server Stats");


### PR DESCRIPTION
**Files Affected:**

macros/run_Poms.C

**Changes:**

- run_Poms.C: L187 - removing "EXPERT"

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart
    Add messages back into diffuse laser and the transmission plotsx`

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module