### PR TITLE
Adding Packet vs Sample Plot wtd. by ADC

### DIFF
--- a/macros/run_Poms.C
+++ b/macros/run_Poms.C
@@ -170,6 +170,7 @@ void StartPoms()
   subsys->AddAction("tpcDraw(\"TPCZSTRIGGERADCVSSAMPLE\")", "TPC ZS trigger threshold QA");
   subsys->AddAction("tpcDraw(\"TPCFIRSTNONZSADCVSFIRSTNONZSSAMPLE\")", "TPC 1st nonZS ADC vs 1st nonZS Sample");
   subsys->AddAction("tpcDraw(\"TPCPACKETYPEFRACTION\")", "TPC PACKET TYPE WF FRACTION");
+  subsys->AddAction("tpcDraw(\"TPCPACKETTYPEVSSAMPLEADC\")", "TPC PACKET TYPE vs SAMPLE wtd. by ADC");
   subsys->AddAction("tpcDraw(\"SERVERSTATS\")", "Server Stats");
   subsys->AddAction(new SubSystemActionSavePlot(subsys));
   pmf->RegisterSubSystem(subsys);

--- a/macros/run_tpc_client.C
+++ b/macros/run_tpc_client.C
@@ -103,6 +103,7 @@ void tpcDrawInit(const int online = 0)
     cl->registerHisto("Packet_Type_Fraction_HB",servername);
     cl->registerHisto("Packet_Type_Fraction_NORM",servername);
     cl->registerHisto("Packet_Type_Fraction_ELSE",servername);
+    cl->registerHisto("Packet_Type_vs_sample_ADC",servername);
 
     cl->registerHisto("Noise_Channel_Plots",servername);
 

--- a/subsystems/tpc/TpcMon.cc
+++ b/subsystems/tpc/TpcMon.cc
@@ -764,6 +764,20 @@ int TpcMon::Init()
   DC_SAMPA_vs_TIME -> SetLabelSize(0.05);
   DC_SAMPA_vs_TIME -> GetYaxis() -> SetTitleSize(0.05);
   DC_SAMPA_vs_TIME -> GetYaxis() -> SetTitleOffset(1.0);
+
+  // Packet type vs SAMPLE plots wtd. by ADC for Jin
+  char Packet_type_vs_sample_ADC_title_str[256];
+  char Packet_type_vs_sample_ADC_xtitle_str[256];
+  sprintf(Packet_type_vs_sample_ADC_title_str,"Packet type vs sample, Sector # %i",ebdc_from_serverid( MonitorServerId() ));
+  Packet_Type_vs_sample_ADC = new TH2F("Packet_Type_vs_sample_ADC",Packet_type_vs_sample_ADC_title_str,501,-0.5,500.5,7,0,7);
+  for (int i=0; i!=7; ++i) { Packet_Type_vs_sample_ADC->GetYaxis()->SetBinLabel(i+1,label[i]);}
+  sprintf(Packet_type_vs_sample_ADC_xtitle_str,"Sector %i: Time bin [1/17.5MHz]",ebdc_from_serverid( MonitorServerId() ));
+  Packet_Type_vs_sample_ADC->SetXTitle(Packet_type_vs_sample_ADC_xtitle_str);
+
+  Packet_Type_vs_sample_ADC -> GetXaxis() -> SetLabelSize(0.08);
+  Packet_Type_vs_sample_ADC -> GetYaxis() -> SetLabelSize(0.08);
+  Packet_Type_vs_sample_ADC -> GetYaxis() -> SetTitleSize(0.08);
+  Packet_Type_vs_sample_ADC -> GetYaxis() -> SetTitleOffset(0.6);
   
 
   OnlMonServer *se = OnlMonServer::instance();
@@ -845,6 +859,7 @@ int TpcMon::Init()
   se->registerHisto(this, Packet_Type_Fraction_HB);
   se->registerHisto(this, Packet_Type_Fraction_NORM);
   se->registerHisto(this, Packet_Type_Fraction_ELSE);
+  se->registerHisto(this, Packet_Type_vs_sample_ADC);
 
   se->registerHisto(this, Noise_Channel_Plots);
   se->registerHisto(this,  DC_vs_SAMPA);
@@ -1245,6 +1260,7 @@ int TpcMon::process_event(Event *evt/* evt */)
 
           if( (checksumError == 0 && parityError == 0) && is_channel_stuck == 0)
           {
+	    Packet_Type_vs_sample_ADC->Fill(s,type,adc);
             ADC_vs_SAMPLE -> Fill(s, adc);
             PEDEST_SUB_ADC_vs_SAMPLE -> Fill(s, adc-pedestal);
             ADC_vs_SAMPLE_large -> Fill(s, adc);

--- a/subsystems/tpc/TpcMon.h
+++ b/subsystems/tpc/TpcMon.h
@@ -139,6 +139,7 @@ class TpcMon : public OnlMon
   TH1 *Packet_Type_Fraction_HB = nullptr;
   TH1 *Packet_Type_Fraction_NORM = nullptr;
   TH1 *Packet_Type_Fraction_ELSE = nullptr;
+  TH2 *Packet_Type_vs_sample_ADC = nullptr;
 
   TH1 *Noise_Channel_Plots = nullptr;
   TH2 *DC_vs_SAMPA = nullptr;

--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -478,7 +478,18 @@ int TpcMonDraw::MakeCanvas(const std::string &name)
     transparent[38]->SetFillStyle(4000);
     transparent[38]->Draw();
     TC[38]->SetEditable(false);
-  }   
+  }
+  else if (name == "TPCPACKETTYPE_vs_SAMPLE_ADC")
+  {
+    TC[39] = new TCanvas(name.c_str(), "",-1, 0, xsize , ysize);
+    gSystem->ProcessEvents();
+    //gStyle->SetPalette(57); //kBird CVD friendly
+    TC[39]->Divide(4,7);
+    transparent[39] = new TPad("transparent39", "this does not show", 0, 0, 1, 1);
+    transparent[39]->SetFillStyle(4000);
+    transparent[39]->Draw();
+    TC[39]->SetEditable(false);
+  }
   return 0;
 }
 
@@ -654,6 +665,11 @@ int TpcMonDraw::Draw(const std::string &what)
   if (what == "ALL" || what == "TPCPACKETYPEFRACTION")
   {
     iret +=  DrawTPCPacketTypes(what);
+    idraw++;
+  }
+  if (what == "ALL" || what == "TPCPACKETTYPEVSSAMPLEADC")
+  {
+    iret +=  DrawTPCPACKETTYPEvsSAMPLEADC(what);
     idraw++;
   }
   if (what == "ALL" || what == "SHIFTER_DRIFT_PLOT")
@@ -3737,7 +3753,6 @@ int TpcMonDraw::DrawTPCPacketTypes(const std::string & /* what */)
   return 0;
 }
 
-
 int TpcMonDraw::DrawTPCChansperLVL1_NS(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
@@ -4510,19 +4525,19 @@ int TpcMonDraw::DrawDCvsSAMPA(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
 
-  TH1 *tpcmon_dc_vs_sampa_plots[24] = {nullptr};
+  TH2 *tpcmon_dc_vs_sampa_plots[24] = {nullptr};
   
-  TH1 *tpcmon_dc_vs_sampa_plots_u[48] = {nullptr};
+  TH2 *tpcmon_dc_vs_sampa_plots_u[48] = {nullptr};
   
   char TPCMON_STR[100];
   for( int i=0; i<48; i++ ) 
   {
     //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
     sprintf(TPCMON_STR,"TPCMON_%i",i);
-    tpcmon_dc_vs_sampa_plots_u[i] = (TH1*) cl->getHisto(TPCMON_STR,"DC_vs_SAMPA");
+    tpcmon_dc_vs_sampa_plots_u[i] = (TH2*) cl->getHisto(TPCMON_STR,"DC_vs_SAMPA");
   }
 
-  add_TH1(tpcmon_dc_vs_sampa_plots_u, tpcmon_dc_vs_sampa_plots);
+  add_TH2(tpcmon_dc_vs_sampa_plots_u, tpcmon_dc_vs_sampa_plots);
   
   if (!gROOT->FindObject("DC_vs_SAMPA_CANVAS"))
   {
@@ -4610,19 +4625,19 @@ int TpcMonDraw::DrawDCSAMPAvsTIME(const std::string & /* what */)
 {
   OnlMonClient *cl = OnlMonClient::instance();
 
-  TH1 *tpcmon_dc_sampa_vs_time_plots[24] = {nullptr};
-  
-  TH1 *tpcmon_dc_sampa_vs_time_plots_u[48] = {nullptr};
+  TH2 *tpcmon_dc_sampa_vs_time_plots[24] = {nullptr};
+ 
+  TH2 *tpcmon_dc_sampa_vs_time_plots_u[48] = {nullptr};
   
   char TPCMON_STR[100];
   for( int i=0; i<48; i++ ) 
   {
     //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
     sprintf(TPCMON_STR,"TPCMON_%i",i);
-    tpcmon_dc_sampa_vs_time_plots_u[i] = (TH1*) cl->getHisto(TPCMON_STR,"DC_SAMPA_vs_TIME");
+    tpcmon_dc_sampa_vs_time_plots_u[i] = (TH2*) cl->getHisto(TPCMON_STR,"DC_SAMPA_vs_TIME");
   }
 
-  add_TH1(tpcmon_dc_sampa_vs_time_plots_u, tpcmon_dc_sampa_vs_time_plots);
+  add_TH2(tpcmon_dc_sampa_vs_time_plots_u, tpcmon_dc_sampa_vs_time_plots);
   
   if (!gROOT->FindObject("DC_SAMPA_vs_TIME_CANVAS"))
   {
@@ -4702,6 +4717,71 @@ int TpcMonDraw::DrawDCSAMPAvsTIME(const std::string & /* what */)
   std::pair<time_t,int> evttime = cl->EventTime("CURRENT");
   // fill run number and event time into string
   runnostream << ThisName << "_DC_SAMPA_vs_TIME Run " << cl->RunNumber()
+              << ", Time: " << ctime(&evttime.first);
+  runstring = runnostream.str();
+  TransparentTPad->cd();
+  PrintRun.SetTextColor(evttime.second);
+  PrintRun.DrawText(0.5, 0.91, runstring.c_str());
+
+  MyTC->Update();
+  MyTC->Show();
+  MyTC->SetEditable(false);
+
+  return 0;
+}
+
+int TpcMonDraw::DrawTPCPACKETTYPEvsSAMPLEADC(const std::string & /* what */)
+{
+  OnlMonClient *cl = OnlMonClient::instance();
+
+  TH2 *tpcmon_PacketType_vs_Sample_ADC[24] = {nullptr};
+  TH2 *tpcmon_PacketType_vs_Sample_ADC_u[48] = {nullptr};
+  
+  char TPCMON_STR[100];
+  for( int i=0; i<48; i++ ) 
+  {
+    //const TString TPCMON_STR( Form( "TPCMON_%i", i ) );
+    sprintf(TPCMON_STR,"TPCMON_%i",i);
+    tpcmon_PacketType_vs_Sample_ADC_u[i] = (TH2*) cl->getHisto(TPCMON_STR,"Packet_Type_vs_sample_ADC");
+  }
+
+  add_TH2(tpcmon_PacketType_vs_Sample_ADC_u, tpcmon_PacketType_vs_Sample_ADC);
+  
+  if (!gROOT->FindObject("TPCPACKETTYPE_vs_SAMPLE_ADC"))
+  {
+    MakeCanvas("TPCPACKETTYPE_vs_SAMPLE_ADC");
+  }
+
+  TCanvas *MyTC = TC[39];
+  TPad *TransparentTPad = transparent[39];
+  MyTC->SetEditable(true);
+  MyTC->Clear("D");
+
+  gStyle->SetOptStat(0);
+  gStyle->SetPalette(57); //kBird CVD friendly
+
+
+  for( int i=0; i<24; i++ ) 
+  {
+    if(tpcmon_PacketType_vs_Sample_ADC[i] )
+    {
+      MyTC->cd(i+5);
+      tpcmon_PacketType_vs_Sample_ADC[i]->SetStats(0);
+      tpcmon_PacketType_vs_Sample_ADC[i]->DrawCopy("COLZ");
+    }
+    gPad->Update();
+  }
+
+  TText PrintRun;
+  PrintRun.SetTextFont(62);
+  PrintRun.SetTextSize(0.04);
+  PrintRun.SetNDC();          // set to normalized coordinates
+  PrintRun.SetTextAlign(23);  // center/top alignment
+  std::ostringstream runnostream;
+  std::string runstring;
+  std::pair<time_t,int> evttime = cl->EventTime("CURRENT");
+  // fill run number and event time into string
+  runnostream << ThisName << "_PACKET TYPE vs SAMPLE wtd. by ADC Run " << cl->RunNumber()
               << ", Time: " << ctime(&evttime.first);
   runstring = runnostream.str();
   TransparentTPad->cd();

--- a/subsystems/tpc/TpcMonDraw.h
+++ b/subsystems/tpc/TpcMonDraw.h
@@ -59,6 +59,7 @@ class TpcMonDraw : public OnlMonDraw
   int DrawTPCNStreaksvsEventNo(const std::string &what = "ALL");
   int DrawTPCNEventsvsEBDC(const std::string &what = "ALL");
   int DrawTPCPacketTypes(const std::string &what = "ALL");
+  int DrawTPCPACKETTYPEvsSAMPLEADC (const std::string &what = "ALL");
   int DrawTPCNoiseChannelPlots(const std::string &what = "ALL");
   int DrawShifterTPCDriftWindow(const std::string &what = "ALL");
   int DrawShifterTransmissionDist(const std::string &what = "ALL");
@@ -71,8 +72,8 @@ class TpcMonDraw : public OnlMonDraw
   void add_TH2_modules(TH2* hist[48][3], TH2* histadd[24][3]);
   time_t getTime();
   
-  TCanvas *TC[39] = {nullptr};
-  TPad *transparent[39] = {nullptr};
+  TCanvas *TC[40] = {nullptr};
+  TPad *transparent[40] = {nullptr};
   TPad *Pad[11] = {nullptr};
   TGraphErrors *gr[2] = {nullptr};
   //TPC Module


### PR DESCRIPTION
**Files Affected:**

macros/run_tpc_client.C
macros/run_Poms.C
subsystems/tpc/TpcMon.h
subsystems/tpc/TpcMon.cc
subsystems/tpc/TpcMonDraw.h
subsystems/tpc/TpcMonDraw.cc

**Changes:**

- run_tpc_client.C: L106- adding lines for registering new histo
- run_Poms.C: L173 - drawing new histo in POMS
- TpcMon.h: L142- create histo for Packet vs Sample plot wtd. by ADC
- TpcMon.cc: L768-780,862,1263 - define histos, axes, etc, register histo, fill histo
- TpcMonDraw.h: L62, L75.76 - functions for drawing histo and TCanvs/TPad
- TpcMonDraw.cc: L482-492 - defining TCanvas, L670-674 - function organizing, L4733-4796 drawing 

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart
    Add messages back into diffuse laser and the transmission plotsx`

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module