### PR TITLE
Change the z-axis range for 'all trigger plot' in HCal onl mon

### DIFF
--- a/subsystems/hcal/HcalMonDraw.cc
+++ b/subsystems/hcal/HcalMonDraw.cc
@@ -785,7 +785,8 @@ int HcalMonDraw::DrawAllTrigHits(const std::string& /* what */)
   hist1->GetXaxis()->SetTickLength(0.02);
 
   //hist1->GetZaxis()->SetRangeUser(0, 0.5);// this is for Au-Au
-  hist1->GetZaxis()->SetRangeUser(0, 0.015);// this is for pp
+  //hist1->GetZaxis()->SetRangeUser(0, 0.015);// this is for pp
+  hist1->GetZaxis()->SetRangeUser(0, 0.1);// this is for OO
 
   gPad->SetTopMargin(0.08);
   gPad->SetBottomMargin(0.07);


### PR DESCRIPTION
The z axis range for the 'All Trigger Tower Hits' plot in oHcal and iHCal onl mon is changed to 0.1 from 0.015 to reflect the OO collisions hit frequency.  