### PR TITLE
plot 12 samples for waevform

### DIFF
--- a/subsystems/hcal/HcalMonDraw.cc
+++ b/subsystems/hcal/HcalMonDraw.cc
@@ -1206,8 +1206,8 @@ int HcalMonDraw::DrawThird(const std::string& /* what */)
   h2_hcal_waveform->Draw("colz");
 
   float tsize = 0.06;
-  h2_hcal_waveform->GetXaxis()->SetNdivisions(510, kTRUE);
-  h2_hcal_waveform->GetXaxis()->SetRangeUser(0, 16);
+  h2_hcal_waveform->GetXaxis()->SetNdivisions(16);
+  h2_hcal_waveform->GetXaxis()->SetRangeUser(0, 11);
   h2_hcal_waveform->GetXaxis()->SetTitle("Sample #");
   h2_hcal_waveform->GetYaxis()->SetTitle("Waveform [ADC]");
   h2_hcal_waveform->GetXaxis()->SetLabelSize(tsize);


### PR DESCRIPTION
Finally ... plot only 12 samples for the hcal waveform instead of 16 with the last 4 empty