### PR TITLE
Switch HCal range of all trigger plot for pp

### DIFF
--- a/subsystems/cemc/CemcMon.cc
+++ b/subsystems/cemc/CemcMon.cc
@@ -385,7 +385,8 @@ int CemcMon::process_event(Event *e /* evt */)
     //this is for only process event with the MBD>=2 trigger
     //use MBD>=2 for AuAu
     if(usembdtrig){
-      if(trig_bools.at(TriggerEnum::BitCodes::MBD_NS1_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS1_ZVRTX13) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS1_ZVRTX150) == 0){
+      if(trig_bools.at(TriggerEnum::BitCodes::MBD_NS1_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS1_ZVRTX13) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS1_ZVRTX150) == 0 && trig_bools.at(TriggerEnum::BitCodes::PHOTON4_MBD_NS1_ZVRTX10) ==0)
+      {
         fillhist = false;
       }
     }

--- a/subsystems/cemc/CemcMon.cc
+++ b/subsystems/cemc/CemcMon.cc
@@ -385,7 +385,7 @@ int CemcMon::process_event(Event *e /* evt */)
     //this is for only process event with the MBD>=2 trigger
     //use MBD>=2 for AuAu
     if(usembdtrig){
-      if(trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX30) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX150) == 0 &&trig_bools.at(TriggerEnum::BitCodes::MBD_NS2) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS1) == 0)
+      if(trig_bools.at(TriggerEnum::BitCodes::MBD_NS1_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS1) == 0)
       {
         fillhist = false;
       }

--- a/subsystems/hcal/HcalMon.cc
+++ b/subsystems/hcal/HcalMon.cc
@@ -443,7 +443,7 @@ int HcalMon::process_event(Event* e /* evt */)
     if (usetrig4_10)
     {
       // commenting out until we have a better way to handle cosmic bits -- tanner
-      if (trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX10) == 0 &&trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX30) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2_ZVRTX150) == 0 && trig_bools.at(TriggerEnum::BitCodes::HCAL_SINGLES) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS1) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2) == 0)
+      if (trig_bools.at(TriggerEnum::BitCodes::MBD_NS1_ZVRTX10) == 0 && trig_bools.at(TriggerEnum::BitCodes::HCAL_SINGLES) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS1) == 0 && trig_bools.at(TriggerEnum::BitCodes::MBD_NS2) == 0)
       {
         fillhist = false;
       }

--- a/subsystems/hcal/HcalMonDraw.cc
+++ b/subsystems/hcal/HcalMonDraw.cc
@@ -755,7 +755,8 @@ int HcalMonDraw::DrawAllTrigHits(const std::string& /* what */)
   hist1->GetYaxis()->SetTitleSize(tsize);
   hist1->GetXaxis()->SetTickLength(0.02);
 
-  hist1->GetZaxis()->SetRangeUser(0, 0.5);
+  //hist1->GetZaxis()->SetRangeUser(0, 0.5);// this is for Au-Au
+  hist1->GetZaxis()->SetRangeUser(0, 0.015);// this is for pp
 
   gPad->SetTopMargin(0.08);
   gPad->SetBottomMargin(0.07);


### PR DESCRIPTION
Revert change to HCal all triggers plot made for Au-Au (0.015->0.5->0.015)
The earlier change: https://github.com/sPHENIX-Collaboration/OnlMon/commit/4bea7beab9e9c057aaefe76c287efb372faa8e57

Add photon4 trigger to trigger specific plot for Dan.
We aren't using for monitoring now anyway; we are using the all triggers plot for monitoring. 