### PR TITLE
CD: Change MVTX occupancy z-range

### DIFF
--- a/subsystems/mvtx/MvtxMonDraw.cc
+++ b/subsystems/mvtx/MvtxMonDraw.cc
@@ -505,7 +505,7 @@ int MvtxMonDraw::DrawGeneral(const std::string & /* what */)
   {
     mvtxmon_mGeneralOccupancy[NFlx]->GetYaxis()->SetTitleOffset(0.6);
     mvtxmon_mGeneralOccupancy[NFlx]->SetMinimum(0);
-    mvtxmon_mGeneralOccupancy[NFlx]->SetMaximum(100E-6);  // set a fixed max value
+    mvtxmon_mGeneralOccupancy[NFlx]->SetMaximum(30E-6);  // set a fixed max value, was 100E-6 for AuAu
     mvtxmon_mGeneralOccupancy[NFlx]->SetContour(100);
   }
 


### PR DESCRIPTION
I decreased the maximum occupancy on the MVTX colour panel now we're in pp. The new range seems to max nicely
<img width="386" height="447" alt="Screenshot 2025-12-11 at 3 28 08 pm" src="https://github.com/user-attachments/assets/8b9e400f-bd98-4365-9476-880cdc893f76" />
