### PR TITLE
Moving the diffuse laser bound line back 5 samples (~250 ns)

### DIFF
--- a/subsystems/tpc/TpcMonDraw.cc
+++ b/subsystems/tpc/TpcMonDraw.cc
@@ -4172,15 +4172,15 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
     if( tpcmon_DriftWindow_shifter[i][1] ){  R2_max = tpcmon_DriftWindow_shifter[i][1]->GetBinCenter(tpcmon_DriftWindow_shifter[i][1]->GetMaximumBin());}
     if( tpcmon_DriftWindow_shifter[i][2] ){  R3_max = tpcmon_DriftWindow_shifter[i][2]->GetBinCenter(tpcmon_DriftWindow_shifter[i][2]->GetMaximumBin());}
 
-    if( (R1_max>std::numeric_limits<int>::min() && (R1_max < 360)) || R1_max > 369 ){ R1_bad = 1;} // old peak - 416, new peak 403 50 ns clock, new peak 368 57.14 ns clock 
-    if( (R2_max>std::numeric_limits<int>::min() && (R2_max < 360)) || R2_max > 369 ){ R2_bad = 1;} 
-    if( (R3_max>std::numeric_limits<int>::min() && (R3_max < 360)) || R3_max > 369 ){ R3_bad = 1;}
+    if( (R1_max>std::numeric_limits<int>::min() && (R1_max < 365)) || R1_max > 374){ R1_bad = 1;} // old peak - 416, new peak 403 50 ns clock, new peak 368 57.14 ns clock 
+    if( (R2_max>std::numeric_limits<int>::min() && (R2_max < 365)) || R2_max > 374){ R2_bad = 1;} 
+    if( (R3_max>std::numeric_limits<int>::min() && (R3_max < 365)) || R3_max > 374){ R3_bad = 1;}
 
     for( int l = 2; l>-1; l-- )
     {
       if( tpcmon_DriftWindow_shifter[i][l] )
       {
-        tpcmon_DriftWindow_shifter[i][l]->GetXaxis()->SetRangeUser(341,391); // old peak - 416, new peak 403, new peak 368 57.14 ns clock
+        tpcmon_DriftWindow_shifter[i][l]->GetXaxis()->SetRangeUser(346,396); // old peak - 416, new peak 403, new peak 368 57.14 ns clock
         if(l == 2)
         { 
           tpcmon_DriftWindow_shifter[i][l]->GetYaxis()->SetRangeUser(0.9*min,1.3*max);tpcmon_DriftWindow_shifter[i][l] -> DrawCopy("HIST");
@@ -4192,8 +4192,8 @@ int TpcMonDraw::DrawShifterTPCDriftWindow(const std::string & /* what */)
       }
     }
 
-    t2->DrawLine(360,0.9*min,360,1.3*max);
-    t2->DrawLine(370,0.9*min,370,1.3*max);
+    t2->DrawLine(365,0.9*min,365,1.3*max);
+    t2->DrawLine(375,0.9*min,375,1.3*max);
     
     gPad->Update();  
 


### PR DESCRIPTION
**Files Affected:**

subsystems/tpc/TpcMonDraw.cc

**Changes:**

- subsystems/tpc/TpcMonDraw.cc L4175-7, L4183, L4195-6 -  Moving drift window/bounds 5 samples late

**TODO:**

Add histos for the following:

Make plots nicer and with timestamps so we know they are fresh (see calo code)

FIX THE PHICHANNEL VS LAYER VSSUM( PEDEST_SUB_ADC) PLOT

    FOR JIN: Counts of ADC > threshold (ADC - pedestal > max(20|| 5 sigma)) vs SAMPLE per EBDC
    ~~FOR TOM: diagnostic of horizontal streakers~~
    - NEED TO ADD ABILITY TO SEND TO MCR
    FOR TOM: XY PLOT BUT REFRESH FOR <= 5 EVENTS - MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: ZY PLOT BUT REFRESH FOR <= 5 EVENTS- MAKE IT SO IT IS ALWAYS EXACTLY 5
    FOR TOM: PLOT SHOWING ALL HIT RATE ABOVE THRESHOLD FOR EACH LAYER IN EACH SECTOR
    FOR EVGENY: ANTENNA PAD MULTIPLICITY PLOT
    Persistent Scope Plot (ask Jin)
    ADC vs ADC Bin per FEE
    ADC vs Channel - Evgeny 2D plot in pad row coordinates
    Stuck Channel Detection
    BCO Plots?
    Std. Dev(ADC) in module pie chart
    Add messages back into diffuse laser and the transmission plotsx`

CLEAN UP HISTOS - MAKE HUMAN READABLE (made progress towards this 05.12.24)
FIX COLORING - KBIRD should be the consistent default
NEED BETTER SCHEME FOR COLOR SCALING ADC vs. Module