### PR TITLE
(INTT) Hot map threshold handles

### DIFF
--- a/macros/run_Poms.C
+++ b/macros/run_Poms.C
@@ -93,7 +93,7 @@ void StartPoms()
   subsys->AddAction("inttDraw(\"chip_hitmap\")", "Chip Hitmap");
   subsys->AddAction("inttDraw(\"bco_diff\")", "BCO Diff (Triggered)");
 //  subsys->AddAction("inttDraw(\"zoomed_fphx_bco\")", "Zoomed Fphx BCO (Streaming)");
-  subsys->AddAction("inttDraw(\"history\")", "Decoding Rate");
+//  subsys->AddAction("inttDraw(\"history\")", "Decoding Rate");
 //  subsys->AddAction("inttDraw(\"fphx_bco\")", "Fphx BCO (Streaming) [Expert]");
   subsys->AddAction("inttDraw(\"hitrates\")", "Hitrates [Expert]");
   subsys->AddAction("inttDraw(\"SERVERSTATS\")", "Server Stats");

--- a/macros/run_intt_server.C
+++ b/macros/run_intt_server.C
@@ -1,6 +1,5 @@
 #include "ServerFuncs.C"
 
-#include <onlmon/intt/InttMonConstants.h>
 #include <onlmon/intt/InttMon.h>
 #include <onlmon/OnlMonServer.h>
 

--- a/subsystems/intt/InttMonDraw.h
+++ b/subsystems/intt/InttMonDraw.h
@@ -40,6 +40,9 @@ class InttMonDraw : public OnlMonDraw
   int MakeHtml(std::string const& = "ALL") override;
   int SavePlot(std::string const& = "ALL", std::string const& = "png") override;
 
+  void set_cold_threshold ( double const& lower ) { m_lower = lower; }
+  void set_hot_threshold ( double const& upper ) { m_upper = upper; }
+
  private:
   static constexpr int NCHIPS = 26;
   static constexpr int NFEES = 14;
@@ -124,13 +127,13 @@ class InttMonDraw : public OnlMonDraw
   double constexpr static m_warn_text_size = 0.15;
   double constexpr static m_min_events = 50000;
 
-  // pp
-  // double constexpr static m_lower = 0.015;
-  // double constexpr static m_upper = 0.650;
+  // pp defaults
+  // double m_lower = 0.015;
+  // double m_upper = 0.650;
 
-  // AuAu
-  double constexpr static m_lower = 0.400;
-  double constexpr static m_upper = 2.500;
+  // AuAu defaults
+  double m_lower = 0.400;
+  double m_upper = 2.500;
 };
 
 #endif


### PR DESCRIPTION
I noticed there's an include for a header file that no longer exists in the intt onlmon subdir. I took it out but I'm not sure why that inclusion didn't break something before.

Tested things locally but would appreciate a double check--leaving as a draft for now and if it works you are welcome to merge it.