### PR TITLE
CD: Removed max from MVTX occ plot

### DIFF
--- a/subsystems/mvtx/MvtxMonDraw.cc
+++ b/subsystems/mvtx/MvtxMonDraw.cc
@@ -505,7 +505,7 @@ int MvtxMonDraw::DrawGeneral(const std::string & /* what */)
   {
     mvtxmon_mGeneralOccupancy[NFlx]->GetYaxis()->SetTitleOffset(0.6);
     mvtxmon_mGeneralOccupancy[NFlx]->SetMinimum(0);
-    mvtxmon_mGeneralOccupancy[NFlx]->SetMaximum(40E-6);  // set a fixed max value, was 100E-6 for AuAu
+    //mvtxmon_mGeneralOccupancy[NFlx]->SetMaximum(100E-6);  // Let max value float for pp
     mvtxmon_mGeneralOccupancy[NFlx]->SetContour(100);
   }
 


### PR DESCRIPTION
The max occupancy changes significantly through a fill. I removed the hard coded maximum on the plot so things don't wash out